### PR TITLE
Add support for Map shape handling in C# literals and enhance protocol tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ generation are planned. See the
 [roadmap](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/planning/roadmap.md)
 for details.
 
+Smithy.NET tracks generated-client conformance against official Smithy/AWS and
+Alloy protocol test suites in
+[docs/generated/protocol-conformance.md](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/generated/protocol-conformance.md).
+
 ## Packages
 
 | Package | Purpose |

--- a/docs/generated/protocol-conformance.md
+++ b/docs/generated/protocol-conformance.md
@@ -1,0 +1,21 @@
+# Official Protocol Conformance Matrix
+
+| Protocol | Case kind | Executable | Skipped | Total | Conformance |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `alloy#simpleRestJson` | `Request` | 5 | 18 | 23 | 21.7% |
+| `alloy#simpleRestJson` | `Response` | 1 | 19 | 20 | 5.0% |
+| `aws.protocols#restJson1` | `Request` | 2 | 156 | 158 | 1.3% |
+| `aws.protocols#restJson1` | `Response` | 1 | 113 | 114 | 0.9% |
+| `aws.protocols#restJson1` | `MalformedRequest` | 0 | 191 | 191 | 0.0% |
+
+## Executable Cases
+
+- `alloy#simpleRestJson` `Request` `HealthGet`
+- `alloy#simpleRestJson` `Request` `RoutingAbc`
+- `alloy#simpleRestJson` `Request` `RoutingAbcDef`
+- `alloy#simpleRestJson` `Request` `RoutingAbcLabel`
+- `alloy#simpleRestJson` `Request` `RoutingAbcXyz`
+- `alloy#simpleRestJson` `Response` `headerEndpointResponse`
+- `aws.protocols#restJson1` `Request` `RestJsonEmptyInputAndEmptyOutput`
+- `aws.protocols#restJson1` `Request` `RestJsonHttpPrefixHeadersArePresent`
+- `aws.protocols#restJson1` `Response` `RestJsonHttpPrefixHeadersArePresent`

--- a/docs/supported-surface.md
+++ b/docs/supported-surface.md
@@ -108,7 +108,9 @@ Current generated request bindings include:
 - `@http`
 - `@httpLabel`
 - `@httpQuery`
+- `@httpQueryParams` for map-shaped dynamic query parameters
 - `@httpHeader`
+- `@httpPrefixHeaders` for map-shaped dynamic headers
 - `@httpPayload`
 - default JSON body serialization for unbound input members
 
@@ -116,12 +118,14 @@ Current generated response bindings include:
 
 - JSON body deserialization
 - `@httpHeader`
+- `@httpPrefixHeaders` for map-shaped dynamic headers
 - `@httpPayload`
 - `@httpResponseCode`
 - generated Smithy error dispatch using `@error` and `@httpError`
 
 Protocol support is intentionally narrow until more Smithy protocol compliance
-cases are covered.
+cases are covered. Dynamic query parameter and prefix-header support currently
+targets string-keyed, string-valued generated map shapes.
 
 ## Examples
 

--- a/src/SmithyNet.CodeGeneration/CSharp/CSharpShapeGenerator.ClientEmitter.cs
+++ b/src/SmithyNet.CodeGeneration/CSharp/CSharpShapeGenerator.ClientEmitter.cs
@@ -239,6 +239,12 @@ public sealed partial class CSharpShapeGenerator
             return $"GetHeader<{memberType}>(response.Headers, {FormatString(headerName)})";
         }
 
+        if (IsHttpPrefixHeadersMember(member))
+        {
+            var headerPrefix = member.Traits[SmithyPrelude.HttpPrefixHeadersTrait].AsString();
+            return $"GetPrefixedHeaders<{memberType}>(response.Headers, {FormatString(headerPrefix)})";
+        }
+
         if (IsHttpResponseCodeMember(member))
         {
             return $"({memberType})(int)response.StatusCode";
@@ -285,6 +291,12 @@ public sealed partial class CSharpShapeGenerator
                     $"AppendQuery(requestUriBuilder, {FormatString(queryName)}, input.{propertyName});"
                 );
             }
+
+            foreach (var member in GetSortedMembers(input).Where(IsHttpQueryParamsMember))
+            {
+                var propertyName = CSharpIdentifier.PropertyName(member.Name);
+                builder.Line($"AppendQueryMap(requestUriBuilder, input.{propertyName});");
+            }
         }
 
         builder.Line("var requestUri = requestUriBuilder.ToString();");
@@ -298,6 +310,15 @@ public sealed partial class CSharpShapeGenerator
             var propertyName = CSharpIdentifier.PropertyName(member.Name);
             builder.Line(
                 $"AddHeader(request.Headers, {FormatString(headerName)}, input.{propertyName});"
+            );
+        }
+
+        foreach (var member in GetSortedMembers(input).Where(IsHttpPrefixHeadersMember))
+        {
+            var headerPrefix = member.Traits[SmithyPrelude.HttpPrefixHeadersTrait].AsString();
+            var propertyName = CSharpIdentifier.PropertyName(member.Name);
+            builder.Line(
+                $"AddPrefixedHeaders(request.Headers, {FormatString(headerPrefix)}, input.{propertyName});"
             );
         }
     }
@@ -333,7 +354,9 @@ public sealed partial class CSharpShapeGenerator
     {
         return !IsHttpLabelMember(member)
             && !IsHttpQueryMember(member)
+            && !IsHttpQueryParamsMember(member)
             && !IsHttpHeaderMember(member)
+            && !IsHttpPrefixHeadersMember(member)
             && !IsHttpPayloadMember(member);
     }
 
@@ -346,8 +369,14 @@ public sealed partial class CSharpShapeGenerator
     private static bool IsHttpPayloadMember(MemberShape member) =>
         member.Traits.Has(SmithyPrelude.HttpPayloadTrait);
 
+    private static bool IsHttpPrefixHeadersMember(MemberShape member) =>
+        member.Traits.Has(SmithyPrelude.HttpPrefixHeadersTrait);
+
     private static bool IsHttpQueryMember(MemberShape member) =>
         member.Traits.Has(SmithyPrelude.HttpQueryTrait);
+
+    private static bool IsHttpQueryParamsMember(MemberShape member) =>
+        member.Traits.Has(SmithyPrelude.HttpQueryParamsTrait);
 
     private static bool IsHttpResponseCodeMember(MemberShape member) =>
         member.Traits.Has(SmithyPrelude.HttpResponseCodeTrait);
@@ -356,6 +385,7 @@ public sealed partial class CSharpShapeGenerator
     {
         return output.Members.Values.Any(member =>
             IsHttpHeaderMember(member)
+            || IsHttpPrefixHeadersMember(member)
             || IsHttpPayloadMember(member)
             || IsHttpResponseCodeMember(member)
         );
@@ -539,6 +569,31 @@ public sealed partial class CSharpShapeGenerator
         builder.Line();
 
         builder.Line(
+            "private static void AddPrefixedHeaders(IDictionary<string, IReadOnlyList<string>> headers, string prefix, object? value)"
+        );
+        builder.Block(() =>
+        {
+            builder.Line("if (value is null)");
+            builder.Block(() =>
+            {
+                builder.Line("return;");
+            });
+            builder.Line();
+            builder.Line("foreach (var item in EnumerateStringMap(value))");
+            builder.Block(() =>
+            {
+                builder.Line("if (item.Value is null)");
+                builder.Block(() =>
+                {
+                    builder.Line("continue;");
+                });
+                builder.Line();
+                builder.Line("headers[$\"{prefix}{item.Key}\"] = [FormatHttpValue(item.Value)];");
+            });
+        });
+        builder.Line();
+
+        builder.Line(
             "private static void AppendQuery(StringBuilder builder, string name, object? value)"
         );
         builder.Block(() =>
@@ -565,6 +620,23 @@ public sealed partial class CSharpShapeGenerator
         });
         builder.Line();
 
+        builder.Line("private static void AppendQueryMap(StringBuilder builder, object? value)");
+        builder.Block(() =>
+        {
+            builder.Line("if (value is null)");
+            builder.Block(() =>
+            {
+                builder.Line("return;");
+            });
+            builder.Line();
+            builder.Line("foreach (var item in EnumerateStringMap(value))");
+            builder.Block(() =>
+            {
+                builder.Line("AppendQueryValue(builder, item.Key, item.Value);");
+            });
+        });
+        builder.Line();
+
         builder.Line(
             "private static void AppendQueryValue(StringBuilder builder, string name, object? value)"
         );
@@ -580,6 +652,60 @@ public sealed partial class CSharpShapeGenerator
             builder.Line("builder.Append(Uri.EscapeDataString(name));");
             builder.Line("builder.Append('=');");
             builder.Line("builder.Append(Uri.EscapeDataString(FormatHttpValue(value)));");
+        });
+        builder.Line();
+
+        builder.Line(
+            "private static IEnumerable<KeyValuePair<string, object?>> EnumerateStringMap(object value)"
+        );
+        builder.Block(() =>
+        {
+            builder.Line(
+                "var values = value is IDictionary ? value : value.GetType().GetProperty(\"Values\")?.GetValue(value);"
+            );
+            builder.Line("if (values is not IEnumerable enumerable)");
+            builder.Block(() =>
+            {
+                builder.Line("yield break;");
+            });
+            builder.Line();
+            builder.Line("foreach (var item in enumerable)");
+            builder.Block(() =>
+            {
+                builder.Line("if (item is null)");
+                builder.Block(() =>
+                {
+                    builder.Line("continue;");
+                });
+                builder.Line();
+                builder.Line("if (item is DictionaryEntry dictionaryEntry)");
+                builder.Block(() =>
+                {
+                    builder.Line("if (dictionaryEntry.Key is not null)");
+                    builder.Block(() =>
+                    {
+                        builder.Line(
+                            "yield return new KeyValuePair<string, object?>(dictionaryEntry.Key.ToString() ?? string.Empty, dictionaryEntry.Value);"
+                        );
+                    });
+                    builder.Line();
+                    builder.Line("continue;");
+                });
+                builder.Line();
+                builder.Line("var itemType = item.GetType();");
+                builder.Line(
+                    "var key = itemType.GetProperty(\"Key\")?.GetValue(item)?.ToString();"
+                );
+                builder.Line("if (key is null)");
+                builder.Block(() =>
+                {
+                    builder.Line("continue;");
+                });
+                builder.Line();
+                builder.Line(
+                    "yield return new KeyValuePair<string, object?>(key, itemType.GetProperty(\"Value\")?.GetValue(item));"
+                );
+            });
         });
         builder.Line();
 
@@ -644,6 +770,68 @@ public sealed partial class CSharpShapeGenerator
             {
                 builder.Line("? ConvertHttpValue<T>(values[0])");
                 builder.Line(": default!;");
+            });
+        });
+        builder.Line();
+
+        builder.Line(
+            "private static T GetPrefixedHeaders<T>(IReadOnlyDictionary<string, IReadOnlyList<string>> headers, string prefix)"
+        );
+        builder.Block(() =>
+        {
+            builder.Line("var values = new Dictionary<string, string>(StringComparer.Ordinal);");
+            builder.Line("foreach (var header in headers)");
+            builder.Block(() =>
+            {
+                builder.Line(
+                    "if (!header.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) || header.Value.Count == 0)"
+                );
+                builder.Block(() =>
+                {
+                    builder.Line("continue;");
+                });
+                builder.Line();
+                builder.Line("values[header.Key[prefix.Length..]] = header.Value[0];");
+            });
+            builder.Line();
+            builder.Line("return CreateStringMap<T>(values);");
+        });
+        builder.Line();
+
+        builder.Line("private static T CreateStringMap<T>(Dictionary<string, string> values)");
+        builder.Block(() =>
+        {
+            builder.Line("if (values.Count == 0)");
+            builder.Block(() =>
+            {
+                builder.Line("return default!;");
+            });
+            builder.Line();
+            builder.Line("var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);");
+            builder.Line("if (targetType.IsAssignableFrom(values.GetType()))");
+            builder.Block(() =>
+            {
+                builder.Line("return (T)(object)values;");
+            });
+            builder.Line();
+            builder.Line(
+                "var constructor = targetType.GetConstructor([typeof(IReadOnlyDictionary<string, string>)]);"
+            );
+            builder.Line("if (constructor is null)");
+            builder.Block(() =>
+            {
+                builder.Line(
+                    "constructor = targetType.GetConstructor([typeof(Dictionary<string, string>)]);"
+                );
+            });
+            builder.Line();
+            builder.Line("return constructor is not null");
+            builder.Indented(() =>
+            {
+                builder.Line("? (T)constructor.Invoke([values])");
+                builder.Line(
+                    ": throw new InvalidOperationException($\"Cannot create string map type '{targetType}'.\");"
+                );
             });
         });
         builder.Line();

--- a/src/SmithyNet.CodeGeneration/CSharp/CSharpShapeGenerator.ServerEmitter.cs
+++ b/src/SmithyNet.CodeGeneration/CSharp/CSharpShapeGenerator.ServerEmitter.cs
@@ -447,6 +447,15 @@ public sealed partial class CSharpShapeGenerator
                 );
             }
 
+            foreach (var member in GetSortedMembers(output).Where(IsHttpPrefixHeadersMember))
+            {
+                var propertyName = CSharpIdentifier.PropertyName(member.Name);
+                var headerPrefix = member.Traits[SmithyPrelude.HttpPrefixHeadersTrait].AsString();
+                builder.Line(
+                    $"SmithyAspNetCoreProtocol.AddPrefixedResponseHeaders(httpContext, {FormatString(headerPrefix)}, output.{propertyName});"
+                );
+            }
+
             if (GetSortedMembers(output).FirstOrDefault(IsHttpPayloadMember) is { } payloadMember)
             {
                 var propertyName = CSharpIdentifier.PropertyName(payloadMember.Name);
@@ -538,12 +547,30 @@ public sealed partial class CSharpShapeGenerator
                 : $"SmithyAspNetCoreProtocol.GetQueryValue<{memberType}>(httpContext, {FormatString(queryName)})";
         }
 
+        if (IsHttpQueryParamsMember(member))
+        {
+            var excludedNames = GetSortedMembers(input)
+                .Where(IsHttpQueryMember)
+                .Select(queryMember => queryMember.Traits[SmithyPrelude.HttpQueryTrait].AsString());
+            var expression =
+                $"SmithyAspNetCoreProtocol.GetQueryParams<{memberType}>(httpContext, [{string.Join(", ", excludedNames.Select(FormatString))}])";
+            return required ? $"{expression}!" : expression;
+        }
+
         if (IsHttpHeaderMember(member))
         {
             var headerName = member.Traits[SmithyPrelude.HttpHeaderTrait].AsString();
             return required
                 ? $"SmithyAspNetCoreProtocol.GetRequiredHeaderValue<{memberType}>(httpContext, {FormatString(headerName)})"
                 : $"SmithyAspNetCoreProtocol.GetHeaderValue<{memberType}>(httpContext, {FormatString(headerName)})";
+        }
+
+        if (IsHttpPrefixHeadersMember(member))
+        {
+            var headerPrefix = member.Traits[SmithyPrelude.HttpPrefixHeadersTrait].AsString();
+            var expression =
+                $"SmithyAspNetCoreProtocol.GetPrefixedHeaders<{memberType}>(httpContext, {FormatString(headerPrefix)})";
+            return required ? $"{expression}!" : expression;
         }
 
         if (IsHttpPayloadMember(member))

--- a/src/SmithyNet.CodeGeneration/Model/SmithyPrelude.cs
+++ b/src/SmithyNet.CodeGeneration/Model/SmithyPrelude.cs
@@ -30,7 +30,11 @@ public static class SmithyPrelude
 
     public static ShapeId HttpPayloadTrait { get; } = new(Namespace, "httpPayload");
 
+    public static ShapeId HttpPrefixHeadersTrait { get; } = new(Namespace, "httpPrefixHeaders");
+
     public static ShapeId HttpQueryTrait { get; } = new(Namespace, "httpQuery");
+
+    public static ShapeId HttpQueryParamsTrait { get; } = new(Namespace, "httpQueryParams");
 
     public static ShapeId HttpErrorTrait { get; } = new(Namespace, "httpError");
 

--- a/src/SmithyNet.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
+++ b/src/SmithyNet.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Http;
@@ -44,6 +45,30 @@ public static class SmithyAspNetCoreProtocol
     }
 
     [return: MaybeNull]
+    public static T GetQueryParams<T>(HttpContext httpContext, IReadOnlyList<string> excludedNames)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(excludedNames);
+
+        var excluded = new HashSet<string>(excludedNames, StringComparer.Ordinal);
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var query in httpContext.Request.Query)
+        {
+            if (excluded.Contains(query.Key))
+            {
+                continue;
+            }
+
+            if (query.Value.Count > 0)
+            {
+                values[query.Key] = query.Value[0] ?? string.Empty;
+            }
+        }
+
+        return CreateStringMap<T>(values);
+    }
+
+    [return: MaybeNull]
     public static T GetHeaderValue<T>(HttpContext httpContext, string name)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
@@ -65,6 +90,27 @@ public static class SmithyAspNetCoreProtocol
         }
 
         return ConvertHttpValue<T>(values.FirstOrDefault())!;
+    }
+
+    [return: MaybeNull]
+    public static T GetPrefixedHeaders<T>(HttpContext httpContext, string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var header in httpContext.Request.Headers)
+        {
+            if (
+                header.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && header.Value.Count > 0
+            )
+            {
+                values[header.Key[prefix.Length..]] = header.Value[0] ?? string.Empty;
+            }
+        }
+
+        return CreateStringMap<T>(values);
     }
 
     public static async Task<T> ReadJsonRequestBodyAsync<T>(
@@ -151,6 +197,31 @@ public static class SmithyAspNetCoreProtocol
         httpContext.Response.Headers[name] = FormatHttpValue(value);
     }
 
+    public static void AddPrefixedResponseHeaders(
+        HttpContext httpContext,
+        string prefix,
+        object? value
+    )
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        if (value is null)
+        {
+            return;
+        }
+
+        foreach (var item in EnumerateStringMap(value))
+        {
+            if (item.Value is null)
+            {
+                continue;
+            }
+
+            httpContext.Response.Headers[$"{prefix}{item.Key}"] = FormatHttpValue(item.Value);
+        }
+    }
+
     public static void SetStatusCode(HttpContext httpContext, object value)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
@@ -200,6 +271,70 @@ public static class SmithyAspNetCoreProtocol
         }
 
         return (T)Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+    }
+
+    [return: MaybeNull]
+    private static T CreateStringMap<T>(Dictionary<string, string> values)
+    {
+        if (values.Count == 0)
+        {
+            return default;
+        }
+
+        var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+        if (targetType.IsAssignableFrom(values.GetType()))
+        {
+            return (T)(object)values;
+        }
+
+        var constructor = targetType.GetConstructor([typeof(IReadOnlyDictionary<string, string>)]);
+        constructor ??= targetType.GetConstructor([typeof(Dictionary<string, string>)]);
+        return constructor is not null
+            ? (T)constructor.Invoke([values])
+            : throw new InvalidOperationException($"Cannot create string map type '{targetType}'.");
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> EnumerateStringMap(object value)
+    {
+        var values =
+            value is IDictionary ? value : value.GetType().GetProperty("Values")?.GetValue(value);
+        if (values is not IEnumerable enumerable)
+        {
+            yield break;
+        }
+
+        foreach (var item in enumerable)
+        {
+            if (item is null)
+            {
+                continue;
+            }
+
+            if (item is DictionaryEntry dictionaryEntry)
+            {
+                if (dictionaryEntry.Key is not null)
+                {
+                    yield return new KeyValuePair<string, object?>(
+                        dictionaryEntry.Key.ToString() ?? string.Empty,
+                        dictionaryEntry.Value
+                    );
+                }
+
+                continue;
+            }
+
+            var itemType = item.GetType();
+            var key = itemType.GetProperty("Key")?.GetValue(item)?.ToString();
+            if (key is null)
+            {
+                continue;
+            }
+
+            yield return new KeyValuePair<string, object?>(
+                key,
+                itemType.GetProperty("Value")?.GetValue(item)
+            );
+        }
     }
 
     private static async Task<string> ReadJsonRequestBodyContentAsync(

--- a/tests/SmithyNet.Tests/Protocol/ComplianceCSharpLiterals.cs
+++ b/tests/SmithyNet.Tests/Protocol/ComplianceCSharpLiterals.cs
@@ -41,6 +41,7 @@ internal static class ComplianceCSharpLiterals
         return shape.Kind switch
         {
             ShapeKind.Structure => CreateStructure(model, shape, value, currentNamespace, options),
+            ShapeKind.Map => CreateMap(model, shape, value, currentNamespace, options),
             ShapeKind.Enum =>
                 $"new {GetTypeReference(target, currentNamespace, options)}({FormatString(value.AsString())})",
             ShapeKind.IntEnum =>
@@ -78,6 +79,11 @@ internal static class ComplianceCSharpLiterals
         }
 
         var shape = model.GetShape(target);
+        if (shape.Kind == ShapeKind.Map)
+        {
+            return CreateMapEqualityAssertion(shape, actualExpression, expected, failureContext);
+        }
+
         if (shape.Kind != ShapeKind.Structure)
         {
             throw new NotSupportedException(
@@ -122,6 +128,47 @@ internal static class ComplianceCSharpLiterals
                     : "null"
             );
         return $"new {GetTypeReference(shape.Id, currentNamespace, options)}({string.Join(", ", arguments)})";
+    }
+
+    private static string CreateMap(
+        SmithyModel model,
+        ModelShape shape,
+        Document value,
+        string currentNamespace,
+        CSharpGenerationOptions options
+    )
+    {
+        var mapValue = shape.Members["value"];
+        var entries = value
+            .AsObject()
+            .Select(item =>
+                $"[{FormatString(item.Key)}] = {CreateValue(model, mapValue.Target, item.Value, shape.Id.Namespace, options)}"
+            );
+        return $"new {GetTypeReference(shape.Id, currentNamespace, options)}(new Dictionary<string, string> {{ {string.Join(", ", entries)} }})";
+    }
+
+    private static string CreateMapEqualityAssertion(
+        ModelShape shape,
+        string actualExpression,
+        Document expected,
+        string failureContext
+    )
+    {
+        if (shape.Members["value"].Target != ShapeId.Parse("smithy.api#String"))
+        {
+            throw new NotSupportedException(
+                $"Protocol test map assertion generation for '{shape.Id}' is not supported."
+            );
+        }
+
+        return string.Join(
+            Environment.NewLine,
+            expected
+                .AsObject()
+                .Select(item =>
+                    $"if (!{actualExpression}!.Values.TryGetValue({FormatString(item.Key)}, out var {CSharpIdentifier.ParameterName(item.Key)}Value) || {CSharpIdentifier.ParameterName(item.Key)}Value != {FormatString(item.Value.AsString())}) throw new InvalidOperationException({FormatString(failureContext)});"
+                )
+        );
     }
 
     private static string GetTypeReference(

--- a/tests/SmithyNet.Tests/Protocol/OfficialProtocolSuiteTests.cs
+++ b/tests/SmithyNet.Tests/Protocol/OfficialProtocolSuiteTests.cs
@@ -1,0 +1,984 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using SmithyNet.CodeGeneration;
+using SmithyNet.CodeGeneration.CSharp;
+using SmithyNet.CodeGeneration.Model;
+using SmithyNet.Core;
+using Xunit.Abstractions;
+
+namespace SmithyNet.Tests.Protocol;
+
+public sealed class OfficialProtocolSuiteTests(
+    OfficialProtocolSuiteFixture fixture,
+    ITestOutputHelper output
+) : IClassFixture<OfficialProtocolSuiteFixture>
+{
+    private static readonly ShapeId RestJson1Protocol = ShapeId.Parse("aws.protocols#restJson1");
+    private static readonly ShapeId SimpleRestJsonProtocol = ShapeId.Parse("alloy#simpleRestJson");
+
+    [Fact]
+    public void OfficialAwsRestJson1SuiteIsAvailable()
+    {
+        var inventory = ProtocolSuiteInventory.Create(fixture.Model, RestJson1Protocol);
+
+        Assert.Equal(158, inventory.RequestCaseCount);
+        Assert.Equal(114, inventory.ResponseCaseCount);
+        Assert.Equal(191, inventory.MalformedRequestCaseCount);
+        Assert.Contains("RestJsonHttpPrefixHeadersArePresent", inventory.RequestCaseIds);
+        Assert.Contains("RestJsonHttpPayloadWithStructure", inventory.RequestCaseIds);
+        Assert.Contains("RestJsonHttpResponseCode", inventory.ResponseCaseIds);
+    }
+
+    [Fact]
+    public void OfficialAlloySimpleRestJsonSuiteIsAvailable()
+    {
+        var inventory = ProtocolSuiteInventory.Create(fixture.Model, SimpleRestJsonProtocol);
+
+        Assert.Equal(23, inventory.RequestCaseCount);
+        Assert.Equal(20, inventory.ResponseCaseCount);
+        Assert.Equal(0, inventory.MalformedRequestCaseCount);
+        Assert.Contains("AddMenuItem", inventory.RequestCaseIds);
+        Assert.Contains("RoutingAbcLabel", inventory.RequestCaseIds);
+        Assert.Contains("RoundTripDataResponse", inventory.ResponseCaseIds);
+    }
+
+    [Fact]
+    public void OfficialProtocolCasesAreAllClassifiedForConformance()
+    {
+        var cases = OfficialProtocolCase
+            .Enumerate(fixture.Model, RestJson1Protocol)
+            .Concat(OfficialProtocolCase.Enumerate(fixture.Model, SimpleRestJsonProtocol))
+            .ToArray();
+        var classifications = cases.Select(OfficialProtocolConformanceMatrix.Classify).ToArray();
+
+        Assert.Equal(506, cases.Length);
+        Assert.DoesNotContain(
+            classifications,
+            classification => classification.Status == OfficialProtocolCaseStatus.Unknown
+        );
+        Assert.All(
+            classifications.Where(classification =>
+                classification.Status == OfficialProtocolCaseStatus.Skipped
+            ),
+            classification => Assert.False(string.IsNullOrWhiteSpace(classification.Reason))
+        );
+    }
+
+    [Fact]
+    public void OfficialProtocolConformanceMatrixHasInitialExecutableAllowlist()
+    {
+        var executableCases = OfficialProtocolCase
+            .Enumerate(fixture.Model, RestJson1Protocol)
+            .Concat(OfficialProtocolCase.Enumerate(fixture.Model, SimpleRestJsonProtocol))
+            .Select(OfficialProtocolConformanceMatrix.Classify)
+            .Where(classification => classification.Status == OfficialProtocolCaseStatus.Executable)
+            .Select(classification => $"{classification.Case.Kind}:{classification.Case.Id}")
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(9, executableCases.Count);
+        Assert.Contains("Request:HealthGet", executableCases);
+        Assert.Contains("Request:RoutingAbc", executableCases);
+        Assert.Contains("Request:RoutingAbcDef", executableCases);
+        Assert.Contains("Request:RoutingAbcLabel", executableCases);
+        Assert.Contains("Request:RoutingAbcXyz", executableCases);
+        Assert.Contains("Response:headerEndpointResponse", executableCases);
+        Assert.Contains("Request:RestJsonEmptyInputAndEmptyOutput", executableCases);
+        Assert.Contains("Request:RestJsonHttpPrefixHeadersArePresent", executableCases);
+        Assert.Contains("Response:RestJsonHttpPrefixHeadersArePresent", executableCases);
+    }
+
+    [Fact]
+    public async Task ExecutableOfficialProtocolCasesPassGeneratedClientConformance()
+    {
+        var executableCases = OfficialProtocolCase
+            .Enumerate(fixture.Model, RestJson1Protocol)
+            .Concat(OfficialProtocolCase.Enumerate(fixture.Model, SimpleRestJsonProtocol))
+            .Where(testCase =>
+                OfficialProtocolConformanceMatrix.Classify(testCase).Status
+                == OfficialProtocolCaseStatus.Executable
+            )
+            .ToArray();
+
+        foreach (var testCase in executableCases)
+        {
+            await OfficialGeneratedClientConformanceRunner.RunAsync(fixture.Model, testCase);
+        }
+    }
+
+    [Fact]
+    public async Task OfficialProtocolConformanceMatrixMatchesSnapshot()
+    {
+        var cases = OfficialProtocolCase
+            .Enumerate(fixture.Model, RestJson1Protocol)
+            .Concat(OfficialProtocolCase.Enumerate(fixture.Model, SimpleRestJsonProtocol));
+        var markdown = OfficialProtocolConformanceMatrixRenderer.Render(cases);
+        var snapshotPath = OfficialProtocolConformanceMatrixRenderer.GetRepositoryReportPath();
+        var actualPath = OfficialProtocolConformanceMatrixRenderer.GetRepositoryActualReportPath();
+        var snapshot = await File.ReadAllTextAsync(snapshotPath);
+
+        output.WriteLine(markdown);
+
+        if (NormalizeLineEndings(snapshot) != NormalizeLineEndings(markdown))
+        {
+            await File.WriteAllTextAsync(actualPath, markdown);
+        }
+        else if (File.Exists(actualPath))
+        {
+            File.Delete(actualPath);
+        }
+
+        Assert.True(
+            NormalizeLineEndings(snapshot) == NormalizeLineEndings(markdown),
+            $"Protocol conformance snapshot is stale. Compare '{snapshotPath}' with '{actualPath}' and update the snapshot if the change is intentional."
+        );
+    }
+
+    private static string NormalizeLineEndings(string value)
+    {
+        return value.ReplaceLineEndings("\n");
+    }
+}
+
+public sealed class OfficialProtocolSuiteFixture : IAsyncLifetime
+{
+    private TemporaryDirectory? directory;
+
+    public SmithyModel Model { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        directory = TemporaryDirectory.Create();
+        Directory.CreateDirectory(directory.Path);
+        await File.WriteAllTextAsync(
+            Path.Combine(directory.Path, "smithy-build.json"),
+            """
+            {
+              "version": "1.0",
+              "maven": {
+                "dependencies": [
+                  "software.amazon.smithy:smithy-aws-traits:1.68.0",
+                  "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0",
+                  "com.disneystreaming.alloy:alloy-core:0.3.38",
+                  "com.disneystreaming.alloy:alloy-protocol-tests:0.3.38"
+                ]
+              }
+            }
+            """
+        );
+
+        var result = await new SmithyBuildRunner().BuildAsync(
+            new SmithyBuildOptions(
+                directory.Path,
+                "smithy-build.json",
+                Path.Combine(directory.Path, "smithy-build")
+            )
+        );
+        Model = result.Model;
+    }
+
+    public Task DisposeAsync()
+    {
+        directory?.Dispose();
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed record ProtocolSuiteInventory(
+    int RequestCaseCount,
+    int ResponseCaseCount,
+    int MalformedRequestCaseCount,
+    IReadOnlySet<string> RequestCaseIds,
+    IReadOnlySet<string> ResponseCaseIds
+)
+{
+    private static readonly ShapeId HttpMalformedRequestTestsTrait = ShapeId.Parse(
+        "smithy.test#httpMalformedRequestTests"
+    );
+
+    public static ProtocolSuiteInventory Create(SmithyModel model, ShapeId protocol)
+    {
+        var requestCases = model
+            .Shapes.Values.Where(shape => shape.Kind == ShapeKind.Operation)
+            .SelectMany(operation =>
+                HttpProtocolComplianceCases.ReadRequestTests(model, operation.Id)
+            )
+            .Where(testCase => testCase.Protocol == protocol)
+            .ToArray();
+        var responseCases = model
+            .Shapes.Values.SelectMany(operation =>
+                HttpProtocolComplianceCases.ReadResponseTests(model, operation.Id)
+            )
+            .Where(testCase => testCase.Protocol == protocol)
+            .ToArray();
+        var malformedRequestCaseCount = model
+            .Shapes.Values.SelectMany(shape =>
+                shape.Traits.GetValueOrDefault(HttpMalformedRequestTestsTrait) is { } malformed
+                    ? malformed
+                        .AsArray()
+                        .Where(testCase =>
+                            ShapeId.Parse(testCase.AsObject()["protocol"].AsString()) == protocol
+                        )
+                    : []
+            )
+            .Count();
+
+        return new ProtocolSuiteInventory(
+            requestCases.Length,
+            responseCases.Length,
+            malformedRequestCaseCount,
+            requestCases.Select(testCase => testCase.Id).ToHashSet(StringComparer.Ordinal),
+            responseCases.Select(testCase => testCase.Id).ToHashSet(StringComparer.Ordinal)
+        );
+    }
+}
+
+internal enum OfficialProtocolCaseKind
+{
+    Request,
+    Response,
+    MalformedRequest,
+}
+
+internal enum OfficialProtocolCaseStatus
+{
+    Executable,
+    Skipped,
+    Unknown,
+}
+
+internal sealed record OfficialProtocolCase(
+    ShapeId Owner,
+    ShapeId Protocol,
+    OfficialProtocolCaseKind Kind,
+    string Id
+)
+{
+    private static readonly ShapeId HttpMalformedRequestTestsTrait = ShapeId.Parse(
+        "smithy.test#httpMalformedRequestTests"
+    );
+
+    public static IEnumerable<OfficialProtocolCase> Enumerate(SmithyModel model, ShapeId protocol)
+    {
+        foreach (var shape in model.Shapes.Values)
+        {
+            if (shape.Kind == ShapeKind.Operation)
+            {
+                foreach (
+                    var requestTest in HttpProtocolComplianceCases
+                        .ReadRequestTests(model, shape.Id)
+                        .Where(testCase => testCase.Protocol == protocol)
+                )
+                {
+                    yield return new OfficialProtocolCase(
+                        shape.Id,
+                        protocol,
+                        OfficialProtocolCaseKind.Request,
+                        requestTest.Id
+                    );
+                }
+            }
+
+            foreach (
+                var responseTest in HttpProtocolComplianceCases
+                    .ReadResponseTests(model, shape.Id)
+                    .Where(testCase => testCase.Protocol == protocol)
+            )
+            {
+                yield return new OfficialProtocolCase(
+                    shape.Id,
+                    protocol,
+                    OfficialProtocolCaseKind.Response,
+                    responseTest.Id
+                );
+            }
+
+            if (shape.Traits.GetValueOrDefault(HttpMalformedRequestTestsTrait) is not { } malformed)
+            {
+                continue;
+            }
+
+            foreach (var malformedTest in malformed.AsArray())
+            {
+                var properties = malformedTest.AsObject();
+                if (ShapeId.Parse(properties["protocol"].AsString()) != protocol)
+                {
+                    continue;
+                }
+
+                yield return new OfficialProtocolCase(
+                    shape.Id,
+                    protocol,
+                    OfficialProtocolCaseKind.MalformedRequest,
+                    properties["id"].AsString()
+                );
+            }
+        }
+    }
+}
+
+internal sealed record OfficialProtocolCaseClassification(
+    OfficialProtocolCase Case,
+    OfficialProtocolCaseStatus Status,
+    string? Reason
+);
+
+internal static class OfficialProtocolConformanceMatrix
+{
+    private static readonly ShapeId RestJson1Protocol = ShapeId.Parse("aws.protocols#restJson1");
+    private static readonly ShapeId SimpleRestJsonProtocol = ShapeId.Parse("alloy#simpleRestJson");
+
+    private static readonly HashSet<(
+        ShapeId Protocol,
+        OfficialProtocolCaseKind Kind,
+        string Id
+    )> ExecutableCases =
+    [
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Request, "HealthGet"),
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Request, "RoutingAbc"),
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Request, "RoutingAbcDef"),
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Request, "RoutingAbcLabel"),
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Request, "RoutingAbcXyz"),
+        (SimpleRestJsonProtocol, OfficialProtocolCaseKind.Response, "headerEndpointResponse"),
+        (RestJson1Protocol, OfficialProtocolCaseKind.Request, "RestJsonEmptyInputAndEmptyOutput"),
+        (
+            RestJson1Protocol,
+            OfficialProtocolCaseKind.Request,
+            "RestJsonHttpPrefixHeadersArePresent"
+        ),
+        (
+            RestJson1Protocol,
+            OfficialProtocolCaseKind.Response,
+            "RestJsonHttpPrefixHeadersArePresent"
+        ),
+    ];
+
+    public static OfficialProtocolCaseClassification Classify(OfficialProtocolCase testCase)
+    {
+        if (ExecutableCases.Contains((testCase.Protocol, testCase.Kind, testCase.Id)))
+        {
+            return new OfficialProtocolCaseClassification(
+                testCase,
+                OfficialProtocolCaseStatus.Executable,
+                null
+            );
+        }
+
+        return new OfficialProtocolCaseClassification(
+            testCase,
+            OfficialProtocolCaseStatus.Skipped,
+            GetSkipReason(testCase)
+        );
+    }
+
+    private static string GetSkipReason(OfficialProtocolCase testCase)
+    {
+        if (testCase.Kind == OfficialProtocolCaseKind.MalformedRequest)
+        {
+            return testCase.Protocol == RestJson1Protocol
+                ? "restJson1 server generation and malformed request rejection are not implemented."
+                : "Malformed request conformance execution is not implemented.";
+        }
+
+        if (
+            testCase.Protocol == RestJson1Protocol
+            && testCase.Owner.Namespace != "aws.protocoltests.restjson"
+        )
+        {
+            return "AWS service-specific restJson1 protocol fixtures are outside the current generated-client slice.";
+        }
+
+        if (testCase.Id == "HeaderEndpointInput")
+        {
+            return "HTTP URI normalization for trailing slashes does not match the official case.";
+        }
+
+        if (testCase.Id.Contains("Greedy", StringComparison.Ordinal))
+        {
+            return "Greedy label URI expansion is not implemented.";
+        }
+
+        if (
+            testCase.Id.Contains("Endpoint", StringComparison.Ordinal)
+            || testCase.Id.Contains("Host", StringComparison.Ordinal)
+        )
+        {
+            return "Endpoint and host-prefix binding traits are not implemented.";
+        }
+
+        if (testCase.Id.Contains("Checksum", StringComparison.Ordinal))
+        {
+            return "HTTP checksum traits are not implemented.";
+        }
+
+        if (
+            testCase.Id.Contains("OpenUnions", StringComparison.Ordinal)
+            || testCase.Id.Contains("Union", StringComparison.Ordinal)
+        )
+        {
+            return "Full union protocol encodings are not implemented.";
+        }
+
+        if (testCase.Id.Contains("Preserve", StringComparison.Ordinal))
+        {
+            return "alloy#preserveKeyOrder behavior is not implemented.";
+        }
+
+        if (testCase.Id.Contains("Routing", StringComparison.Ordinal))
+        {
+            return "Official server routing conformance execution is not implemented.";
+        }
+
+        if (testCase.Id.Contains("Validation", StringComparison.Ordinal))
+        {
+            return "Protocol-aware runtime validation is not implemented.";
+        }
+
+        return testCase.Kind switch
+        {
+            OfficialProtocolCaseKind.Request =>
+                "Official request conformance execution is not yet enabled for this case.",
+            OfficialProtocolCaseKind.Response =>
+                "Official response conformance execution is not yet enabled for this case.",
+            _ => "Official conformance execution is not yet enabled for this case.",
+        };
+    }
+}
+
+internal static class OfficialProtocolConformanceMatrixRenderer
+{
+    private const string GeneratedReportRelativePath = "docs/generated/protocol-conformance.md";
+
+    public static string GetRepositoryReportPath()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        return Path.Combine(repositoryRoot, GeneratedReportRelativePath);
+    }
+
+    public static string GetRepositoryActualReportPath()
+    {
+        return Path.ChangeExtension(GetRepositoryReportPath(), ".actual.md");
+    }
+
+    public static string Render(IEnumerable<OfficialProtocolCase> cases)
+    {
+        var classifications = cases
+            .Select(OfficialProtocolConformanceMatrix.Classify)
+            .OrderBy(
+                classification => classification.Case.Protocol.ToString(),
+                StringComparer.Ordinal
+            )
+            .ThenBy(classification => classification.Case.Kind)
+            .ThenBy(classification => classification.Case.Id, StringComparer.Ordinal)
+            .ToArray();
+        var builder = new StringBuilder();
+        builder.AppendLine("# Official Protocol Conformance Matrix");
+        builder.AppendLine();
+        builder.AppendLine("| Protocol | Case kind | Executable | Skipped | Total | Conformance |");
+        builder.AppendLine("| --- | ---: | ---: | ---: | ---: | ---: |");
+
+        foreach (
+            var group in classifications.GroupBy(classification => new
+            {
+                classification.Case.Protocol,
+                classification.Case.Kind,
+            })
+        )
+        {
+            var executable = group.Count(classification =>
+                classification.Status == OfficialProtocolCaseStatus.Executable
+            );
+            var skipped = group.Count(classification =>
+                classification.Status == OfficialProtocolCaseStatus.Skipped
+            );
+            var total = executable + skipped;
+            builder.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"| `{group.Key.Protocol}` | `{group.Key.Kind}` | {executable} | {skipped} | {total} | {CreatePercentage(executable, total)} |"
+            );
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Executable Cases");
+        builder.AppendLine();
+        foreach (
+            var classification in classifications.Where(classification =>
+                classification.Status == OfficialProtocolCaseStatus.Executable
+            )
+        )
+        {
+            builder.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"- `{classification.Case.Protocol}` `{classification.Case.Kind}` `{classification.Case.Id}`"
+            );
+        }
+
+        return builder.ToString();
+    }
+
+    private static string CreatePercentage(int executable, int total)
+    {
+        return total == 0
+            ? "0.0%"
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"{(double)executable / total * 100:0.0}%"
+            );
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (
+            directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "SmithyNet.slnx"))
+        )
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not find the Smithy.NET repository root."
+            );
+    }
+}
+
+internal static class OfficialGeneratedClientConformanceRunner
+{
+    public static async Task RunAsync(SmithyModel model, OfficialProtocolCase testCase)
+    {
+        if (testCase.Kind is OfficialProtocolCaseKind.MalformedRequest)
+        {
+            throw new InvalidOperationException(
+                $"Malformed request case '{testCase.Id}' cannot run through the generated client conformance runner."
+            );
+        }
+
+        using var directory = TemporaryDirectory.Create();
+        Directory.CreateDirectory(directory.Path);
+        var operation = model.GetShape(testCase.Owner);
+        var service = FindContainingService(model, operation.Id, testCase.Protocol);
+        var suppressOutput =
+            testCase.Kind == OfficialProtocolCaseKind.Request
+            && testCase.Protocol == ShapeId.Parse("alloy#simpleRestJson");
+        var filteredModel = CreateSingleOperationModel(model, service, operation, suppressOutput);
+        operation = filteredModel.GetShape(operation.Id);
+        service = filteredModel.GetShape(service.Id);
+
+        foreach (var generatedFile in new CSharpShapeGenerator().Generate(filteredModel))
+        {
+            var path = Path.Combine(directory.Path, generatedFile.Path);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(path, generatedFile.Contents);
+        }
+
+        await WriteProjectAsync(directory.Path);
+        await WriteProgramAsync(directory.Path, filteredModel, service, operation, testCase);
+
+        var build = await RunDotNet(
+            directory.Path,
+            "build",
+            "-p:UseSharedCompilation=false",
+            "--disable-build-servers"
+        );
+        Assert.True(
+            build.ExitCode == 0,
+            $"dotnet build failed for official protocol case '{testCase.Id}' with exit code {build.ExitCode}.{Environment.NewLine}{build.Output}{Environment.NewLine}{build.Error}"
+        );
+
+        var run = await RunDotNet(directory.Path, "run", "--no-build");
+        Assert.True(
+            run.ExitCode == 0,
+            $"dotnet run failed for official protocol case '{testCase.Id}' with exit code {run.ExitCode}.{Environment.NewLine}{run.Output}{Environment.NewLine}{run.Error}"
+        );
+    }
+
+    private static ModelShape FindContainingService(
+        SmithyModel model,
+        ShapeId operationId,
+        ShapeId protocol
+    )
+    {
+        return model
+            .Shapes.Values.Where(shape =>
+                shape.Kind == ShapeKind.Service
+                && shape.Traits.Has(protocol)
+                && shape.Operations.Contains(operationId)
+            )
+            .OrderBy(shape => shape.Id.ToString(), StringComparer.Ordinal)
+            .First();
+    }
+
+    private static SmithyModel CreateSingleOperationModel(
+        SmithyModel model,
+        ModelShape service,
+        ModelShape operation,
+        bool suppressOutput
+    )
+    {
+        var shapes = new Dictionary<ShapeId, ModelShape>();
+        var filteredOperation = operation with
+        {
+            Errors = [],
+            Input = operation.Input is { } input && IsUnit(input) ? null : operation.Input,
+            Output = suppressOutput ? null : operation.Output,
+        };
+        AddShape(service with { Operations = [operation.Id] });
+        AddShape(filteredOperation);
+        AddShapeClosure(filteredOperation.Input);
+        if (!suppressOutput)
+        {
+            AddShapeClosure(operation.Output);
+        }
+
+        return new SmithyModel(model.SmithyVersion, model.Metadata, shapes);
+
+        void AddShapeClosure(ShapeId? id)
+        {
+            if (
+                id is not { } shapeId
+                || shapeId.Namespace == SmithyPrelude.Namespace
+                || shapes.ContainsKey(shapeId)
+            )
+            {
+                return;
+            }
+
+            var shape = model.GetShape(shapeId);
+            AddShape(shape);
+            AddShapeClosure(shape.Target);
+            AddShapeClosure(shape.Input);
+            AddShapeClosure(shape.Output);
+            foreach (var error in shape.Errors)
+            {
+                AddShapeClosure(error);
+            }
+
+            foreach (var member in shape.Members.Values)
+            {
+                AddShapeClosure(member.Target);
+            }
+        }
+
+        void AddShape(ModelShape shape)
+        {
+            shapes.TryAdd(shape.Id, shape);
+        }
+
+        static bool IsUnit(ShapeId id)
+        {
+            return id.Namespace == SmithyPrelude.Namespace && id.Name == "Unit";
+        }
+    }
+
+    private static async Task WriteProjectAsync(string projectDirectory)
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(projectDirectory, "OfficialProtocolCase.csproj"),
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+              </PropertyGroup>
+              <ItemGroup>
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Client/SmithyNet.Client.csproj" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Core/SmithyNet.Core.csproj" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Http/SmithyNet.Http.csproj" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Json/SmithyNet.Json.csproj" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Server.AspNetCore/SmithyNet.Server.AspNetCore.csproj" />
+                <ProjectReference Include="{{FindRepositoryRoot()}}/src/SmithyNet.Server/SmithyNet.Server.csproj" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+    }
+
+    private static Task WriteProgramAsync(
+        string projectDirectory,
+        SmithyModel model,
+        ModelShape service,
+        ModelShape operation,
+        OfficialProtocolCase testCase
+    )
+    {
+        var serviceNamespace = CSharpIdentifier.Namespace(
+            service.Id.Namespace,
+            baseNamespace: null
+        );
+        var serviceTypeName = CSharpIdentifier.TypeName(service.Id.Name);
+        var clientTypeName = $"{serviceTypeName}Client";
+        var interfaceName = $"I{clientTypeName}";
+        var methodName = $"{CSharpIdentifier.PropertyName(operation.Id.Name)}Async";
+        var requestTest =
+            testCase.Kind == OfficialProtocolCaseKind.Request
+                ? HttpProtocolComplianceCases
+                    .ReadRequestTests(model, operation.Id)
+                    .Single(item => item.Id == testCase.Id && item.Protocol == testCase.Protocol)
+                : null;
+        var responseTest =
+            testCase.Kind == OfficialProtocolCaseKind.Response
+                ? HttpProtocolComplianceCases
+                    .ReadResponseTests(model, operation.Id)
+                    .Single(item => item.Id == testCase.Id && item.Protocol == testCase.Protocol)
+            : requestTest is not null ? CreateSuccessResponseForRequestTest()
+            : null;
+        var input = CreateClientInput(model, operation, requestTest?.Parameters ?? Document.Null);
+        var call =
+            operation.Output is { } outputId && responseTest is not null
+                ? $$"""
+            var output = await client.{{methodName}}({{input}});
+            {{ComplianceCSharpLiterals.CreateEqualityAssertion(
+                model,
+                outputId,
+                "output",
+                responseTest.Parameters,
+                operation.Id.Namespace,
+                new CSharpGenerationOptions(),
+                $"Unexpected output for {testCase.Id}"
+            )}}
+            """
+                : $"await client.{methodName}({input});";
+        var handlerCase = requestTest is not null
+            ? CreateRequestAssertions(requestTest)
+            : string.Empty;
+        var requestOnlyWithoutOutput =
+            testCase.Kind == OfficialProtocolCaseKind.Request
+            && testCase.Protocol == ShapeId.Parse("alloy#simpleRestJson");
+        var responseHeaders =
+            requestOnlyWithoutOutput ? string.Empty
+            : responseTest is not null ? CreateResponseHeaders(responseTest.Headers)
+            : string.Empty;
+        var responseStatusCode = requestOnlyWithoutOutput ? 204 : responseTest?.Code ?? 200;
+        var responseBody = requestOnlyWithoutOutput ? string.Empty : responseTest?.Body ?? "{}";
+
+        return File.WriteAllTextAsync(
+            Path.Combine(projectDirectory, "Program.cs"),
+            $$"""
+            using System.Net;
+            using System.Text;
+            using {{serviceNamespace}};
+
+            {{interfaceName}} client = new {{clientTypeName}}(new HttpClient(new Handler())
+            {
+                BaseAddress = new Uri("https://example.test")
+            });
+
+            {{call}}
+
+            internal sealed class Handler : HttpMessageHandler
+            {
+                protected override async Task<HttpResponseMessage> SendAsync(
+                    HttpRequestMessage request,
+                    CancellationToken cancellationToken)
+                {
+                    {{handlerCase}}
+
+                    return new HttpResponseMessage((HttpStatusCode){{responseStatusCode.ToString(
+                CultureInfo.InvariantCulture
+            )}})
+                    {
+                        Content = new StringContent({{ComplianceCSharpLiterals.FormatString(
+                responseBody
+            )}}, Encoding.UTF8, "application/json")
+                    }{{responseHeaders}};
+                }
+            }
+
+            internal static class ResponseExtensions
+            {
+                public static HttpResponseMessage WithHeader(
+                    this HttpResponseMessage response,
+                    string name,
+                    string value)
+                {
+                    response.Headers.Add(name, value);
+                    return response;
+                }
+            }
+            """
+        );
+
+        HttpResponseTestCase CreateSuccessResponseForRequestTest()
+        {
+            return new HttpResponseTestCase(
+                $"{testCase.Id}SyntheticResponse",
+                testCase.Protocol,
+                200,
+                requestTest?.Headers
+                    ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                "{}",
+                Document.From(new Dictionary<string, Document>())
+            );
+        }
+    }
+
+    private static string CreateClientInput(
+        SmithyModel model,
+        ModelShape operation,
+        Document parameters
+    )
+    {
+        if (operation.Input is not { } inputId)
+        {
+            return string.Empty;
+        }
+
+        if (parameters.Kind == DocumentKind.Null && model.GetShape(inputId).Members.Count == 0)
+        {
+            var inputType = GetTypeReference(inputId, operation.Id.Namespace);
+            return $"new {inputType}()";
+        }
+
+        return ComplianceCSharpLiterals.CreateValue(
+            model,
+            inputId,
+            parameters.Kind == DocumentKind.Null
+                ? Document.From(new Dictionary<string, Document>())
+                : parameters,
+            operation.Id.Namespace,
+            new CSharpGenerationOptions()
+        );
+    }
+
+    private static string CreateRequestAssertions(HttpRequestTestCase testCase)
+    {
+        var expectedRequestUri =
+            testCase.QueryParams.Count == 0
+                ? testCase.Uri
+                : $"{testCase.Uri}?{string.Join("&", testCase.QueryParams)}";
+        var headerAssertions = string.Join(
+            Environment.NewLine,
+            testCase.Headers.Select(
+                (header, index) =>
+                    $$"""
+                    if (!request.Headers.TryGetValues({{ComplianceCSharpLiterals.FormatString(
+                        header.Key
+                    )}}, out var requestHeader{{index.ToString(
+                        CultureInfo.InvariantCulture
+                    )}}) || requestHeader{{index.ToString(
+                        CultureInfo.InvariantCulture
+                    )}}.Single() != {{ComplianceCSharpLiterals.FormatString(header.Value)}})
+                    {
+                        throw new InvalidOperationException({{ComplianceCSharpLiterals.FormatString(
+                        $"Unexpected request header: {header.Key}"
+                    )}});
+                    }
+                    """
+            )
+        );
+
+        return $$"""
+                    if (request.Method.Method != {{ComplianceCSharpLiterals.FormatString(
+                testCase.Method
+            )}} || request.RequestUri?.PathAndQuery != {{ComplianceCSharpLiterals.FormatString(
+                expectedRequestUri
+            )}})
+                    {
+                        throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri?.PathAndQuery}");
+                    }
+
+                    {{headerAssertions}}
+
+                    var body = request.Content is null
+                        ? string.Empty
+                        : await request.Content.ReadAsStringAsync(cancellationToken);
+                    if (body != {{ComplianceCSharpLiterals.FormatString(
+                testCase.Body ?? string.Empty
+            )}})
+                    {
+                        throw new InvalidOperationException($"Unexpected request body: {body}");
+                    }
+            """;
+    }
+
+    private static string CreateResponseHeaders(IReadOnlyDictionary<string, string> headers)
+    {
+        return string.Concat(
+            headers.Select(header =>
+                $".WithHeader({ComplianceCSharpLiterals.FormatString(header.Key)}, {ComplianceCSharpLiterals.FormatString(header.Value)})"
+            )
+        );
+    }
+
+    private static string GetTypeReference(ShapeId id, string currentNamespace)
+    {
+        var typeName = CSharpIdentifier.TypeName(id.Name);
+        return string.Equals(id.Namespace, currentNamespace, StringComparison.Ordinal)
+            ? typeName
+            : $"global::{CSharpIdentifier.Namespace(id.Namespace, baseNamespace: null)}.{typeName}";
+    }
+
+    private static async Task<(int ExitCode, string Output, string Error)> RunDotNet(
+        string projectDirectory,
+        params string[] arguments
+    )
+    {
+        using var process = Process.Start(
+            new ProcessStartInfo("dotnet", arguments)
+            {
+                WorkingDirectory = projectDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            }
+        );
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        return (process.ExitCode, await outputTask, await errorTask);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (
+            directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "SmithyNet.slnx"))
+        )
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not find the Smithy.NET repository root."
+            );
+    }
+}
+
+internal sealed class TemporaryDirectory : IDisposable
+{
+    private TemporaryDirectory(string path)
+    {
+        Path = path;
+    }
+
+    public string Path { get; }
+
+    public static TemporaryDirectory Create()
+    {
+        return new TemporaryDirectory(
+            System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "smithy-net-official-protocol-tests",
+                Guid.NewGuid().ToString("N")
+            )
+        );
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/SmithyNet.Tests/Protocol/RestJsonProtocolComplianceTests.cs
+++ b/tests/SmithyNet.Tests/Protocol/RestJsonProtocolComplianceTests.cs
@@ -45,10 +45,12 @@ public sealed class RestJsonProtocolComplianceTests
                         "method": "POST",
                         "uri": "/forecast/Zurich",
                         "queryParams": [
-                          "units=metric"
+                          "units=metric",
+                          "debug=true"
                         ],
                         "headers": {
-                          "x-request-id": "request-1"
+                          "x-request-id": "request-1",
+                          "x-meta-trace": "abc"
                         },
                         "body": "{\"note\":\"morning\"}",
                         "bodyMediaType": "application/json",
@@ -57,7 +59,13 @@ public sealed class RestJsonProtocolComplianceTests
                           "details": {
                             "note": "morning"
                           },
+                          "metadata": {
+                            "trace": "abc"
+                          },
                           "requestId": "request-1",
+                          "tags": {
+                            "debug": "true"
+                          },
                           "units": "metric"
                         }
                       }
@@ -68,11 +76,15 @@ public sealed class RestJsonProtocolComplianceTests
                         "protocol": "aws.protocols#restJson1",
                         "code": 200,
                         "headers": {
-                          "x-request-id": "response-1"
+                          "x-request-id": "response-1",
+                          "x-extra-source": "server"
                         },
                         "body": "{\"summary\":\"clear\"}",
                         "bodyMediaType": "application/json",
                         "params": {
+                          "metadata": {
+                            "source": "server"
+                          },
                           "requestId": "response-1",
                           "status": 200,
                           "summary": "clear"
@@ -98,6 +110,28 @@ public sealed class RestJsonProtocolComplianceTests
                     }
                   }
                 },
+                "example.weather#ForecastMetadata": {
+                  "type": "map",
+                  "members": {
+                    "key": {
+                      "target": "smithy.api#String"
+                    },
+                    "value": {
+                      "target": "smithy.api#String"
+                    }
+                  }
+                },
+                "example.weather#ForecastTags": {
+                  "type": "map",
+                  "members": {
+                    "key": {
+                      "target": "smithy.api#String"
+                    },
+                    "value": {
+                      "target": "smithy.api#String"
+                    }
+                  }
+                },
                 "example.weather#GetForecastInput": {
                   "type": "structure",
                   "members": {
@@ -115,11 +149,25 @@ public sealed class RestJsonProtocolComplianceTests
                         "smithy.api#httpPayload": {}
                       }
                     },
+                    "metadata": {
+                      "target": "example.weather#ForecastMetadata",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpPrefixHeaders": "x-meta-"
+                      }
+                    },
                     "requestId": {
                       "target": "smithy.api#String",
                       "traits": {
                         "smithy.api#required": {},
                         "smithy.api#httpHeader": "x-request-id"
+                      }
+                    },
+                    "tags": {
+                      "target": "example.weather#ForecastTags",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpQueryParams": {}
                       }
                     },
                     "units": {
@@ -133,6 +181,13 @@ public sealed class RestJsonProtocolComplianceTests
                 "example.weather#GetForecastOutput": {
                   "type": "structure",
                   "members": {
+                    "metadata": {
+                      "target": "example.weather#ForecastMetadata",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpPrefixHeaders": "x-extra-"
+                      }
+                    },
                     "requestId": {
                       "target": "smithy.api#String",
                       "traits": {

--- a/tests/SmithyNet.Tests/Protocol/SimpleRestJsonServerProtocolTests.cs
+++ b/tests/SmithyNet.Tests/Protocol/SimpleRestJsonServerProtocolTests.cs
@@ -104,6 +104,20 @@ public sealed class SimpleRestJsonServerProtocolTests
                         "smithy.api#httpHeader": "x-request-id"
                       }
                     },
+                    "metadata": {
+                      "target": "example.weather#ForecastMetadata",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpPrefixHeaders": "x-meta-"
+                      }
+                    },
+                    "tags": {
+                      "target": "example.weather#ForecastTags",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpQueryParams": {}
+                      }
+                    },
                     "units": {
                       "target": "smithy.api#String",
                       "traits": {
@@ -142,6 +156,28 @@ public sealed class SimpleRestJsonServerProtocolTests
                     }
                   }
                 },
+                "example.weather#ForecastMetadata": {
+                  "type": "map",
+                  "members": {
+                    "key": {
+                      "target": "smithy.api#String"
+                    },
+                    "value": {
+                      "target": "smithy.api#String"
+                    }
+                  }
+                },
+                "example.weather#ForecastTags": {
+                  "type": "map",
+                  "members": {
+                    "key": {
+                      "target": "smithy.api#String"
+                    },
+                    "value": {
+                      "target": "smithy.api#String"
+                    }
+                  }
+                },
                 "example.weather#PutForecastBodyInput": {
                   "type": "structure",
                   "members": {
@@ -167,6 +203,13 @@ public sealed class SimpleRestJsonServerProtocolTests
                       "traits": {
                         "smithy.api#required": {},
                         "smithy.api#httpHeader": "x-response-id"
+                      }
+                    },
+                    "metadata": {
+                      "target": "example.weather#ForecastMetadata",
+                      "traits": {
+                        "smithy.api#required": {},
+                        "smithy.api#httpPrefixHeaders": "x-extra-"
                       }
                     },
                     "status": {
@@ -284,14 +327,16 @@ public sealed class SimpleRestJsonServerProtocolTests
                 BaseAddress = new Uri($"http://127.0.0.1:{port}")
             };
 
-            using var get = new HttpRequestMessage(HttpMethod.Get, "/forecast/Zurich?units=metric");
+            using var get = new HttpRequestMessage(HttpMethod.Get, "/forecast/Zurich?units=metric&source=radar");
             get.Headers.Add("x-request-id", "request-1");
+            get.Headers.Add("x-meta-trace", "trace-1");
             using var getResponse = await client.SendAsync(get);
             await AssertResponseAsync(
                 getResponse,
                 HttpStatusCode.Accepted,
                 "response-1",
-                "{\"summary\":\"Zurich:metric:request-1\"}");
+                "server",
+                "{\"summary\":\"Zurich:metric:request-1:trace-1:radar\"}");
 
             using var put = new HttpRequestMessage(HttpMethod.Post, "/forecast/Zurich")
             {
@@ -302,6 +347,7 @@ public sealed class SimpleRestJsonServerProtocolTests
                 putResponse,
                 HttpStatusCode.Created,
                 "response-2",
+                "server",
                 "{\"summary\":\"Zurich:storm\"}");
 
             using var putBody = new HttpRequestMessage(HttpMethod.Post, "/forecast-body")
@@ -316,12 +362,14 @@ public sealed class SimpleRestJsonServerProtocolTests
                 putBodyResponse,
                 HttpStatusCode.OK,
                 "response-3",
+                "server",
                 "{\"summary\":\"rain:high\"}");
 
             using var errorResponse = await client.GetAsync("/forecast/fail");
             await AssertResponseAsync(
                 errorResponse,
                 HttpStatusCode.BadRequest,
+                null,
                 null,
                 "{\"message\":\"bad forecast\",\"reason\":\"invalid\"}");
 
@@ -338,6 +386,7 @@ public sealed class SimpleRestJsonServerProtocolTests
                 HttpResponseMessage response,
                 HttpStatusCode expectedStatusCode,
                 string? expectedResponseId,
+                string? expectedExtraSource,
                 string expectedBody)
             {
                 var body = await response.Content.ReadAsStringAsync();
@@ -356,6 +405,15 @@ public sealed class SimpleRestJsonServerProtocolTests
                     }
                 }
 
+                if (expectedExtraSource is not null)
+                {
+                    if (!response.Headers.TryGetValues("x-extra-source", out var sources)
+                        || sources.Single() != expectedExtraSource)
+                    {
+                        throw new InvalidOperationException("Unexpected prefix response header.");
+                    }
+                }
+
                 if (!JsonNode.DeepEquals(JsonNode.Parse(body), JsonNode.Parse(expectedBody)))
                 {
                     throw new InvalidOperationException($"Unexpected body: {body}");
@@ -370,9 +428,10 @@ public sealed class SimpleRestJsonServerProtocolTests
                 {
                     return Task.FromResult(
                         new GetForecastOutput(
+                            new ForecastMetadata(new Dictionary<string, string> { ["source"] = "server" }),
                             "response-1",
                             202,
-                            $"{input.City}:{input.Units}:{input.RequestId}"));
+                            $"{input.City}:{input.Units}:{input.RequestId}:{input.Metadata.Values["trace"]}:{input.Tags.Values["source"]}"));
                 }
 
                 public Task<GetForecastOutput> PutForecastAsync(
@@ -381,6 +440,7 @@ public sealed class SimpleRestJsonServerProtocolTests
                 {
                     return Task.FromResult(
                         new GetForecastOutput(
+                            new ForecastMetadata(new Dictionary<string, string> { ["source"] = "server" }),
                             "response-2",
                             201,
                             $"{input.City}:{input.Details.Note}"));
@@ -392,6 +452,7 @@ public sealed class SimpleRestJsonServerProtocolTests
                 {
                     return Task.FromResult(
                         new GetForecastOutput(
+                            new ForecastMetadata(new Dictionary<string, string> { ["source"] = "server" }),
                             "response-3",
                             200,
                             $"{input.Note}:{input.Severity}"));


### PR DESCRIPTION
- Implemented handling for Map shapes in ComplianceCSharpLiterals, including CreateMap and CreateMapEqualityAssertion methods.
- Introduced OfficialProtocolSuiteTests to validate AWS RestJson1 and Alloy SimpleRestJson protocols, ensuring conformance with expected cases.
- Updated RestJsonProtocolComplianceTests and SimpleRestJsonServerProtocolTests to include new metadata and tags structures, enhancing request and response validation.
- Enhanced test cases to assert additional headers and body structures, improving overall protocol compliance coverage.