### PR TITLE
Update README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ the [Smithy reference implementations](https://github.com/smithy-lang/smithy)._
 
 # NSmithy
 
+**Documentation: [thomaslaich.github.io/smithy-dotnet](https://thomaslaich.github.io/smithy-dotnet/)**
+
 NSmithy is a preview-stage .NET toolkit that turns a [Smithy](https://smithy.io)
 model into idiomatic C# at build time. From a single contract you get the same
 model types, typed clients, and server scaffolding that any other Smithy
@@ -17,8 +19,6 @@ in order to make code generation as seemless as possible.
 - **Typed protocol-aware clients**: Supports `alloy#simpleRestJson`, `aws.protocols#restJson1`, `aws.protocols#restXml`, and `smithy.protocols#rpcv2Cbor`.
 - **ASP.NET Core server surfaces**: Implements Smithy services as ASP.NET Core endpoints with minimal boilerplate.
 - **Conformance**: Protocols are tested against the official Smithy/AWS and alloy protocol test suites.
-
-See the [roadmap](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/planning/roadmap.md) for planned features.
 
 ## Quick Start
 
@@ -170,13 +170,3 @@ dotnet build
 
 When the environment is active, `smithy` is resolved from `PATH`. Set `SmithyCliPath` to force a specific executable if needed.
 
-## Documentation
-
-- [Protocol Status](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/protocols/README.md)
-- [Quick Start](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/quick-start.md)
-- [Multi-Protocol Guide](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/multi-protocol.md)
-- [MSBuild Reference](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/msbuild.md)
-- [Architecture](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/architecture/hybrid-codegen.md)
-- [Design Docs](https://github.com/thomaslaich/smithy-dotnet/blob/main/designs/README.md)
-- [Known Limitations](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/known-limitations.md)
-- [Roadmap](https://github.com/thomaslaich/smithy-dotnet/blob/main/docs/planning/roadmap.md)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -71,7 +71,8 @@ Console.WriteLine(response.Message); // Hello, World!`;
   .how-it-works {
     display: grid;
     grid-template-columns: 2fr 3fr;
-    gap: 1.5rem 3rem;
+    column-gap: 3rem;
+    row-gap: 3rem;
     align-items: start;
     margin: 3rem 0;
   }
@@ -91,9 +92,7 @@ Start by describing your API in [Smithy IDL](https://smithy.io) — operations, 
 
 </div>
 <Code code={smithyCode} lang="smithy" />
-</div>
 
-<div class="how-it-works">
 <div>
 
 ### Implement server stubs
@@ -102,9 +101,7 @@ NSmithy generates a typed handler interface — one method per service operation
 
 </div>
 <Code code={serverCode} lang="csharp" />
-</div>
 
-<div class="how-it-works">
 <div>
 
 ### Use the generated client


### PR DESCRIPTION
- Add docs link prominently below the title in README
- Remove dead docs/ links and redundant Documentation section
- Fix roadmap link to point to Starlight site
- Align landing page how-it-works steps in a single shared grid
  so text and code columns line up across all three rows
