### PR TITLE
Fix broken docs links and bump version to preview.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The fastest way to try NSmithy is with the [smithy-dotnet-minimal-pixi](https://
 
    ```xml
    <ItemGroup>
-     <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.5" />
-     <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.5" />
-     <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.5" />
-     <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.5" />
-     <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.5" PrivateAssets="all" />
+     <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.6" />
+     <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.6" />
+     <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.6" />
+     <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.6" />
+     <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.6" PrivateAssets="all" />
    </ItemGroup>
    ```
 
@@ -88,7 +88,7 @@ The fastest way to try NSmithy is with the [smithy-dotnet-minimal-pixi](https://
      "maven": {
        "dependencies": [
          "com.disneystreaming.alloy:alloy-core:0.3.38",
-         "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.5"
+         "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.6"
        ]
      },
      "plugins": {

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,8 +18,8 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- package version: `0.1.0-preview.5`
-- release tag: `v0.1.0-preview.5`
+- package version: `0.1.0-preview.6`
+- release tag: `v0.1.0-preview.6`
 
 ## GitHub Release Flow
 

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -16,7 +16,7 @@ NSmithy keeps a hybrid boundary:
 - NSmithy reads the Smithy build output and performs C# and `.proto`
   generation inside the .NET build.
 
-The rationale is documented in [Hybrid Codegen Architecture](../architecture/hybrid-codegen/).
+The rationale is documented in [Hybrid Codegen Architecture](../design/codegen-architecture/).
 
 The generator is implemented as a Smithy Java plugin, invoked through the
 existing MSBuild and Smithy CLI flow.

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -4,7 +4,7 @@ description: Get up and running with NSmithy.
 ---
 
 This guide assumes the Smithy CLI and JDK are already available in your build
-environment. If not, see [Environment Setup](./environment/) first.
+environment. If not, see [Environment Setup](/smithy-dotnet/getting-started/environment/) first.
 
 ## Configure The Project
 
@@ -14,24 +14,24 @@ and servers — remove the server packages if you only need generated clients.
 ```xml
 <ItemGroup>
   <!-- code generation (build-time only) -->
-  <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.5" PrivateAssets="all" />
+  <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.6" PrivateAssets="all" />
 
   <!-- core runtime (always required) -->
-  <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.5" />
+  <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.6" />
 
   <!-- server runtime (only needed for generated ASP.NET Core servers) -->
   <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.5" />
+  <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.6" />
 </ItemGroup>
 ```
 
 NSmithy.MSBuild picks up the `smithy-build.json` next to the `.csproj`
 automatically — no additional MSBuild properties are needed for basic use.
-See the [MSBuild reference](../reference/msbuild/) for the full property list.
+See the [MSBuild reference](/smithy-dotnet/reference/msbuild/) for the full property list.
 
 ## Add A Model
 
@@ -44,7 +44,7 @@ Add a `smithy-build.json` next to your `.csproj`:
   "maven": {
     "dependencies": [
       "com.disneystreaming.alloy:alloy-core:0.3.38",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.5"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.6"
     ]
   },
   "plugins": {
@@ -133,6 +133,6 @@ internal sealed class HelloHandler : IHelloServiceHandler
 ## Next Steps
 
 - [Minimal pixi example](https://github.com/thomaslaich/smithy-dotnet-minimal-pixi) — a standalone repo with everything wired up
-- [MSBuild Reference](../reference/msbuild/) — all MSBuild properties and items for `NSmithy.MSBuild`
-- [Multi-Protocol](../guides/multi-protocol/) — expose one service over both HTTP and gRPC
-- [Protocol Status](../protocols/) — what protocols are supported and at what stage
+- [MSBuild Reference](/smithy-dotnet/reference/msbuild/) — all MSBuild properties and items for `NSmithy.MSBuild`
+- [Multi-Protocol](/smithy-dotnet/guides/multi-protocol/) — expose one service over both HTTP and gRPC
+- [Protocol Status](/smithy-dotnet/protocols/) — what protocols are supported and at what stage

--- a/website/src/content/docs/guides/cbor-xml.md
+++ b/website/src/content/docs/guides/cbor-xml.md
@@ -55,7 +55,7 @@ to a fixed `POST /service/{Service}/operation/{Operation}` path.
 Add `NSmithy.Codecs.Cbor` to your project:
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.5" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.6" />
 ```
 
 Use the generated client the same way as any other NSmithy client:
@@ -126,7 +126,7 @@ name is used as-is.
 Add `NSmithy.Codecs.Xml` to your project:
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.5" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.6" />
 ```
 
 ```csharp
@@ -144,5 +144,5 @@ Console.WriteLine(response.Message);
 
 ## Related
 
-- [Protocol Status](../protocols/) — current coverage and what "early preview" means
-- [Conformance Tests](../protocols/conformance/) — how protocol correctness is verified
+- [Protocol Status](/smithy-dotnet/protocols/) — current coverage and what "early preview" means
+- [Conformance Tests](/smithy-dotnet/protocols/conformance/) — how protocol correctness is verified

--- a/website/src/content/docs/guides/grpc.md
+++ b/website/src/content/docs/guides/grpc.md
@@ -9,7 +9,7 @@ NSmithy can generate gRPC surfaces from a Smithy model annotated with
 those stubs with a typed adapter that matches the same handler interface used by
 the HTTP surface.
 
-This is experimental in the current preview — see [Protocol Status](../protocols/)
+This is experimental in the current preview — see [Protocol Status](/smithy-dotnet/protocols/)
 for the current maturity level.
 
 ## Model
@@ -61,7 +61,7 @@ No extra plugin configuration is needed beyond referencing `alloy-core`:
   "maven": {
     "dependencies": [
       "com.disneystreaming.alloy:alloy-core:0.3.38",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.5"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.6"
     ]
   },
   "plugins": {
@@ -80,14 +80,14 @@ standard NSmithy packages:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.5" PrivateAssets="all" />
-  <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.5" />
+  <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.6" PrivateAssets="all" />
+  <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.6" />
   <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.5" />
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.5" />
+  <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.6" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.6" />
 
   <!-- gRPC -->
   <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
@@ -146,5 +146,5 @@ Console.WriteLine(response.Message); // Hello, world!
 
 ## Related
 
-- [Multi-Protocol](./multi-protocol/) — serve both HTTP and gRPC from one handler
-- [Protocol Status](../protocols/) — current gRPC maturity level
+- [Multi-Protocol](/smithy-dotnet/guides/multi-protocol/) — serve both HTTP and gRPC from one handler
+- [Protocol Status](/smithy-dotnet/protocols/) — current gRPC maturity level

--- a/website/src/content/docs/guides/simple-rest-json.md
+++ b/website/src/content/docs/guides/simple-rest-json.md
@@ -137,5 +137,5 @@ populated from the `x-request-id` response header, not the JSON body.
 
 ## Related
 
-- [Multi-Protocol](./multi-protocol/) — serve the same handler over HTTP and gRPC simultaneously
-- [Protocol Status](../protocols/) — current coverage and conformance status
+- [Multi-Protocol](/smithy-dotnet/guides/multi-protocol/) — serve the same handler over HTTP and gRPC simultaneously
+- [Protocol Status](/smithy-dotnet/protocols/) — current coverage and conformance status

--- a/website/src/content/docs/protocols/index.md
+++ b/website/src/content/docs/protocols/index.md
@@ -46,7 +46,7 @@ These protocols are not current NSmithy targets:
 ## Related Docs
 
 - [Known Limitations](../reference/known-limitations/)
-- [Multi-Protocol Guide](../multi-protocol/)
-- [Architecture](../architecture/hybrid-codegen/)
+- [Multi-Protocol Guide](../guides/multi-protocol/)
+- [Architecture](../design/codegen-architecture/)
 - [Conformance Matrix](./conformance/)
 - [Roadmap](../contributing/roadmap/)


### PR DESCRIPTION
- Convert all relative internal links to absolute /smithy-dotnet/... paths
  (relative links resolve incorrectly in the browser against the URL path)
- Fix broken links in protocols/index.md and contributing/roadmap.md
  that pointed to the old architecture/ and multi-protocol/ locations
- Bump all NSmithy package and codegen references from 0.1.0-preview.5
  to 0.1.0-preview.6 in docs and README
