### PR TITLE
docs: add SigV4 auth and generator split to roadmap

### DIFF
--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -69,6 +69,35 @@ reflection over ASP.NET Core endpoints.
 - Expand test coverage before broadening feature claims.
 - Clarify the model constraints required by the current generated path.
 
+### 7. Split the C# and `.proto` code generators
+
+`ProtoGenerator` currently lives inside `smithy-csharp-codegen` alongside the
+C# generators. As the gRPC path matures it should move into its own module
+(`smithy-proto-codegen` or similar) so that:
+
+- The C# generator has no dependency on proto concerns.
+- The `.proto` generator can evolve, be versioned, and be distributed
+  independently.
+- Consumers who only need C# output do not pull in proto generation logic.
+
+### 8. AWS authentication — SigV4 signing
+
+Real AWS services require [SigV4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+request signing via the `@aws.auth#sigv4` trait. Currently, generated clients
+send unsigned requests and cannot authenticate against AWS endpoints.
+
+This work involves:
+
+- Recognising `@aws.auth#sigv4` (and related auth traits) during codegen.
+- Providing a signing middleware or hook in `NSmithy.Client` so credentials can
+  be injected into the request pipeline.
+- Defining a credential-provider abstraction that fits the existing
+  `SmithyClientOptions` / `ISmithyClientMiddleware` model.
+
+Until this is in place, `aws.protocols#restJson1` clients work correctly for
+protocol-level correctness (conformance tests pass) but cannot call real AWS
+services.
+
 ## Later Work
 
 These are plausible future areas, but they are not the current focus:


### PR DESCRIPTION
## Summary

- Adds roadmap item 7: split `ProtoGenerator` out of `smithy-csharp-codegen` into its own module (`smithy-proto-codegen` or similar), so C# and proto concerns can evolve independently
- Adds roadmap item 8: SigV4 signing support, explaining that `aws.protocols#restJson1` clients currently send unsigned requests and cannot call real AWS services

## Context

The conformance tests for RestJson1 pass at 98.53%, but those only cover protocol-level HTTP binding correctness — none of them exercise actual SigV4 signing. Without `@aws.auth#sigv4` support, generated clients won't work against real AWS endpoints.
