### PR TITLE
feat: split examples into simpleRestJson (pizza) and restJson1 (weather), fix codegen bugs

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpClientCodegenPlugin.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpClientCodegenPlugin.java
@@ -2,6 +2,10 @@ package io.github.thomaslaich.nsmithy.csharp.codegen;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.integrations.CSharpIntegration;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.codegen.core.directed.CodegenDirector;
@@ -9,6 +13,8 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
 public final class CSharpClientCodegenPlugin implements SmithyBuildPlugin {
+
+  private static final Logger LOGGER = Logger.getLogger(CSharpClientCodegenPlugin.class.getName());
 
   @Override
   public String getName() {
@@ -31,5 +37,36 @@ public final class CSharpClientCodegenPlugin implements SmithyBuildPlugin {
     runner.performDefaultCodegenTransforms();
     runner.createDedicatedInputsAndOutputs();
     runner.run();
+
+    formatGeneratedCode(context.getFileManifest().getBaseDir());
+  }
+
+  private static final String NULL_DEVICE =
+      System.getProperty("os.name", "").toLowerCase().contains("win") ? "NUL" : "/dev/null";
+
+  private static void formatGeneratedCode(Path outputDir) {
+    String dir = outputDir.toAbsolutePath().toString();
+    for (List<String> cmd :
+        List.of(
+            List.of(
+                "csharpier", "format", "--include-generated", "--ignore-path", NULL_DEVICE, dir),
+            List.of(
+                "dotnet",
+                "csharpier",
+                "format",
+                "--include-generated",
+                "--ignore-path",
+                NULL_DEVICE,
+                dir))) {
+      try {
+        int exit = new ProcessBuilder(cmd).redirectErrorStream(true).inheritIO().start().waitFor();
+        if (exit == 0) return;
+        LOGGER.fine(cmd + " exited with code " + exit + " — trying next");
+      } catch (IOException | InterruptedException e) {
+        LOGGER.fine(cmd + " not available: " + e.getMessage());
+        if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+      }
+    }
+    LOGGER.fine("csharpier not found — generated files left unformatted");
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -666,10 +666,31 @@ public final class ClientGenerator implements Runnable {
           }
           // fallback: first error. Wrap in an explicit block so the inner `var errorBody`
           // doesn't collide with the per-status branches above (CS0136).
+          // Guard against empty bodies: if we have nothing to deserialize we cannot
+          // recognise any error, so return null and let InvokeAsync throw a generic
+          // SmithyClientException instead of crashing with MissingMethodException.
           ShapeId fallback = errorIds.get(0);
           StructureShape err = model.expectShape(fallback, StructureShape.class);
+          boolean fallbackHasBody =
+              !ProtocolSupport.useDocumentBindings(kind) && !responseBodyMembers(err).isEmpty();
           writer.write("");
-          writer.openBlock("{", "}", () -> writeErrorReturn(sp, err));
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                if (fallbackHasBody) {
+                  writer.write("if (response.Content.Length == 0)");
+                  writer.openBlock(
+                      "{",
+                      "}",
+                      () ->
+                          writer.write(
+                              "return"
+                                  + " System.Threading.Tasks.ValueTask.FromResult<System.Exception?>(null);"));
+                  writer.write("");
+                }
+                writeErrorReturn(sp, err);
+              });
         });
     writer.write("");
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -643,8 +643,9 @@ public final class ServerGenerator implements Runnable {
             if (ShapeSupport.isHttpHeader(m)) {
               String name = m.expectTrait(HttpHeaderTrait.class).getValue();
               writer.write(
-                  "SmithyAspNetCoreProtocol.AddResponseHeader(httpContext, $L, output.$L);",
+                  "SmithyAspNetCoreProtocol.AddResponseHeader(httpContext, $L, $L, output.$L);",
                   CSharpNaming.formatString(name),
+                  SchemaGenerator.memberSchemaExpr(context, m),
                   CSharpNaming.propertyName(m.getMemberName()));
             }
           }
@@ -666,10 +667,7 @@ public final class ServerGenerator implements Runnable {
             writePayloadResponseWriter(payload.get());
             return;
           }
-          List<MemberShape> bodyMembers =
-              ShapeSupport.sortedMembers(output).stream()
-                  .filter(m -> ShapeSupport.isHttpBody(m) && !ShapeSupport.isHttpResponseCode(m))
-                  .collect(Collectors.toList());
+          List<MemberShape> bodyMembers = ClientGenerator.responseBodyMembers(output);
           if (bodyMembers.isEmpty()) return;
           writer.openBlock(
               "var responseBody = new $L(",

--- a/examples/rest-json1/.envrc
+++ b/examples/rest-json1/.envrc
@@ -1,0 +1,2 @@
+watch_file pixi.lock
+eval "$(pixi shell-hook)"

--- a/examples/rest-json1/NuGet.config
+++ b/examples/rest-json1/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="smithy-net-local" value="../../artifacts/packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/examples/rest-json1/README.md
+++ b/examples/rest-json1/README.md
@@ -1,0 +1,48 @@
+# NSmithy restJson1 Example
+
+A Weather service built with `aws.protocols#restJson1`. The model is adapted from
+the [Smithy quickstart](https://smithy.io/2.0/quickstart.html) and demonstrates
+resources, pagination, errors, and HTTP binding traits using the AWS REST JSON protocol.
+
+- `contracts`: the Smithy model, packaged as a contracts project.
+- `server`: generated ASP.NET Core endpoints with a handwritten `IWeatherServiceHandler` implementation that supports real server-side pagination.
+- `client`: generated typed client that pages through all cities using the `nextToken` continuation token.
+
+The server and client reference the contracts project directly. No
+`smithy-build.json` is needed — NSmithy synthesizes one from the model sources
+and Maven dependencies declared in the contracts project.
+
+## Run
+
+From the repository root, build and pack local packages:
+
+```bash
+just build
+just pack
+just refresh-examples
+```
+
+Start the server:
+
+```bash
+cd examples/rest-json1
+pixi shell  # not needed when using direnv
+dotnet run --project server --urls http://localhost:5000
+```
+
+In another shell, run the client:
+
+```bash
+cd examples/rest-json1
+dotnet run --project client -- http://localhost:5000
+```
+
+Or call the server directly:
+
+```bash
+curl -i http://localhost:5000/current-time
+curl -i 'http://localhost:5000/cities?pageSize=3'
+curl -i 'http://localhost:5000/cities?pageSize=3&nextToken=CHI'
+curl -i http://localhost:5000/cities/SEA
+curl -i http://localhost:5000/cities/SEA/forecast
+```

--- a/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
+++ b/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <SmithyService>alloy.test#PizzaAdminService</SmithyService>
-    <SmithyGeneratedNamespaces>alloy.test</SmithyGeneratedNamespaces>
+    <SmithyService>example.weather#Weather</SmithyService>
+    <SmithyGeneratedNamespaces>example.weather</SmithyGeneratedNamespaces>
     <SmithyGenerateServer>false</SmithyGenerateServer>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
@@ -15,6 +15,6 @@
     <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-SNAPSHOT" />
-    <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
+    <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/client/Program.cs
+++ b/examples/rest-json1/client/Program.cs
@@ -1,0 +1,33 @@
+using Example.Weather;
+using NSmithy.Client;
+
+var endpoint = args.Length > 0 ? args[0] : "http://localhost:5000";
+
+var client = new WeatherClient(
+    new HttpClient(),
+    new SmithyClientOptions { Endpoint = new Uri(endpoint) }
+);
+
+var time = await client.GetCurrentTimeAsync(new GetCurrentTimeInput());
+Console.WriteLine($"Current time: {time.Time:u}");
+
+// Paginate through all cities, 3 per page
+Console.WriteLine("All cities (paginated, page size 3):");
+string? nextToken = null;
+var page = 1;
+do
+{
+    var result = await client.ListCitiesAsync(
+        new ListCitiesInput(nextToken: nextToken, pageSize: 3)
+    );
+    Console.WriteLine($"  Page {page++}:");
+    foreach (var city in result.Items.Values)
+        Console.WriteLine($"    {city.CityId}: {city.Name}");
+    nextToken = result.NextToken;
+} while (nextToken is not null);
+
+var seattle = await client.GetCityAsync(new GetCityInput("SEA"));
+Console.WriteLine($"Seattle: ({seattle.Coordinates.Latitude}, {seattle.Coordinates.Longitude})");
+
+var forecast = await client.GetForecastAsync(new GetForecastInput("SEA"));
+Console.WriteLine($"Forecast for SEA: {forecast.ChanceOfRain:P0} chance of rain");

--- a/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
+++ b/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionSuffix>SNAPSHOT</VersionSuffix>
+    <SmithyPublish>true</SmithyPublish>
+    <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
+    <SmithyMavenArtifactId>rest-json1</SmithyMavenArtifactId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT" />
+    <SmithyMavenDependency Include="software.amazon.smithy:smithy-aws-traits:1.68.0" />
+  </ItemGroup>
+</Project>

--- a/examples/rest-json1/contracts/model/weather.smithy
+++ b/examples/rest-json1/contracts/model/weather.smithy
@@ -2,10 +2,10 @@ $version: "2"
 
 namespace example.weather
 
-use alloy#simpleRestJson
+use aws.protocols#restJson1
 
 /// Provides weather forecasts.
-@simpleRestJson
+@restJson1
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
     version: "2006-03-01"

--- a/examples/rest-json1/pixi.lock
+++ b/examples/rest-json1/pixi.lock
@@ -1,0 +1,43 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smithy-1.71.0-hc364b38_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 47759
+  timestamp: 1774072956767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+  sha256: f6f06243c1a35b6590f06be386bd5cefc5b1773b985a61b7917b93dab4cf18ec
+  md5: a4024e03865a7411c1028eac83d1956c
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  size: 199165105
+  timestamp: 1771443790144
+- conda: https://conda.anaconda.org/conda-forge/noarch/smithy-1.71.0-hc364b38_0.conda
+  sha256: d7c1bb6b580cd0b323037b74faf0a957d7b49744d493c24ebc9ef55ac8ac2db1
+  md5: 9c293c98ba039252acb2af2c46292ff4
+  depends:
+  - openjdk
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8462348
+  timestamp: 1779220023511

--- a/examples/rest-json1/pixi.toml
+++ b/examples/rest-json1/pixi.toml
@@ -1,0 +1,12 @@
+[workspace]
+authors = ["Thomas Laich <thomaslaich@gmail.com>"]
+channels = ["conda-forge"]
+name = "rest-json1"
+platforms = ["osx-arm64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+openjdk = ">=25.0.2,<26"
+smithy = ">=1.70.0,<2"

--- a/examples/rest-json1/rest-json1.slnx
+++ b/examples/rest-json1/rest-json1.slnx
@@ -1,0 +1,11 @@
+<Solution>
+  <Folder Name="/contracts/">
+    <Project Path="contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
+  </Folder>
+  <Folder Name="/client/">
+    <Project Path="client/NSmithy.Examples.RestJson1.Client.csproj" />
+  </Folder>
+  <Folder Name="/server/">
+    <Project Path="server/NSmithy.Examples.RestJson1.Server.csproj" />
+  </Folder>
+</Solution>

--- a/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
+++ b/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <SmithyService>alloy.test#PizzaAdminService</SmithyService>
-    <SmithyGeneratedNamespaces>alloy.test</SmithyGeneratedNamespaces>
+    <SmithyService>example.weather#Weather</SmithyService>
+    <SmithyGeneratedNamespaces>example.weather</SmithyGeneratedNamespaces>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
   </PropertyGroup>
@@ -12,6 +12,6 @@
   <ItemGroup>
     <PackageReference Include="NSmithy.Server" Version="0.1.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-SNAPSHOT" />
-    <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
+    <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/server/Program.cs
+++ b/examples/rest-json1/server/Program.cs
@@ -1,0 +1,84 @@
+using Example.Weather;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddWeatherServiceHandler<WeatherHandler>();
+
+var app = builder.Build();
+app.MapWeatherServiceHttp();
+app.Run();
+
+internal sealed class WeatherHandler : IWeatherServiceHandler
+{
+    private static readonly List<(
+        string CityId,
+        string Name,
+        float Latitude,
+        float Longitude
+    )> Cities =
+    [
+        ("SEA", "Seattle", 47.6f, -122.3f),
+        ("NYC", "New York", 40.7f, -74.0f),
+        ("LAX", "Los Angeles", 34.1f, -118.2f),
+        ("CHI", "Chicago", 41.9f, -87.6f),
+        ("HOU", "Houston", 29.8f, -95.4f),
+        ("PHX", "Phoenix", 33.4f, -112.1f),
+        ("PHL", "Philadelphia", 39.9f, -75.2f),
+        ("SAN", "San Antonio", 29.4f, -98.5f),
+        ("SDA", "San Diego", 32.7f, -117.2f),
+        ("DAL", "Dallas", 32.8f, -96.8f),
+    ];
+
+    public Task<GetCurrentTimeOutput> GetCurrentTimeAsync(
+        GetCurrentTimeInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new GetCurrentTimeOutput(DateTimeOffset.UtcNow));
+
+    public Task<GetCityOutput> GetCityAsync(
+        GetCityInput input,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var city = Cities.FirstOrDefault(c => c.CityId == input.CityId);
+        if (city == default)
+            throw new NoSuchResource(null, "City");
+
+        return Task.FromResult(
+            new GetCityOutput(
+                coordinates: new CityCoordinates(city.Latitude, city.Longitude),
+                name: city.Name
+            )
+        );
+    }
+
+    public Task<ListCitiesOutput> ListCitiesAsync(
+        ListCitiesInput input,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var pageSize = input.PageSize ?? 3;
+        var startIndex = 0;
+
+        if (input.NextToken is { } token)
+        {
+            var idx = Cities.FindIndex(c => c.CityId == token);
+            startIndex = idx < 0 ? 0 : idx + 1;
+        }
+
+        var page = Cities.Skip(startIndex).Take(pageSize).ToList();
+        var nextToken = startIndex + page.Count < Cities.Count ? page.Last().CityId : null;
+
+        return Task.FromResult(
+            new ListCitiesOutput(
+                items: new CitySummaries(
+                    page.Select(c => new CitySummary(c.CityId, c.Name)).ToList()
+                ),
+                nextToken: nextToken
+            )
+        );
+    }
+
+    public Task<GetForecastOutput> GetForecastAsync(
+        GetForecastInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new GetForecastOutput(chanceOfRain: 0.4f));
+}

--- a/examples/simple-rest-json/README.md
+++ b/examples/simple-rest-json/README.md
@@ -1,11 +1,11 @@
 # NSmithy simpleRestJson Example
 
-A Weather service built with `alloy#simpleRestJson`. The model is adapted from
-the [Smithy quickstart](https://smithy.io/2.0/quickstart.html) and demonstrates
-resources, pagination, errors, and HTTP binding traits.
+A Pizza Admin service built with `alloy#simpleRestJson`. The model is adapted from the
+[Alloy protocol tests](https://github.com/disneystreaming/alloy) and demonstrates
+unions, enums, maps, errors, HTTP header binding, and payload binding.
 
 - `contracts`: the Smithy model, packaged as a contracts project.
-- `server`: generated ASP.NET Core endpoints with a handwritten `IWeatherServiceHandler` implementation.
+- `server`: generated ASP.NET Core endpoints with a handwritten `IPizzaAdminServiceHandler` implementation.
 - `client`: generated typed client that calls the server.
 
 The server and client reference the contracts project directly. No
@@ -40,8 +40,30 @@ dotnet run --project client -- http://localhost:5000
 Or call the server directly:
 
 ```bash
-curl -i http://localhost:5000/current-time
-curl -i http://localhost:5000/cities
-curl -i http://localhost:5000/cities/SEA
-curl -i http://localhost:5000/cities/SEA/forecast
+curl -i http://localhost:5000/health
+curl -i http://localhost:5000/version
+curl -i http://localhost:5000/restaurant/napoli/menu
+curl -i -X POST http://localhost:5000/restaurant/napoli/menu/item \
+  -H 'Content-Type: application/json' \
+  -d '{"food":{"pizza":{"name":"Quattro Formaggi","base":"T","toppings":["CHEESE"]}},"price":11.0}'
 ```
+
+The `/openUnions` endpoint round-trips an `OpenUnionsPayload` union. There are two variants:
+
+**Tagged union** — the variant name is the key, and its value is the payload:
+
+```bash
+curl -i -X PUT http://localhost:5000/openUnions \
+  -H 'Content-Type: application/json' \
+  -d '{"tagged":{"str":"hello"}}'
+```
+
+**Discriminated union** — the discriminator field (`key`) is inlined into the object alongside the payload fields:
+
+```bash
+curl -i -X PUT http://localhost:5000/openUnions \
+  -H 'Content-Type: application/json' \
+  -d '{"discriminated":{"key":"smol","content":"hello"}}'
+```
+
+Both return the body echoed back with `200 OK`.

--- a/examples/simple-rest-json/client/Program.cs
+++ b/examples/simple-rest-json/client/Program.cs
@@ -1,23 +1,42 @@
-using Example.Weather;
+using Alloy.Test;
 using NSmithy.Client;
 
 var endpoint = args.Length > 0 ? args[0] : "http://localhost:5000";
 
-var client = new WeatherClient(
+var client = new PizzaAdminServiceClient(
     new HttpClient(),
     new SmithyClientOptions { Endpoint = new Uri(endpoint) }
 );
 
-var time = await client.GetCurrentTimeAsync(new GetCurrentTimeInput());
-Console.WriteLine($"Current time: {time.Time}");
+var health = await client.HealthAsync(new HealthInput());
+Console.WriteLine($"Health: {health.Status}");
 
-var cities = await client.ListCitiesAsync(new ListCitiesInput(pageSize: 10));
-Console.WriteLine($"Cities ({cities.Items.Values.Count}):");
-foreach (var c in cities.Items.Values)
-    Console.WriteLine($"  {c.CityId}: {c.Name}");
+var version = await client.VersionAsync(new VersionInput());
+Console.WriteLine($"Version: {version.Version}");
 
-var seattle = await client.GetCityAsync(new GetCityInput("SEA"));
-Console.WriteLine($"Seattle: ({seattle.Coordinates.Latitude}, {seattle.Coordinates.Longitude})");
+var menu = await client.GetMenuAsync(new GetMenuInput("napoli"));
+Console.WriteLine($"Menu for napoli ({menu.Menu.Values.Count} items):");
+foreach (var (name, item) in menu.Menu.Values)
+    Console.WriteLine($"  {name}: ${item.Price:F2}");
 
-var forecast = await client.GetForecastAsync(new GetForecastInput("SEA"));
-Console.WriteLine($"Forecast for SEA: {forecast.ChanceOfRain:P0} chance of rain");
+var added = await client.AddMenuItemAsync(
+    new AddMenuItemInput(
+        new MenuItem(
+            Food.FromPizza(
+                new Pizza(
+                    PizzaBase.TOMATO,
+                    "Hawaii",
+                    new Ingredients([Ingredient.TOMATO, Ingredient.CHEESE, Ingredient.PINEAPPLE])
+                )
+            ),
+            12.50f
+        ),
+        "napoli"
+    )
+);
+Console.WriteLine($"Added item: {added.ItemId} at {added.Added:u}");
+
+menu = await client.GetMenuAsync(new GetMenuInput("napoli"));
+Console.WriteLine($"Updated menu ({menu.Menu.Values.Count} items):");
+foreach (var (name, item) in menu.Menu.Values)
+    Console.WriteLine($"  {name}: ${item.Price:F2}");

--- a/examples/simple-rest-json/contracts/model/pizza.smithy
+++ b/examples/simple-rest-json/contracts/model/pizza.smithy
@@ -1,0 +1,399 @@
+$version: "2"
+
+namespace alloy.test
+
+use alloy#simpleRestJson
+use alloy#jsonUnknown
+use alloy#discriminated
+use alloy#preserveKeyOrder
+
+@simpleRestJson
+service PizzaAdminService {
+    version: "1.0.0",
+    errors: [GenericServerError, GenericClientError],
+    operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, HttpPayloadWithDefault, HttpPayloadRequiredWithDefault, OpenUnions, Primitives, PreserveOrder]
+}
+
+@http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
+operation AddMenuItem {
+    input: AddMenuItemRequest,
+    errors: [PriceError],
+    output: AddMenuItemResult
+}
+
+@readonly
+@http(method: "GET", uri: "/restaurant/{restaurant}/menu", code: 200)
+operation GetMenu {
+    input: GetMenuRequest,
+    errors: [NotFoundError, FallbackError],
+    output: GetMenuResult
+}
+
+@http(method: "POST", uri: "/headers/", code: 200)
+operation HeaderEndpoint {
+    input: HeaderEndpointData,
+    output: HeaderEndpointData
+}
+
+@http(method: "POST", uri: "/roundTrip/{label}", code: 200)
+operation RoundTrip {
+    input: RoundTripData,
+    output: RoundTripData
+}
+
+@readonly
+@http(method: "GET", uri: "/get-enum/{aa}", code: 200)
+operation GetEnum {
+    input: GetEnumInput,
+    output: GetEnumOutput,
+    errors: [ UnknownServerError ]
+}
+
+@readonly
+@http(method: "GET", uri: "/custom-code/{code}", code: 200)
+operation CustomCode {
+    input: CustomCodeInput,
+    output: CustomCodeOutput,
+    errors: [ UnknownServerError ]
+}
+
+@readonly
+@http(method: "GET", uri: "/version", code: 200)
+operation Version {
+    output: VersionOutput
+}
+
+
+structure RoundTripData {
+    @httpLabel
+    @required
+    label: String,
+    @httpHeader("HEADER")
+    header: String,
+    @httpQuery("query")
+    query: String,
+    body: String
+}
+
+structure HeaderEndpointData {
+    @httpHeader("X-UPPERCASE-HEADER")
+    uppercaseHeader: String,
+    @httpHeader("X-Capitalized-Header")
+    capitalizedHeader: String,
+    @httpHeader("x-lowercase-header")
+    lowercaseHeader: String,
+    @httpHeader("x-MiXeD-hEaDEr")
+    mixedHeader: String,
+}
+
+structure AddMenuItemResult {
+    @httpPayload
+    @required
+    itemId: String,
+    @timestampFormat("epoch-seconds")
+    @httpHeader("X-ADDED-AT")
+    @required
+    added: Timestamp
+}
+
+
+structure VersionOutput {
+    @httpPayload
+    @required
+    version: String
+}
+
+@error("client")
+structure PriceError {
+    @required
+    message: String,
+    @required
+    @httpHeader("X-CODE")
+    code: Integer
+}
+
+structure GetMenuRequest {
+    @httpLabel
+    @required
+    restaurant: String
+}
+
+structure GetMenuResult {
+    @required
+    @httpPayload
+    menu: Menu
+}
+
+@error("client")
+@httpError(404)
+structure NotFoundError {
+    @required
+    name: String
+}
+
+@error("client")
+structure FallbackError {
+    @required
+    error: String
+}
+
+map Menu {
+    key: String,
+    value: MenuItem
+}
+
+structure AddMenuItemRequest {
+    @httpLabel
+    @required
+    restaurant: String,
+    @httpPayload
+    @required
+    menuItem: MenuItem
+}
+
+structure MenuItem {
+    @required
+    food: Food,
+    @required
+    price: Float
+}
+
+union Food {
+    pizza: Pizza,
+    salad: Salad
+}
+
+structure Salad {
+    @required
+    name: String,
+    @required
+    ingredients: Ingredients
+}
+
+structure Pizza {
+    @required
+    name: String,
+    @required
+    base: PizzaBase,
+    @required
+    toppings: Ingredients
+}
+
+enum PizzaBase {
+    CREAM = "C"
+    TOMATO = "T"
+}
+
+enum Ingredient {
+    TOMATO = "TOMATO"
+    CHEESE = "CHEESE"
+    PINEAPPLE = "PINEAPPLE"
+    BACON = "BACON"
+    CHICKEN = "CHICKEN"
+    SALAD = "Salad"
+    MUSHROOM = "MUSHROOM"
+    OLIVES = "OLIVES"
+    ONIONS = "ONIONS"
+    PEPPERONI = "PEPPERONI"
+    PEPPERS = "PEPPERS"
+}
+
+list Ingredients {
+    member: Ingredient
+}
+
+@error("server")
+@httpError(502)
+structure GenericServerError {
+    @required
+    message: String
+}
+
+@error("client")
+@httpError(418)
+structure GenericClientError {
+    @required
+    message: String
+}
+
+@readonly
+@http(method: "GET", uri: "/health", code: 200)
+operation Health {
+    input: HealthRequest,
+    output: HealthResponse,
+    errors: [ UnknownServerError ]
+}
+
+structure HealthRequest {
+    @httpQuery("query")
+    @length(min: 0, max: 5)
+    query: String
+}
+
+@freeForm(i: 1, a: 2)
+structure HealthResponse {
+    @required
+    status: String
+}
+
+@error("server")
+@httpError(500)
+structure UnknownServerError {
+    @required
+    errorCode: UnknownServerErrorCode,
+
+    description: String,
+
+    stateHash: String
+}
+
+enum UnknownServerErrorCode {
+    ERROR_CODE = "server.error",
+}
+
+
+@trait
+document freeForm
+
+
+structure GetEnumInput {
+    @required
+    @httpLabel
+    aa: TheEnum
+}
+
+structure GetEnumOutput {
+    result: String
+}
+
+enum TheEnum {
+    V1 = "v1"
+    V2 = "v2"
+}
+
+
+@readonly
+@http(method: "GET", uri: "/get-int-enum/{aa}", code: 200)
+operation GetIntEnum {
+    input := {
+        @required
+        @httpLabel
+        aa: EnumResult
+    }
+    output := {
+        @required
+        result: EnumResult
+    }
+    errors: [ UnknownServerError ]
+}
+
+intEnum EnumResult {
+    FIRST = 1
+    SECOND = 2
+}
+
+structure CustomCodeInput {
+    @httpLabel
+    @required
+    code: Integer
+}
+
+structure CustomCodeOutput {
+    @httpResponseCode
+    code: Integer
+}
+
+@idempotent
+@http(uri: "/httpPayloadWithDefault", method: "PUT")
+operation HttpPayloadWithDefault {
+    input: HttpPayloadWithDefaultInputOutput,
+    output: HttpPayloadWithDefaultInputOutput
+}
+
+structure HttpPayloadWithDefaultInputOutput {
+    @httpPayload
+    @default("default value")
+    body: String,
+}
+
+@idempotent
+@http(uri: "/httpPayloadRequiredWithDefault", method: "PUT")
+operation HttpPayloadRequiredWithDefault {
+    input: HttpPayloadRequiredWithDefaultInputOutput
+    output: HttpPayloadRequiredWithDefaultInputOutput
+}
+
+structure HttpPayloadRequiredWithDefaultInputOutput {
+    @httpPayload
+    @default("default value")
+    @required
+    body: String
+}
+
+@idempotent
+@http(uri: "/openUnions", method: "PUT")
+operation OpenUnions {
+    input := {
+      @required @httpPayload data: OpenUnionsPayload
+    }
+    output := {
+        @required @httpPayload data: OpenUnionsPayload
+    }
+}
+
+union OpenUnionsPayload {
+    tagged: OpenTaggedUnion
+    discriminated: OpenDiscriminatedUnion
+}
+
+union OpenTaggedUnion {
+    str: String
+    @jsonUnknown other: Document
+}
+
+@discriminated("key")
+union OpenDiscriminatedUnion {
+    smol: SmallStruct
+    @jsonUnknown other: Document
+}
+
+structure SmallStruct {
+    @required content: String
+}
+
+@http(uri: "/primitive/encoding", method: "POST", code: 200)
+operation Primitives {
+    input: PrimitiveEncodings
+    output: PrimitiveEncodings
+}
+
+structure PrimitiveEncodings {
+    @required
+    uuid: alloy#UUID
+    @required
+    localDate: alloy#LocalDate
+    @required
+    localTime: alloy#LocalTime
+    @required
+    duration: alloy#Duration
+    @required
+    offsetDateTime: alloy#OffsetDateTime
+}
+
+@preserveKeyOrder
+map MyMap {
+    key: String,
+    value: Integer
+}
+
+@http(uri: "/preserveKeyOrder", method: "POST", code: 200)
+operation PreserveOrder {
+    input: PreserveOrderStruct
+    output: PreserveOrderStruct
+}
+
+structure PreserveOrderStruct {
+    map: MyMap
+    @preserveKeyOrder
+    document: Document
+}

--- a/examples/simple-rest-json/server/Program.cs
+++ b/examples/simple-rest-json/server/Program.cs
@@ -1,56 +1,149 @@
-using Example.Weather;
+using Alloy.Test;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddWeatherServiceHandler<WeatherHandler>();
+builder.Services.AddPizzaAdminServiceHandler<PizzaHandler>();
 
 var app = builder.Build();
-app.MapWeatherServiceHttp();
+app.MapPizzaAdminServiceHttp();
 app.Run();
 
-internal sealed class WeatherHandler : IWeatherServiceHandler
+internal sealed class PizzaHandler : IPizzaAdminServiceHandler
 {
-    public Task<GetCurrentTimeOutput> GetCurrentTimeAsync(
-        GetCurrentTimeInput input,
+    private static readonly Dictionary<string, MenuItem> DefaultMenu = new()
+    {
+        ["margherita"] = new MenuItem(
+            Food.FromPizza(
+                new Pizza(
+                    PizzaBase.TOMATO,
+                    "Margherita",
+                    new Ingredients([Ingredient.TOMATO, Ingredient.CHEESE])
+                )
+            ),
+            8.50f
+        ),
+        ["pepperoni"] = new MenuItem(
+            Food.FromPizza(
+                new Pizza(
+                    PizzaBase.TOMATO,
+                    "Pepperoni",
+                    new Ingredients([Ingredient.TOMATO, Ingredient.CHEESE, Ingredient.PEPPERONI])
+                )
+            ),
+            10.00f
+        ),
+        ["caesar"] = new MenuItem(
+            Food.FromSalad(
+                new Salad(new Ingredients([Ingredient.SALAD, Ingredient.CHEESE]), "Caesar")
+            ),
+            7.00f
+        ),
+    };
+
+    private readonly object _lock = new();
+    private readonly Dictionary<string, Dictionary<string, MenuItem>> _menus = new();
+
+    public Task<AddMenuItemOutput> AddMenuItemAsync(
+        AddMenuItemInput input,
         CancellationToken cancellationToken = default
     )
     {
-        return Task.FromResult(new GetCurrentTimeOutput(DateTimeOffset.UtcNow));
+        lock (_lock)
+        {
+            if (!_menus.TryGetValue(input.Restaurant, out var items))
+                _menus[input.Restaurant] = items = new(DefaultMenu);
+            var itemId = Guid.NewGuid().ToString("N")[..8];
+            items[itemId] = input.MenuItem;
+            return Task.FromResult(new AddMenuItemOutput(DateTimeOffset.UtcNow, itemId));
+        }
     }
 
-    public Task<GetCityOutput> GetCityAsync(
-        GetCityInput input,
+    public Task<GetMenuOutput> GetMenuAsync(
+        GetMenuInput input,
         CancellationToken cancellationToken = default
     )
     {
-        if (input.CityId == "unknown")
-            throw new NoSuchResource(null, "City");
-
-        return Task.FromResult(
-            new GetCityOutput(name: "Seattle", coordinates: new CityCoordinates(47.6f, -122.3f))
-        );
+        lock (_lock)
+        {
+            if (!_menus.TryGetValue(input.Restaurant, out var items))
+                items = DefaultMenu;
+            return Task.FromResult(new GetMenuOutput(new Menu(items)));
+        }
     }
 
-    public Task<ListCitiesOutput> ListCitiesAsync(
-        ListCitiesInput input,
+    public Task<HealthOutput> HealthAsync(
+        HealthInput input,
         CancellationToken cancellationToken = default
-    )
-    {
-        return Task.FromResult(
-            new ListCitiesOutput(
-                new CitySummaries([
-                    new CitySummary("SEA", "Seattle"),
-                    new CitySummary("NYC", "New York"),
-                    new CitySummary("LAX", "Los Angeles"),
-                ])
+    ) => Task.FromResult(new HealthOutput("ok"));
+
+    public Task<VersionOutput> VersionAsync(
+        VersionInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new VersionOutput("1.0.0"));
+
+    public Task<HeaderEndpointOutput> HeaderEndpointAsync(
+        HeaderEndpointInput input,
+        CancellationToken cancellationToken = default
+    ) =>
+        Task.FromResult(
+            new HeaderEndpointOutput(
+                input.CapitalizedHeader,
+                input.LowercaseHeader,
+                input.MixedHeader,
+                input.UppercaseHeader
             )
         );
-    }
 
-    public Task<GetForecastOutput> GetForecastAsync(
-        GetForecastInput input,
+    public Task<RoundTripOutput> RoundTripAsync(
+        RoundTripInput input,
         CancellationToken cancellationToken = default
-    )
-    {
-        return Task.FromResult(new GetForecastOutput(chanceOfRain: 0.4f));
-    }
+    ) => Task.FromResult(new RoundTripOutput(input.Label, input.Body, input.Header, input.Query));
+
+    public Task<GetEnumOutput> GetEnumAsync(
+        GetEnumInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new GetEnumOutput(input.Aa.Value));
+
+    public Task<GetIntEnumOutput> GetIntEnumAsync(
+        GetIntEnumInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new GetIntEnumOutput(input.Aa));
+
+    public Task<CustomCodeOutput> CustomCodeAsync(
+        CustomCodeInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new CustomCodeOutput(input.Code));
+
+    public Task<HttpPayloadWithDefaultOutput> HttpPayloadWithDefaultAsync(
+        HttpPayloadWithDefaultInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new HttpPayloadWithDefaultOutput(input.Body));
+
+    public Task<HttpPayloadRequiredWithDefaultOutput> HttpPayloadRequiredWithDefaultAsync(
+        HttpPayloadRequiredWithDefaultInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new HttpPayloadRequiredWithDefaultOutput(input.Body));
+
+    public Task<OpenUnionsOutput> OpenUnionsAsync(
+        OpenUnionsInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new OpenUnionsOutput(input.Data));
+
+    public Task<PrimitivesOutput> PrimitivesAsync(
+        PrimitivesInput input,
+        CancellationToken cancellationToken = default
+    ) =>
+        Task.FromResult(
+            new PrimitivesOutput(
+                input.Duration,
+                input.LocalDate,
+                input.LocalTime,
+                input.OffsetDateTime,
+                input.Uuid
+            )
+        );
+
+    public Task<PreserveOrderOutput> PreserveOrderAsync(
+        PreserveOrderInput input,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(new PreserveOrderOutput(input.Document, input.Map));
 }

--- a/justfile
+++ b/justfile
@@ -39,6 +39,8 @@ pack:
 refresh-examples:
     dotnet clean examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj --verbosity minimal
     dotnet clean examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj --verbosity minimal
+    dotnet clean examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj --verbosity minimal
+    dotnet clean examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj --verbosity minimal
     dotnet clean examples/aws/client/NSmithy.Examples.Aws.Client.csproj --verbosity minimal
     dotnet clean examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj --verbosity minimal
     dotnet clean examples/grpc/client-rest/NSmithy.Examples.Grpc.ClientRest.csproj --verbosity minimal
@@ -47,6 +49,9 @@ refresh-examples:
     rm -rf examples/simple-rest-json/contracts/obj
     rm -rf examples/simple-rest-json/server/obj
     rm -rf examples/simple-rest-json/client/obj
+    rm -rf examples/rest-json1/contracts/obj
+    rm -rf examples/rest-json1/server/obj
+    rm -rf examples/rest-json1/client/obj
     rm -rf examples/aws/client/obj
     rm -rf examples/grpc/server/obj
     rm -rf examples/grpc/client-rest/obj
@@ -55,6 +60,9 @@ refresh-examples:
     dotnet restore examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj --no-cache --force
     dotnet restore examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj --no-cache --force
     dotnet restore examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj --no-cache --force
+    dotnet restore examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj --no-cache --force
+    dotnet restore examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj --no-cache --force
+    dotnet restore examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj --no-cache --force
     dotnet restore examples/aws/client/NSmithy.Examples.Aws.Client.csproj --no-cache --force
     dotnet restore examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj --no-cache --force
     dotnet restore examples/grpc/client-rest/NSmithy.Examples.Grpc.ClientRest.csproj --no-cache --force

--- a/packages/NSmithy.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
+++ b/packages/NSmithy.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using NSmithy.Codecs.Json;
+using NSmithy.Core;
 using NSmithy.Core.Serde;
 using NSmithy.Protocols.RestJson;
 
@@ -226,6 +227,24 @@ public static class SmithyAspNetCoreProtocol
         }
 
         httpContext.Response.Headers[name] = RestJsonProtocol.FormatHttpValue(value);
+    }
+
+    public static void AddResponseHeader(
+        HttpContext httpContext,
+        string name,
+        Schema schema,
+        object? value
+    )
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (value is null)
+        {
+            return;
+        }
+
+        httpContext.Response.Headers[name] = RestJsonProtocol.FormatHttpValue(schema, value);
     }
 
     public static void AddPrefixedResponseHeaders(

--- a/smithy-dotnet.code-workspace
+++ b/smithy-dotnet.code-workspace
@@ -17,6 +17,10 @@
       "path": "examples/simple-rest-json"
     },
     {
+      "name": "Example: RestJson1",
+      "path": "examples/rest-json1"
+    },
+    {
       "name": "Example: gRPC",
       "path": "examples/grpc"
     },


### PR DESCRIPTION
- Replace weather model in simple-rest-json with the full PizzaAdminService
  (unions, enums, maps, headers, payload binding) using alloy#simpleRestJson
- Add rest-json1 example with the weather service using aws.protocols#restJson1
  and working server-side pagination in ListCities
- Add curl examples for the /openUnions endpoint (tagged and discriminated variants)
- Add rest-json1 workspace folder and refresh-examples entries in justfile

Codegen bug fixes surfaced by the pizza service:
- ServerGenerator: pass Schema to AddResponseHeader so @timestampFormat("epoch-seconds")
  headers are serialized as decimal seconds instead of ISO 8601 (fixes FormatException
  when client parses the X-ADDED-AT response header)
- ServerGenerator: use ClientGenerator.responseBodyMembers() when building the
  *OutputHttpBody constructor call, fixing CS7036 for operations whose output shape
  has non-body HTTP bindings (e.g. RoundTripData with httpLabel/httpQuery members)
- ClientGenerator: guard fallback error deserializer against empty response bodies
  to avoid MissingMethodException from Activator.CreateInstance on types with no
  parameterless constructor
- CSharpClientCodegenPlugin: resolve pre-existing merge conflict; keep the stashed
  version that adds optional csharpier post-formatting of generated files
