### PR TITLE
fix: suppress TraitValue.UnknownMember warnings from alloy-protocol-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 
 # NSmithy
 
-NSmithy is a preview-stage .NET toolkit that turns a [Smithy](https://smithy.io) model into idiomatic C# at build time. From a single contract you get typed clients, server scaffolding, and shared model types — fully integrated into your MSBuild workflow.
-
 **[NSmithy Docs](https://thomaslaich.github.io/smithy-dotnet/)** · **[Design Docs](designs/README.md)** · **[smithy.io](https://smithy.io)**
+
+NSmithy is a preview-stage .NET toolkit that turns a [Smithy](https://smithy.io) model into idiomatic C# at build time. From a single contract you get typed clients, server scaffolding, and shared model types — fully integrated into your MSBuild workflow.
 
 ## Features
 
@@ -50,3 +50,11 @@ The recommended way to work on this repo is with [Nix](https://nixos.org/) (pref
    just docs     # start the documentation dev server
    just ci       # run the full CI pipeline locally
    ```
+
+## Related Projects
+
+- **[Smithy](https://smithy.io)** — the IDL and protocol framework NSmithy is built on.
+- **[smithy4s](https://disneystreaming.github.io/smithy4s/)** — the main inspiration for NSmithy; generates Scala code from Smithy models with similar goals, though with a more ambitious scope (own parser, independent toolchain).
+- **[alloy](https://github.com/disneystreaming/alloy)** — Smithy extensions used by NSmithy for `simpleRestJson` and gRPC protocols.
+- **[smithy-go](https://github.com/smithy-lang/smithy-go)** / **[smithy-typescript](https://github.com/smithy-lang/smithy-typescript)** — official Smithy codegen plugins for Go and TypeScript, which NSmithy draws inspiration from.
+- **[TypeSpec](https://typespec.io)** — Microsoft's alternative API description language with similar goals. Compiles to OpenAPI, JSON Schema, Protobuf, and more; has first-party .NET emitters.

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -151,6 +151,7 @@
     >
     <SmithyGrpcServices Condition="'$(SmithyGrpcServices)' == ''">Both</SmithyGrpcServices>
     <SmithyCliPath Condition="'$(SmithyCliPath)' == ''">smithy</SmithyCliPath>
+    <SmithyExtraArgs Condition="'$(SmithyExtraArgs)' == ''"></SmithyExtraArgs>
     <SmithyGenerateClient Condition="'$(SmithyGenerateClient)' == ''">true</SmithyGenerateClient>
     <SmithyGenerateServer Condition="'$(SmithyGenerateServer)' == ''">true</SmithyGenerateServer>
     <SmithyEmitGeneratedFiles Condition="'$(SmithyEmitGeneratedFiles)' == ''"
@@ -261,7 +262,7 @@
   >
     <MakeDir Directories="$(SmithyBuildOutputPath)" />
     <Exec
-      Command="&quot;$(SmithyCliPath)&quot; build --config &quot;$(SmithyBuildFile)&quot; --output &quot;$(SmithyBuildOutputPath.TrimEnd('/').TrimEnd('\\'))&quot;"
+      Command="&quot;$(SmithyCliPath)&quot; build --config &quot;$(SmithyBuildFile)&quot; --output &quot;$(SmithyBuildOutputPath.TrimEnd('/').TrimEnd('\\'))&quot; $(SmithyExtraArgs)"
       WorkingDirectory="$(MSBuildProjectDirectory)"
     />
     <Touch Files="$(SmithyStampFile)" AlwaysCreate="true" />

--- a/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
+++ b/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
@@ -19,6 +19,12 @@
     <SmithyGenerateServer>false</SmithyGenerateServer>
     <!-- Many alloy protocol-test fixtures emit warnings (unused traits etc.) -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!--
+      alloy-protocol-tests 0.3.38 uses HttpRequestTestCase#code and HttpResponseTestCase#{uri,method}
+      which don't exist in smithy-model 1.68.0. The "Error validating trait" text in the WARNING
+      message body causes MSBuild's Exec task to treat it as a build error, so suppress it here.
+    -->
+    <SmithyExtraArgs>--hide-validators TraitValue.UnknownMember.smithy.test#HttpRequestTestCase.code,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.uri,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.method</SmithyExtraArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
alloy-protocol-tests 0.3.38 uses HttpRequestTestCase#code and
HttpResponseTestCase#{uri,method} which don't exist in smithy-model 1.68.0.
Smithy emits WARNING events whose message body contains "Error validating
trait…", which MSBuild's <Exec> task matches as a build error, failing CI.

- Add SmithyExtraArgs property to NSmithy.MSBuild.targets so individual
  projects can pass extra flags to the smithy CLI
- Use --hide-validators in SimpleRestJson.Conformance.csproj to suppress
  the three specific unknown-member event IDs
