### PR TITLE
chore: bump version from preview.11 to preview.12

### DIFF
--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -11,19 +11,19 @@
 
   <ItemGroup>
     <!--#if (!IsGrpc)-->
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-preview.11" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-preview.12" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.11" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.12" PrivateAssets="all" />
     <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.11" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.12" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +18,6 @@
     <!--#if (IsSimpleRestJson || IsGrpc)-->
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
     <!--#endif-->
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.11" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.12" />
   </ItemGroup>
 </Project>

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.11" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.11" />
+    <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.12" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.11" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.12" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
@@ -36,13 +36,13 @@
   <!--#if (IsRestJson1)-->
   <ItemGroup>
     <SmithyMavenDependency Include="software.amazon.smithy:smithy-aws-traits:1.68.0" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.11" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.12" />
   </ItemGroup>
   <!--#endif-->
   <!--#if (IsSimpleRestJson || IsGrpc)-->
   <ItemGroup>
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.11" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.12" />
   </ItemGroup>
   <!--#endif-->
   <!--#endif-->

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,8 +18,8 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- package version: `0.1.0-preview.11`
-- release tag: `v0.1.0-preview.11`
+- package version: `0.1.0-preview.12`
+- release tag: `v0.1.0-preview.12`
 
 ## GitHub Release Flow
 

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -34,12 +34,12 @@ Replace the generated `.csproj` with:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.11" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.12" />
   </ItemGroup>
 
   <ItemGroup>
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.11" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.12" />
   </ItemGroup>
 </Project>
 ```
@@ -57,7 +57,7 @@ different path. Then add a `ProjectReference` from your server or client project
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.11" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.12" />
   <ProjectReference Include="../MyService.Contracts/MyService.Contracts.csproj" />
 </ItemGroup>
 ```
@@ -93,7 +93,7 @@ dependencies automatically — no `ProjectReference` needed:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.11" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.12" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's built-in static file middleware serves them with zero extra confi
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.11" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.12" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -16,7 +16,7 @@ as XML and decodes XML responses. Status: **Early preview, client-only**.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.11" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.12" />
 ```
 
 ## Modeling

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -16,7 +16,7 @@ are bundled with the Smithy CLI.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.11" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.12" />
 ```
 
 ## Modeling


### PR DESCRIPTION
## Summary
- Replaces all occurrences of `0.1.0-preview.11` with `0.1.0-preview.12` across templates and documentation

## Test plan
- [ ] Verify NuGet packages resolve at the new version after release
