### PR TITLE
fix: fix template CLI args, client Program.cs, add slnx to quick-start

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -66,6 +66,10 @@ in
           "Directory.Packages.props"
           "Directory.Build.props"
         ];
+
+        formatter.csharpier.excludes = [
+          "templates/NSmithy.Templates/content/**"
+        ];
       };
     };
   };

--- a/templates/NSmithy.Templates/content/nsmithy-client/.template.config/dotnetcli.host.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/.template.config/dotnetcli.host.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "Protocol":  { "longName": "protocol" },
+    "Contracts": { "longName": "contracts" }
+  }
+}

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -11,19 +11,19 @@
 
   <ItemGroup>
     <!--#if (!IsGrpc)-->
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-preview.14" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-preview.15" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.14" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.15" PrivateAssets="all" />
     <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->

--- a/templates/NSmithy.Templates/content/nsmithy-client/Program.cs
+++ b/templates/NSmithy.Templates/content/nsmithy-client/Program.cs
@@ -1,27 +1,23 @@
 using Example.Hello;
-//#endif
 //#if (IsGrpc)
 using Grpc.Net.Client;
-//#if (!IsGrpc)
+//#else
 using NSmithy.Client;
-
 //#endif
 
-//#if (!IsGrpc)
-var endpoint = args.Length > 0 ? args[0] : "http://localhost:5000";
-
-var client = new HelloServiceClient(
-    new HttpClient(),
-    new SmithyClientOptions { Endpoint = new Uri(endpoint) }
-);
-
-//#endif
 //#if (IsGrpc)
 var endpoint = args.Length > 0 ? args[0] : "http://localhost:5001";
 
 using var channel = GrpcChannel.ForAddress(endpoint);
 var client = new HelloServiceGrpcClient(channel);
 
+//#else
+var endpoint = args.Length > 0 ? args[0] : "http://localhost:5000";
+
+var client = new HelloServiceClient(
+    new HttpClient(),
+    new SmithyClientOptions { Endpoint = new Uri(endpoint) }
+);
 //#endif
 
 var response = await client.SayHelloAsync(new SayHelloInput("world"));

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/.template.config/dotnetcli.host.json
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/.template.config/dotnetcli.host.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "Protocol": { "longName": "protocol" }
+  }
+}

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.14" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.15" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +18,6 @@
     <!--#if (IsSimpleRestJson || IsGrpc)-->
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
     <!--#endif-->
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.14" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15" />
   </ItemGroup>
 </Project>

--- a/templates/NSmithy.Templates/content/nsmithy-server/.template.config/dotnetcli.host.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "Protocol":   { "longName": "protocol" },
+    "Contracts":  { "longName": "contracts" },
+    "WithDocs":   { "longName": "with-docs" }
+  }
+}

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.14" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.14" />
+    <PackageReference Include="NSmithy.Server" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.15" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.14" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.15" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
@@ -36,13 +36,13 @@
   <!--#if (IsRestJson1)-->
   <ItemGroup>
     <SmithyMavenDependency Include="software.amazon.smithy:smithy-aws-traits:1.68.0" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.14" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15" />
   </ItemGroup>
   <!--#endif-->
   <!--#if (IsSimpleRestJson || IsGrpc)-->
   <ItemGroup>
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.14" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15" />
   </ItemGroup>
   <!--#endif-->
   <!--#endif-->

--- a/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
+++ b/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 //#endif
 //#if (WithDocs)
 using NSmithy.Server.AspNetCore.Docs;
-
 //#endif
 
 var builder = WebApplication.CreateBuilder(args);

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,8 +18,8 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- package version: `0.1.0-preview.12`
-- release tag: `v0.1.0-preview.12`
+- package version: `0.1.0-preview.15`
+- release tag: `v0.1.0-preview.15`
 
 ## GitHub Release Flow
 

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -29,10 +29,12 @@ and client.
 
 ```shell
 mkdir HelloWorld && cd HelloWorld
+dotnet new slnx -n HelloWorld
 # optional: install CSharpier for formatted generated code
 dotnet new tool-manifest
 dotnet tool install csharpier
 dotnet new nsmithy-contracts -n HelloWorld.Contracts
+dotnet sln add HelloWorld.Contracts
 ```
 
 This generates:
@@ -48,6 +50,7 @@ HelloWorld.Contracts/
 
 ```shell
 dotnet new nsmithy-server -n HelloWorld.Server --contracts HelloWorld.Contracts --with-docs
+dotnet sln add HelloWorld.Server
 ```
 
 The `--contracts` flag sets the `ProjectReference` to the contracts project
@@ -75,6 +78,7 @@ See [Endpoint Documentation](/smithy-dotnet/guides/endpoint-documentation/) for 
 
 ```shell
 dotnet new nsmithy-client -n HelloWorld.Client
+dotnet sln add HelloWorld.Client
 ```
 
 The client template defaults to a Maven contracts reference for production use.

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -34,12 +34,12 @@ Replace the generated `.csproj` with:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.12" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.15" />
   </ItemGroup>
 
   <ItemGroup>
     <SmithyMavenDependency Include="com.disneystreaming.alloy:alloy-core:0.3.38" />
-    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.12" />
+    <SmithyMavenDependency Include="io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15" />
   </ItemGroup>
 </Project>
 ```
@@ -57,7 +57,7 @@ different path. Then add a `ProjectReference` from your server or client project
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.12" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.15" />
   <ProjectReference Include="../MyService.Contracts/MyService.Contracts.csproj" />
 </ItemGroup>
 ```
@@ -93,7 +93,7 @@ dependencies automatically — no `ProjectReference` needed:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.12" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.15" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's built-in static file middleware serves them with zero extra confi
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.12" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.15" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -16,7 +16,7 @@ as XML and decodes XML responses. Status: **Early preview, client-only**.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.12" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.15" />
 ```
 
 ## Modeling

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -16,7 +16,7 @@ are bundled with the Smithy CLI.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.12" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.15" />
 ```
 
 ## Modeling


### PR DESCRIPTION
## Summary

- Add `dotnetcli.host.json` to all three templates so parameters are exposed as `--protocol`, `--contracts`, `--with-docs` (kebab-case) rather than the internal PascalCase symbol names which the template engine was rejecting
- Fix `nsmithy-client` `Program.cs`: remove stray `//#endif` and replace broken nested `//#if (!IsGrpc)` with `//#else`, so `using NSmithy.Client` is correctly emitted for non-gRPC templates (previously generated an almost-empty file)
- Add `dotnet new slnx` and `dotnet sln add` steps to the quick-start guide

## Test plan

- [ ] `dotnet new install` the updated templates
- [ ] `dotnet new nsmithy-server --help` shows `--protocol`, `--contracts`, `--with-docs`
- [ ] Quick-start commands run without "Invalid option" errors
- [ ] `dotnet new nsmithy-client -n Test` generates a valid `Program.cs` with `using NSmithy.Client`
- [ ] `dotnet new nsmithy-client -n Test --protocol grpc` generates a valid `Program.cs` with `using Grpc.Net.Client`
