### PR TITLE
docs: clarify that generated servers use ASP.NET Core minimal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NSmithy is a preview-stage .NET toolkit that turns a [Smithy](https://smithy.io)
 
 ## Features
 
-- **MSBuild integration**: Generate C# models, typed clients, and ASP.NET Core server stubs from a Smithy IDL as part of `dotnet build` — no separate codegen step, no Java or JRE installation required.
+- **MSBuild integration**: Generate C# models, typed clients, and ASP.NET Core minimal API server stubs from a Smithy IDL as part of `dotnet build` — no separate codegen step, no Java or JRE installation required.
 - **Protocol support**: Implements `alloy#simpleRestJson`, `aws.protocols#restJson1`, `aws.protocols#restXml`, `smithy.protocols#rpcv2Cbor`, and `alloy.proto#grpc`.
 - **Conformance-tested**: Validated against official Smithy, AWS, and alloy conformance suites.
 

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -18,7 +18,7 @@ NSmithy is a .NET implementation of the Smithy toolchain. It integrates with MSB
 
 - **Typed C# records** for all shapes (structures, unions, enums).
 - **Typed async client interfaces and implementations** per service.
-- **ASP.NET Core handler interfaces and routing adapters** per service.
+- **ASP.NET Core minimal API handler interfaces and routing adapters** per service.
 
 **No Gradle.** Other Smithy ecosystems (Java in particular) typically use Gradle to orchestrate codegen. NSmithy deliberately avoids this: the Smithy CLI is invoked as an MSBuild target, so `dotnet build` is the only build command you need.
 

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -161,8 +161,8 @@ public interface IHelloServiceHandler
 
 ### The Server Handler
 
-The generated `Program.cs` in `HelloWorld.Server` registers your handler and
-maps the routes:
+The generated server uses [ASP.NET Core minimal API](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis).
+`Program.cs` registers your handler and maps the routes:
 
 ```csharp
 builder.Services.AddHelloServiceHandler<HelloHandler>();

--- a/website/src/content/docs/protocols/rest-json.md
+++ b/website/src/content/docs/protocols/rest-json.md
@@ -195,7 +195,7 @@ Members without an explicit binding go into the JSON body.
 ## Server
 
 NSmithy generates one `IWeatherServiceHandler` interface with a method for each
-operation. Implement it once; the generated ASP.NET Core adapter handles routing,
+operation. Implement it once; the generated ASP.NET Core minimal API adapter handles routing,
 serialization, and error dispatch.
 
 ```csharp


### PR DESCRIPTION
## Summary

- Adds "minimal API" to all mentions of generated server stubs in the README, introduction, quick-start, and REST JSON protocol docs
- Links to the ASP.NET Core minimal API docs from the quick-start server handler section

## Test plan

- [ ] Docs site renders correctly (`just docs`)
