### PR TITLE
chore: prepare 0.1.0 release docs and template versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
    </a>
 </p>
 
-> **Work in Progress:** NSmithy is a proof of concept. Protocol implementations are not yet on par with the [Smithy reference implementations](https://github.com/smithy-lang/smithy).
+> **Preview:** NSmithy is in preview — expect some API changes before 1.0. Protocol implementations are not yet on par with the [Smithy reference implementations](https://github.com/smithy-lang/smithy).
 
 # NSmithy
 

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -11,19 +11,19 @@
 
   <ItemGroup>
     <!--#if (!IsGrpc)-->
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.15" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-preview.15" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-preview.15" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-preview.15" />
-    <PackageReference Include="NSmithy.Http" Version="0.1.0-preview.15" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.15" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Core" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Http" Version="0.1.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0" PrivateAssets="all" />
     <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -3,7 +3,7 @@
   "maven": {
     "dependencies": [
       "io.github.YOUR_ORG:your-service-contracts:1.0.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0"
     ]
   },
   "plugins": {

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0" />
   </ItemGroup>
 
 

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.15" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -8,7 +8,7 @@
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-preview.15"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0"
     ]
   },
   "plugins": {

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -7,10 +7,10 @@ NSmithy releases are published by creating a GitHub release.
 
 ## Version
 
-NuGet package versions come from `Directory.Build.props`.
-
-Update `VersionPrefix` and `VersionSuffix` before creating a release. Package
-versions are not derived from the Git tag.
+The published NuGet package version is derived from the GitHub release tag. The
+release workflow strips the leading `v` and passes the result to the build,
+overriding the `VersionPrefix`/`VersionSuffix` placeholders in
+`Directory.Build.props` (those are only used for local SNAPSHOT builds).
 
 ## Tag Format
 
@@ -18,16 +18,14 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- package version: `0.1.0-preview.15`
-- release tag: `v0.1.0-preview.15`
+- release tag: `v0.1.0`
+- package version: `0.1.0`
 
 ## GitHub Release Flow
 
-1. Update the version in `Directory.Build.props`.
-2. Merge or push the version change to the branch you want to release from.
-3. In GitHub, create a new release.
-4. Create a new tag using the `v<package-version>` format.
-5. Publish the release.
+1. In GitHub, create a new release.
+2. Create a new tag using the `v<package-version>` format (e.g. `v0.1.0`).
+3. Publish the release.
 
 Publishing the GitHub release triggers the workflow in `.github/workflows/release.yml`,
-which builds, tests, packs, and pushes the NuGet packages.
+which builds, tests, packs, and pushes the NuGet packages using the version from the tag.

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -128,7 +128,7 @@ dependencies automatically — no `ProjectReference` needed:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-preview.15" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's built-in static file middleware serves them with zero extra confi
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-preview.15" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -16,7 +16,7 @@ as XML and decodes XML responses. Status: **Early preview, client-only**.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-preview.15" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0" />
 ```
 
 ## Modeling

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -16,7 +16,7 @@ are bundled with the Smithy CLI.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-preview.15" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0" />
 ```
 
 ## Modeling


### PR DESCRIPTION
## Summary

Prep for the `0.1.0` release.

- **README**: replaced the "proof of concept / Work in Progress" banner with a preview notice ("expect some API changes before 1.0").
- **Versions**: dropped the `0.1.0-preview.15` placeholder → `0.1.0` everywhere it was hardcoded — `nsmithy-client`/`nsmithy-server`/`nsmithy-contracts` templates (`MyService.csproj` + `smithy-build.json`) and the website docs (`distributing-contracts`, `endpoint-documentation`, `rest-xml`, `rpc-v2-cbor`).
- **releasing.md**: corrected the version section. It previously claimed versions come from `Directory.Build.props` and "are not derived from the Git tag" — the opposite of how `release.yml` actually works (it strips the `v` from the tag and passes `-p:Version=$VERSION`). Now documents the real tag-driven flow.

## Left intentionally unchanged

- `Directory.Build.props` stays `VersionPrefix=0.1.0` / `VersionSuffix=SNAPSHOT` — only used for local builds; the release tag overrides it.
- `examples/**` keep `0.1.0-SNAPSHOT` — they build against the locally published SNAPSHOT, not released packages.
- `aws-overview.md` "proof of concept" wording — accurate and scoped to AWS protocol support specifically.

The actual release is cut by creating a GitHub release with tag `v0.1.0`.
