### PR TITLE
docs: 0.1.0 release notes (CHANGELOG) and README features overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ for the full walkthrough.
 | `smithy.protocols#rpcv2Cbor` | client only | Early preview |
 | `alloy.proto#grpc` | `.proto` emission + gRPC client + ASP.NET Core gRPC server | Experimental |
 
-Start with `alloy#simpleRestJson` for the smoothest end-to-end path. `restXml`
+We recommend `aws.protocols#restJson1` for new projects. `restXml`
 and `rpcv2Cbor` are client-only for now. Full breakdown on the
 [Protocol Status](https://thomaslaich.github.io/smithy-dotnet/protocols/status/) page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to NSmithy are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Preview.** NSmithy is in preview — expect some API changes before 1.0.
+> Protocol implementations are not yet on par with the
+> [Smithy reference implementations](https://github.com/smithy-lang/smithy).
+
+## [Unreleased]
+
+## [0.1.0]
+
+First tagged release. NSmithy turns a [Smithy](https://smithy.io) model into
+idiomatic C# at build time — typed clients, ASP.NET Core minimal-API server
+stubs, and shared model types, generated as part of `dotnet build`. No separate
+codegen step, and no Java or JRE required. Earlier `0.1.0-preview.*` builds are
+superseded.
+
+### Getting started
+
+```bash
+dotnet new install NSmithy.Templates
+dotnet new nsmithy-server   # or: nsmithy-client, nsmithy-contracts
+dotnet build
+```
+
+See the [Quick Start guide](https://thomaslaich.github.io/smithy-dotnet/getting-started/quick-start/)
+for the full walkthrough.
+
+### Protocol support
+
+| Protocol | Generated surfaces | Stage |
+| --- | --- | --- |
+| `alloy#simpleRestJson` | client + ASP.NET Core server | Preview — most complete |
+| `aws.protocols#restJson1` | client + ASP.NET Core server | Preview |
+| `aws.protocols#restXml` | client only | Early preview |
+| `smithy.protocols#rpcv2Cbor` | client only | Early preview |
+| `alloy.proto#grpc` | `.proto` emission + gRPC client + ASP.NET Core gRPC server | Experimental |
+
+Start with `alloy#simpleRestJson` for the smoothest end-to-end path. `restXml`
+and `rpcv2Cbor` are client-only for now. Full breakdown on the
+[Protocol Status](https://thomaslaich.github.io/smithy-dotnet/protocols/status/) page.
+
+### Known limitations
+
+NSmithy is preview-stage and has rough edges — please read
+[Known Limitations](https://thomaslaich.github.io/smithy-dotnet/reference/known-limitations/)
+before filing issues, and report anything not already listed there.
+
+### Packages
+
+All published to NuGet at `0.1.0`:
+
+- **Runtime / codegen:** `NSmithy.Core`, `NSmithy.Http`, `NSmithy.MSBuild`
+- **Client / server:** `NSmithy.Client`, `NSmithy.Server.AspNetCore`, `NSmithy.Server.AspNetCore.Docs`
+- **Codecs:** `NSmithy.Codecs.Json`, `NSmithy.Codecs.Cbor`, `NSmithy.Codecs.Xml`
+- **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`
+- **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
+
+[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/thomaslaich/smithy-dotnet/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ NSmithy is a preview-stage .NET toolkit that turns a [Smithy](https://smithy.io)
 
 ## Features
 
+- **Contract-first, protocol-agnostic**: Define your service once in Smithy — operations, shapes, and errors — independent of any wire protocol. The same model can target a different protocol without rewriting your contract.
 - **MSBuild integration**: Generate C# models, typed clients, and ASP.NET Core minimal API server stubs from a Smithy IDL as part of `dotnet build` — no separate codegen step, no Java or JRE installation required.
-- **Protocol support**: Implements `alloy#simpleRestJson`, `aws.protocols#restJson1`, `aws.protocols#restXml`, `smithy.protocols#rpcv2Cbor`, and `alloy.proto#grpc`.
+- **Protocol support**: REST JSON, REST XML, RPC v2 CBOR, and gRPC.
 - **Conformance-tested**: Validated against official Smithy, AWS, and alloy conformance suites.
 
 ## Development


### PR DESCRIPTION
## Summary

Release-prep documentation for `0.1.0`.

### CHANGELOG.md (new)
Adds a root `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com/) format) with the `0.1.0` entry, so release notes live in the repo and grow with each release. The 0.1.0 section covers:
- What NSmithy is + preview disclaimer
- Quick start (`dotnet new` template names)
- Protocol support matrix (client/server split per protocol), recommending `aws.protocols#restJson1` for new projects
- Pointer to Known Limitations
- The `NSmithy.*` packages published to NuGet at `0.1.0`

Exact conformance counts are intentionally left out of the committed file (they drift); they live on the Protocol Status docs page instead.

### README Features overhaul
Reworks the Features section to lead with NSmithy's core value proposition:
- **Contract-first, protocol-agnostic** — define the service once in Smithy, independent of wire protocol
- **MSBuild integration** (kept)
- **Protocol support** described in general terms (REST JSON, REST XML, RPC v2 CBOR, gRPC) rather than by Smithy shape ID
- **Conformance-tested** (kept)
