### PR TITLE
fix: default client codegen off in NSmithy.Server.AspNetCore

### DIFF
--- a/packages/NSmithy.Server.AspNetCore/NSmithy.Server.AspNetCore.csproj
+++ b/packages/NSmithy.Server.AspNetCore/NSmithy.Server.AspNetCore.csproj
@@ -3,5 +3,17 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="../NSmithy.Codecs.Json/NSmithy.Codecs.Json.csproj" />
     <ProjectReference Include="../NSmithy.Protocols.RestJson/NSmithy.Protocols.RestJson.csproj" />
+
+    <!-- Props file sets SmithyGenerateServer=true / SmithyGenerateClient=false by default -->
+    <None
+      Include="Targets/NSmithy.Server.AspNetCore.props"
+      Pack="true"
+      PackagePath="build/NSmithy.Server.AspNetCore.props"
+    />
+    <None
+      Include="Targets/NSmithy.Server.AspNetCore.props"
+      Pack="true"
+      PackagePath="buildTransitive/NSmithy.Server.AspNetCore.props"
+    />
   </ItemGroup>
 </Project>

--- a/packages/NSmithy.Server.AspNetCore/Targets/NSmithy.Server.AspNetCore.props
+++ b/packages/NSmithy.Server.AspNetCore/Targets/NSmithy.Server.AspNetCore.props
@@ -1,0 +1,11 @@
+<Project>
+  <!--
+    Default code-generation flags for projects that consume a Smithy service as a server.
+    Server stubs are on; client stubs are off unless the user explicitly opts in.
+    Override in your .csproj PropertyGroup if you need both.
+  -->
+  <PropertyGroup>
+    <SmithyGenerateServer Condition="'$(SmithyGenerateServer)' == ''">true</SmithyGenerateServer>
+    <SmithyGenerateClient Condition="'$(SmithyGenerateClient)' == ''">false</SmithyGenerateClient>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
NSmithy.Client shipped a props file defaulting SmithyGenerateClient=true /
SmithyGenerateServer=false, but NSmithy.Server.AspNetCore shipped no props.
Server-only projects therefore inherited the global SmithyGenerateClient=true
default and compiled the generated *.Client.g.cs, which does `using NSmithy.Client;`
— a package server projects don't reference — producing CS0234.

Ship a symmetric props in NSmithy.Server.AspNetCore that defaults
SmithyGenerateServer=true / SmithyGenerateClient=false, packed to build/ and
buildTransitive/. Projects referencing only the server package now get the
correct codegen flags with no manual SmithyGenerateClient=false workaround.
