### PR TITLE
Prepare 0.2.0 release + AGENTS.md / llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in **smithy-dotnet** (the NSmithy project).
+Human-facing docs live at <https://thomaslaich.github.io/smithy-dotnet/> and in
+`designs/`; this file is the short, operational version.
+
+## What this repo is
+
+NSmithy turns a [Smithy](https://smithy.io) model into idiomatic C# at build
+time — typed clients, ASP.NET Core minimal-API server stubs, and shared model
+types, generated as part of `dotnet build`. No separate codegen step and no JRE
+required by consumers.
+
+The build itself is **polyglot**:
+
+- The code generator is **Java/Gradle** (`codegen/`), packaged as a Smithy
+  `SmithyBuildPlugin` JAR.
+- The runtime, MSBuild integration, and tests are **C#/.NET 10** (`NSmithy.slnx`).
+- `NSmithy.MSBuild` invokes the bundled Smithy CLI during `dotnet build`, which
+  loads the codegen JAR to emit C#.
+
+## Common commands
+
+This repo is driven by [`just`](https://github.com/casey/just); run `just` to
+list recipes. Key ones:
+
+| Command | What it does |
+| --- | --- |
+| `just build` | `codegen` + `restore` + `dotnet build` (Release). Run this first. |
+| `just test` | `gradle test` (codegen) then `dotnet test` (runtime + conformance). |
+| `just codegen` | Build the codegen JARs and publish to the local Maven cache (`~/.m2`). |
+| `just fmt` / `just check-format` | Run / verify `treefmt` formatting. |
+| `just pack` | Pack NuGet packages to `artifacts/packages` (used by examples). |
+| `just refresh-examples` | Re-restore/rebuild the `examples/` against freshly packed packages. |
+| `just ci` | `check-format build test pack` — the full CI pipeline locally. |
+| `just docs` | Install and run the docs site (`website/`) dev server. |
+
+You generally **must `just codegen` (or `just build`) before `dotnet test`**:
+the conformance projects resolve
+`io.github.thomaslaich.nsmithy:smithy-csharp-codegen:<version>-SNAPSHOT` from
+`~/.m2`, so a stale or missing JAR produces confusing codegen errors.
+
+## Repository layout
+
+- `codegen/` — Java/Gradle code generators. `smithy-csharp-codegen` (C# emission)
+  and `smithy-proto-codegen` (`.proto` emission for gRPC).
+- `packages/` — C# runtime and tooling packages (`NSmithy.Core`, `NSmithy.Http`,
+  `NSmithy.Client`, `NSmithy.Server.AspNetCore`, `NSmithy.Codecs.*`,
+  `NSmithy.Protocols.*`, `NSmithy.MSBuild`).
+- `tests/` — `NSmithy.Tests` (unit) and `tests/Conformance/*` (one project per
+  protocol, run against the official Smithy/AWS protocol-test fixtures).
+- `examples/` — runnable end-to-end samples (`simple-rest-json`, `rest-json1`,
+  `rpcv2cbor`, `aws`, `grpc`, `polyglot`). These consume **packed** packages from
+  `artifacts/packages`, not project references — see the gotcha below.
+- `templates/NSmithy.Templates` — `dotnet new` project templates.
+- `website/` — Astro/Starlight documentation site.
+- `designs/` — design docs and architecture rationale.
+- `justfile` — task runner entry point.
+
+## Conventions and gotchas
+
+- **Versioning is tag-driven.** Local builds use the `VersionPrefix` /
+  `VersionSuffix` in `Directory.Build.props` (currently `0.2.0` + `SNAPSHOT`); the
+  release workflow overrides the version from the GitHub release tag. When bumping
+  the version, update `Directory.Build.props`, `codegen/build.gradle.kts`, the
+  `NSmithy.MSBuild` targets, templates, examples, conformance `smithy-build.json`,
+  and the website docs together. Do **not** touch the unrelated `path-data-parser`
+  entry in `website/package-lock.json`.
+- **Warnings are errors.** `Directory.Build.props` sets
+  `TreatWarningsAsErrors=true` with `Recommended` analysis; keep the build clean.
+- **Formatting is enforced** via `treefmt` (csharpier for C#, etc.). Run
+  `just fmt` before committing; CI runs `just check-format`.
+- **Examples build against packed packages.** After changing runtime code, run
+  `just pack` (and often `just refresh-examples`) before example builds reflect
+  the change — a plain `dotnet build` of an example will use the old `.nupkg`.
+- **gRPC examples need two build passes** (the first emits the `.proto`, the
+  second compiles it); `just refresh-examples` handles this.
+- **Conformance numbers** on the docs Protocol Status page come from the
+  `ConformanceRateTests.ReportConformanceRate` test output in each
+  `tests/Conformance/*` project; regenerate them from there rather than editing by
+  hand.
+
+## Commit / PR conventions
+
+- Branch off `main`; releases use `release/<x.y.z>` branches.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`,
+  `docs:`, `refactor:`). PRs are squash-merged with a `(#NN)` suffix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.0]
+
+Server-side protocol support takes a big step forward. `smithy.protocols#rpcv2Cbor`
+gains a generated ASP.NET Core server, and REST servers learn to serialize
+responses and modeled errors — bringing `aws.protocols#restJson1` and
+`alloy#simpleRestJson` to full server-side conformance alongside their clients.
+
+### Added
+
+- **rpcv2Cbor server generation.** `NSmithy.Server.AspNetCore` now emits ASP.NET
+  Core minimal-API servers for `smithy.protocols#rpcv2Cbor` services, routed at
+  `POST /service/{Service}/operation/{Operation}`, with CBOR request
+  deserialization plus response and modeled-error serialization. (#54)
+- **REST server response handling.** Generated REST servers now honor the
+  `@http(code)` success status, project outputs through their HTTP bindings
+  (header / payload / document), and serialize modeled errors with the protocol's
+  error-type header and HTTP status. `restJson1` and `simpleRestJson` now run the
+  full set of applicable server conformance cases, not just clients. (#55)
+
+### Changed
+
+- **`NSmithy.Server.AspNetCore` defaults to server-only codegen.** The package
+  now ships props setting `SmithyGenerateServer=true` / `SmithyGenerateClient=false`,
+  so server-only projects no longer compile the generated client (which referenced
+  `NSmithy.Client`) or need a manual `SmithyGenerateClient=false` workaround. (#53)
+
+### Protocol support
+
+| Protocol | Generated surfaces | Stage |
+| --- | --- | --- |
+| `alloy#simpleRestJson` | client + ASP.NET Core server | Preview — most complete |
+| `aws.protocols#restJson1` | client + ASP.NET Core server | Preview |
+| `smithy.protocols#rpcv2Cbor` | client + ASP.NET Core server | Preview |
+| `aws.protocols#restXml` | client only | Early preview |
+| `alloy.proto#grpc` | `.proto` emission + gRPC client + ASP.NET Core gRPC server | Experimental |
+
+`rpcv2Cbor` now generates servers in addition to clients; see the
+[Protocol Status](https://thomaslaich.github.io/smithy-dotnet/protocols/status/)
+page for current conformance numbers.
+
+### Packages
+
+All published to NuGet at `0.2.0`:
+
+- **Runtime / codegen:** `NSmithy.Core`, `NSmithy.Http`, `NSmithy.MSBuild`
+- **Client / server:** `NSmithy.Client`, `NSmithy.Server.AspNetCore`, `NSmithy.Server.AspNetCore.Docs`
+- **Codecs:** `NSmithy.Codecs.Json`, `NSmithy.Codecs.Cbor`, `NSmithy.Codecs.Xml`
+- **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`
+- **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
+
 ## [0.1.0]
 
 First tagged release. NSmithy turns a [Smithy](https://smithy.io) model into
@@ -60,5 +110,6 @@ All published to NuGet at `0.1.0`:
 - **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`
 - **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
 
-[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thomaslaich/smithy-dotnet/releases/tag/v0.1.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <Authors>Thomas Laich</Authors>
     <Description>NSmithy — C# code generation and runtime toolkit for Smithy models.</Description>

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
     // The release pipeline overrides this with `-Pversion=<x.y.z>` so the published
     // Maven Central artifact carries the matching release version.
     version = (findProperty("version") as String?).takeUnless { it.isNullOrBlank() || it == "unspecified" }
-        ?: "0.1.0-SNAPSHOT"
+        ?: "0.2.0-SNAPSHOT"
 }
 
 subprojects {

--- a/examples/aws/client/NSmithy.Examples.Aws.Client.csproj
+++ b/examples/aws/client/NSmithy.Examples.Aws.Client.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/aws/smithy-build.json
+++ b/examples/aws/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
+++ b/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/contracts/Library.Contracts.csproj
+++ b/examples/grpc/contracts/Library.Contracts.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
+++ b/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
@@ -15,8 +15,8 @@
     <ProjectReference Include="../contracts/Library.Contracts.csproj" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
+++ b/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Http" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Http" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
+++ b/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
+++ b/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
+++ b/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
+++ b/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
+++ b/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
+++ b/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
+++ b/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
+++ b/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
+++ b/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
@@ -13,7 +13,7 @@
       artifacts in your contracts smithy-build.json should use this version.
     -->
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
-    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.1.0-SNAPSHOT</SmithyCSharpCodegenVersion>
+    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.2.0-SNAPSHOT</SmithyCSharpCodegenVersion>
     <!--
       Set to 'true' to inject the smithy-docgen plugin into the synthesized smithy-build.json
       and copy the generated HTML docs to wwwroot/docs/.

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -37,7 +37,7 @@
   <PropertyGroup>
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''"
-      >0.1.0-SNAPSHOT</SmithyCSharpCodegenVersion
+      >0.2.0-SNAPSHOT</SmithyCSharpCodegenVersion
     >
     <SmithyGenerateDocs Condition="'$(SmithyGenerateDocs)' == ''">false</SmithyGenerateDocs>
     <SmithyOpenApiProtocol Condition="'$(SmithyOpenApiProtocol)' == ''"></SmithyOpenApiProtocol>

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -11,19 +11,19 @@
 
   <ItemGroup>
     <!--#if (!IsGrpc)-->
-    <PackageReference Include="NSmithy.Client" Version="0.1.0" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.1.0" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Client" Version="0.1.0" />
-    <PackageReference Include="NSmithy.Core" Version="0.1.0" />
-    <PackageReference Include="NSmithy.Http" Version="0.1.0" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Core" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Http" Version="0.2.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0" PrivateAssets="all" />
     <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -3,7 +3,7 @@
   "maven": {
     "dependencies": [
       "io.github.YOUR_ORG:your-service-contracts:1.0.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0"
     ]
   },
   "plugins": {

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.1.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0" />
   </ItemGroup>
 
 

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -8,7 +8,7 @@
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0"
     ]
   },
   "plugins": {

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -13,7 +13,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
       "software.amazon.smithy:smithy-protocol-traits:1.68.0",
       "software.amazon.smithy:smithy-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/SimpleRestJson/smithy-build.json
+++ b/tests/Conformance/SimpleRestJson/smithy-build.json
@@ -6,7 +6,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       "com.disneystreaming.alloy:alloy-protocol-tests:0.3.38"
     ]

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import starlightLlmsTxt from 'starlight-llms-txt';
 import mermaid from 'astro-mermaid';
 import { readFileSync } from 'node:fs';
 
@@ -17,6 +18,15 @@ export default defineConfig({
 		starlight({
 			title: 'NSmithy',
 			description: 'Generate C# models, typed HTTP clients, and ASP.NET Core servers from Smithy models.',
+			plugins: [
+				// Emit /llms.txt (curated index) and /llms-full.txt (full docs) for LLM consumption.
+				// https://llmstxt.org · https://github.com/HiDeoo/starlight-llms-txt
+				starlightLlmsTxt({
+					projectName: 'NSmithy',
+					description:
+						'NSmithy generates C# models, typed HTTP clients, and ASP.NET Core minimal-API servers from Smithy models at build time — no separate codegen step and no JRE required by consumers.',
+				}),
+			],
 			logo: {
 				src: './src/assets/brand/nsmithy_logo_1.png',
 				alt: 'NSmithy logo',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,6 +13,9 @@
         "astro-mermaid": "^2.0.1",
         "mermaid": "^11.14.0",
         "sharp": "^0.34.2"
+      },
+      "devDependencies": {
+        "starlight-llms-txt": "^0.10.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1957,6 +1960,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -2270,6 +2280,16 @@
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "license": "MIT"
     },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2577,6 +2597,19 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3852,6 +3885,19 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -4212,6 +4258,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -4481,6 +4554,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -5758,6 +5841,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -6321,6 +6431,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -6360,6 +6485,24 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6776,6 +6919,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/starlight-llms-txt": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.10.0.tgz",
+      "integrity": "sha512-LgkSjkvdACsGHkFq1ES00F0BU4lRepjJoaUmOgxBxNWx4txwpySVPtntKdAvDvlhinyN0ZBRpnAsN/sVQ1UEfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^5.0.4",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.10",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.4",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.38.0",
+        "astro": "^6.0.0"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -6885,10 +7053,34 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7056,6 +7248,22 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/website/package.json
+++ b/website/package.json
@@ -15,5 +15,8 @@
     "astro-mermaid": "^2.0.1",
     "mermaid": "^11.14.0",
     "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "starlight-llms-txt": "^0.10.0"
   }
 }

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,13 +18,13 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- release tag: `v0.1.0`
-- package version: `0.1.0`
+- release tag: `v0.2.0`
+- package version: `0.2.0`
 
 ## GitHub Release Flow
 
 1. In GitHub, create a new release.
-2. Create a new tag using the `v<package-version>` format (e.g. `v0.1.0`).
+2. Create a new tag using the `v<package-version>` format (e.g. `v0.2.0`).
 3. Publish the release.
 
 Publishing the GitHub release triggers the workflow in `.github/workflows/release.yml`,

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -128,7 +128,7 @@ dependencies automatically — no `ProjectReference` needed:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's built-in static file middleware serves them with zero extra confi
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.1.0" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -16,7 +16,7 @@ as XML and decodes XML responses. Status: **Early preview, client-only**.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.1.0" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.2.0" />
 ```
 
 ## Modeling

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -15,7 +15,7 @@ are bundled with the Smithy CLI.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0" />
 ```
 
 ## Modeling
@@ -60,15 +60,15 @@ structure InvalidName {
 ### Server
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore" Version="0.1.0" />
+<PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
 ```
 
 ### Client
 
 ```xml
-<PackageReference Include="NSmithy.Client" Version="0.1.0" />
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.1.0" />
-<PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.1.0" />
+<PackageReference Include="NSmithy.Client" Version="0.2.0" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0" />
+<PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0" />
 ```
 
 ## Server

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -16,8 +16,8 @@ server is never counted toward client coverage and vice versa.
 
 | Protocol | Surfaces | Stage | Client | Server |
 | --- | --- | --- | --- | --- |
-| `alloy#simpleRestJson` | both | Preview (most complete) | 43/43 (100%) | not yet exercised |
-| `aws.protocols#restJson1` | both | Preview | 243/247 (98.4%) | 19/227 (8.4%) |
+| `alloy#simpleRestJson` | both | Preview (most complete) | 43/43 (100%) | 43/43 (100%) |
+| `aws.protocols#restJson1` | both | Preview | 243/247 (98.4%) | 224/227 (98.7%) |
 | `aws.protocols#restXml` | client | Early preview | codec-only, no cases yet | — |
 | `smithy.protocols#rpcv2Cbor` | both | Preview | 68/68 (100%) | 60/60 (100%) |
 | `alloy.proto#grpc` | both | Experimental | tested via examples¹ | tested via examples¹ |
@@ -29,16 +29,18 @@ smallest test surface, and more explicit model requirements such as
 
 Notes:
 
-- `alloy#simpleRestJson`'s protocol tests all declare `appliesTo: both`, so they
-  apply to servers too; there is simply no server conformance project driving
-  them yet, hence "not yet exercised" rather than a percentage.
-- `aws.protocols#restJson1`'s client surface is mature; its server surface is
-  still early (request/response serialization and error responses are only
-  partially exercised).
+- `alloy#simpleRestJson`'s protocol tests all declare `appliesTo: both`; both the
+  client and the generated ASP.NET Core server now run every applicable case.
+- `aws.protocols#restJson1` exercises both surfaces against nearly every
+  applicable case. The handful of unmet cases are curated out of the client
+  allowlist; on the server, cases whose operation has no generated handler
+  (auxiliary services like Glacier that ship fixtures but aren't part of the
+  `RestJson` service) are out of scope rather than counted as failures.
 - `aws.protocols#restXml` currently validates the XML codec and transport
   abstractions; no official conformance cases are executed yet.
-- `smithy.protocols#rpcv2Cbor` is the only protocol with both client and server
-  fully exercised against every applicable case.
+- `smithy.protocols#rpcv2Cbor`, `alloy#simpleRestJson`, and `aws.protocols#restJson1`
+  all exercise both the client and the generated server against their applicable
+  cases.
 
 ## Recommended Use
 


### PR DESCRIPTION
## Summary

Prepares the **0.2.0** release and improves the repo's discoverability by LLMs.

### Release prep
- Add a `0.2.0` entry to `CHANGELOG.md` covering:
  - rpcv2Cbor ASP.NET Core **server** generation (#54)
  - REST server response + modeled-error handling, bringing restJson1 and simpleRestJson to full server conformance (#55)
  - server-only codegen default in `NSmithy.Server.AspNetCore` (#53)
- Bump `0.1.0` → `0.2.0` across `Directory.Build.props`, the codegen Gradle version, `NSmithy.MSBuild` targets, templates, examples, conformance `smithy-build.json`, and website docs. (The unrelated `path-data-parser` npm dep in `package-lock.json` is left untouched.)

### Docs accuracy
- Refresh the **Protocol Status** page from the current `ConformanceRateTests` output:
  - simpleRestJson server: *not yet exercised* → **43/43 (100%)**
  - restJson1 server: **19/227 (8.4%)** → **224/227 (98.7%)**

### LLM discoverability
- Add a repo-root **`AGENTS.md`** ([agents.md](https://agents.md) standard) describing the polyglot build, `just` recipes, layout, and gotchas for coding agents.
- Wire the **`starlight-llms-txt`** plugin so the docs site emits `/llms.txt`, `/llms-small.txt`, and `/llms-full.txt` ([llmstxt.org](https://llmstxt.org)). These are build output (served from `website/dist` by the docs workflow), so they are not checked in.

## Testing
- `just build` + conformance `ReportConformanceRate` tests (source of the updated numbers) — all pass.
- `just check-format` — clean.
- `npm run build` (docs) — succeeds and emits the three `llms*.txt` files.

## Follow-up
The actual NuGet publish is triggered by creating the `v0.2.0` GitHub release/tag (see `contributing/releasing.md`); that remains a manual step after merge.
