### PR TITLE
Prepare 0.3.0 release: changelog + version bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ the conformance projects resolve
 ## Conventions and gotchas
 
 - **Versioning is tag-driven.** Local builds use the `VersionPrefix` /
-  `VersionSuffix` in `Directory.Build.props` (currently `0.2.0` + `SNAPSHOT`); the
+  `VersionSuffix` in `Directory.Build.props` (currently `0.3.0` + `SNAPSHOT`); the
   release workflow overrides the version from the GitHub release tag. When bumping
   the version, update `Directory.Build.props`, `codegen/build.gradle.kts`, the
   `NSmithy.MSBuild` targets, templates, examples, conformance `smithy-build.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,74 @@ and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0]
+
+Native gRPC arrives, and client construction is reworked so a single generated
+`{Service}Client` can speak any protocol the service declares. gRPC now runs on
+NSmithy's own proto3 codec and gRPC protocol over the shared HTTP transport — no
+`protoc`, `Grpc.Tools`, or `Grpc.Net.Client` dependency.
+
+### Added
+
+- **Native gRPC.** Two new packages — `NSmithy.Codecs.Proto` (a schema-driven
+  proto3 wire codec) and `NSmithy.Protocols.Grpc` (`GrpcProtocol`: 5-byte
+  message framing, `application/grpc+proto`, the `grpc-status` trailer error
+  model, and HTTP/2) — implement gRPC over the same `HttpClientTransport` as the
+  REST and rpcv2Cbor protocols, with no `protoc` / `Grpc.Tools` / `Grpc.Net`
+  dependency. Servers gain a native `Map{Service}Grpc` that coexists with the
+  REST map for dual-protocol services. (#58)
+- **Protocol-agnostic client construction.** Codegen now emits a single
+  `{Service}Client` with `(endpoint, …)`, `(httpClient, …)`, and `(invoker, …)`
+  constructors, each taking an optional `protocol` that defaults to the service's
+  primary declared protocol. The same client speaks whichever `IProtocol` it is
+  given, so a service may declare any combination of protocols. (#58)
+- **Opt-in generated dependency injection.** Setting
+  `SmithyGenerateDependencyInjection=true` generates an `Add{Service}Client(...)`
+  extension (flowing through `smithy-build.json` as the `generateDependencyInjection`
+  codegen setting). It is generation-gated, so the `Microsoft.Extensions.Http`
+  dependency is only pulled in when enabled, and it configures HTTP/2 from the
+  selected protocol. See the new
+  [Dependency Injection](https://thomaslaich.github.io/smithy-dotnet/guides/dependency-injection/)
+  guide. (#58)
+
+### Changed
+
+- **Protocols are instantiable.** `IProtocol` exposes `RequiresHttp2`, and
+  protocols are now constructed (`new GrpcProtocol()`) rather than reached through
+  static `.Instance` singletons. (#58)
+- **`SmithyClientOptions` removed.** `middleware` and `idempotencyTokenProvider`
+  are now first-class constructor parameters on the generated client. (#58)
+- **Protocol-agnostic request mutations.** Compression and content-MD5 handling
+  moved into `NSmithy.Http/SmithyRequestModifiers`, and error dispatch is unified
+  through `IOperationProtocol.RequiresErrorDiscriminator` /
+  `SupportsHttpStatusErrorFallback`. (#58)
+
+### Protocol support
+
+| Protocol | Generated surfaces | Stage |
+| --- | --- | --- |
+| `alloy#simpleRestJson` | client + ASP.NET Core server | Preview — most complete |
+| `aws.protocols#restJson1` | client + ASP.NET Core server | Preview |
+| `smithy.protocols#rpcv2Cbor` | client + ASP.NET Core server | Preview |
+| `aws.protocols#restXml` | client only | Early preview |
+| `alloy.proto#grpc` | `.proto` emission + native gRPC client + ASP.NET Core gRPC server | Experimental |
+
+gRPC now runs on NSmithy's own proto codec and gRPC protocol; see the
+[Protocol Status](https://thomaslaich.github.io/smithy-dotnet/protocols/status/)
+page for current conformance numbers.
+
+### Packages
+
+All published to NuGet at `0.3.0`:
+
+- **Runtime / codegen:** `NSmithy.Core`, `NSmithy.Http`, `NSmithy.MSBuild`
+- **Client / server:** `NSmithy.Client`, `NSmithy.Server.AspNetCore`, `NSmithy.Server.AspNetCore.Docs`
+- **Codecs:** `NSmithy.Codecs.Json`, `NSmithy.Codecs.Cbor`, `NSmithy.Codecs.Xml`, `NSmithy.Codecs.Proto`
+- **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`, `NSmithy.Protocols.Grpc`
+- **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
+
+`NSmithy.Codecs.Proto` and `NSmithy.Protocols.Grpc` are new in this release.
+
 ## [0.2.0]
 
 Server-side protocol support takes a big step forward. `smithy.protocols#rpcv2Cbor`
@@ -110,6 +178,7 @@ All published to NuGet at `0.1.0`:
 - **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`
 - **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
 
-[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thomaslaich/smithy-dotnet/releases/tag/v0.1.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <Authors>Thomas Laich</Authors>
     <Description>NSmithy — C# code generation and runtime toolkit for Smithy models.</Description>

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
     // The release pipeline overrides this with `-Pversion=<x.y.z>` so the published
     // Maven Central artifact carries the matching release version.
     version = (findProperty("version") as String?).takeUnless { it.isNullOrBlank() || it == "unspecified" }
-        ?: "0.2.0-SNAPSHOT"
+        ?: "0.3.0-SNAPSHOT"
 }
 
 subprojects {

--- a/examples/aws/client/NSmithy.Examples.Aws.Client.csproj
+++ b/examples/aws/client/NSmithy.Examples.Aws.Client.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/aws/smithy-build.json
+++ b/examples/aws/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
+++ b/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
@@ -19,9 +19,9 @@
   -->
   <ItemGroup>
     <ProjectReference Include="../contracts/Library.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.3.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/contracts/Library.Contracts.csproj
+++ b/examples/grpc/contracts/Library.Contracts.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
+++ b/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
@@ -17,9 +17,9 @@
   -->
   <ItemGroup>
     <ProjectReference Include="../contracts/Library.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
+++ b/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Http" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Http" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
+++ b/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
+++ b/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
+++ b/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
+++ b/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
+++ b/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
+++ b/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
+++ b/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
+++ b/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
+++ b/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.3.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
@@ -13,7 +13,7 @@
       artifacts in your contracts smithy-build.json should use this version.
     -->
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
-    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.2.0-SNAPSHOT</SmithyCSharpCodegenVersion>
+    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.3.0-SNAPSHOT</SmithyCSharpCodegenVersion>
     <!--
       Set to 'true' to inject the smithy-docgen plugin into the synthesized smithy-build.json
       and copy the generated HTML docs to wwwroot/docs/.

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -37,7 +37,7 @@
   <PropertyGroup>
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''"
-      >0.2.0-SNAPSHOT</SmithyCSharpCodegenVersion
+      >0.3.0-SNAPSHOT</SmithyCSharpCodegenVersion
     >
     <SmithyGenerateDocs Condition="'$(SmithyGenerateDocs)' == ''">false</SmithyGenerateDocs>
     <SmithyOpenApiProtocol Condition="'$(SmithyOpenApiProtocol)' == ''"></SmithyOpenApiProtocol>

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -10,19 +10,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.2.0" />
-    <PackageReference Include="NSmithy.Core" Version="0.2.0" />
-    <PackageReference Include="NSmithy.Http" Version="0.2.0" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.3.0" />
+    <PackageReference Include="NSmithy.Core" Version="0.3.0" />
+    <PackageReference Include="NSmithy.Http" Version="0.3.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0" PrivateAssets="all" />
     <!--
       The HelloService model declares both @simpleRestJson and @grpc, so the generated client
       supports both protocols (pick one via the constructor's `protocol:` parameter, e.g.
       new GrpcProtocol()) and references both protocol packages. Native gRPC needs no
       Grpc.Net.Client / Google.Protobuf / protoc.
     -->
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.2.0" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.2.0" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.3.0" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.3.0" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.3.0" />
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->
     <PackageReference Include="MyService.Contracts" Version="1.0.0" />

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -3,7 +3,7 @@
   "maven": {
     "dependencies": [
       "io.github.YOUR_ORG:your-service-contracts:1.0.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0"
     ]
   },
   "plugins": {

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.2.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.3.0" />
   </ItemGroup>
 
 

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.3.0" />
     <!--#endif-->
     <!--#if (IsGrpc)-->
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -8,7 +8,7 @@
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0"
     ]
   },
   "plugins": {

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -13,7 +13,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.68.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
       "software.amazon.smithy:smithy-protocol-traits:1.68.0",
       "software.amazon.smithy:smithy-protocol-tests:1.68.0"
     ]

--- a/tests/Conformance/SimpleRestJson/smithy-build.json
+++ b/tests/Conformance/SimpleRestJson/smithy-build.json
@@ -6,7 +6,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.2.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       "com.disneystreaming.alloy:alloy-protocol-tests:0.3.38"
     ]

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,13 +18,13 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- release tag: `v0.2.0`
-- package version: `0.2.0`
+- release tag: `v0.3.0`
+- package version: `0.3.0`
 
 ## GitHub Release Flow
 
 1. In GitHub, create a new release.
-2. Create a new tag using the `v<package-version>` format (e.g. `v0.2.0`).
+2. Create a new tag using the `v<package-version>` format (e.g. `v0.3.0`).
 3. Publish the release.
 
 Publishing the GitHub release triggers the workflow in `.github/workflows/release.yml`,

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -128,7 +128,7 @@ dependencies automatically — no `ProjectReference` needed:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's built-in static file middleware serves them with zero extra confi
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.2.0" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.3.0" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -16,7 +16,7 @@ as XML and decodes XML responses. Status: **Early preview, client-only**.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.2.0" />
+<PackageReference Include="NSmithy.Codecs.Xml" Version="0.3.0" />
 ```
 
 ## Modeling

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -15,7 +15,7 @@ are bundled with the Smithy CLI.
 ## NuGet Package
 
 ```xml
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.3.0" />
 ```
 
 ## Modeling
@@ -60,15 +60,15 @@ structure InvalidName {
 ### Server
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore" Version="0.2.0" />
+<PackageReference Include="NSmithy.Server.AspNetCore" Version="0.3.0" />
 ```
 
 ### Client
 
 ```xml
-<PackageReference Include="NSmithy.Client" Version="0.2.0" />
-<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.2.0" />
-<PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.2.0" />
+<PackageReference Include="NSmithy.Client" Version="0.3.0" />
+<PackageReference Include="NSmithy.Codecs.Cbor" Version="0.3.0" />
+<PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.3.0" />
 ```
 
 ## Server


### PR DESCRIPTION
## Summary

The `v0.3.0` tag was published, but the in-repo CHANGELOG and `0.2.0`
version references were never updated. This back-fills both so the source
tree matches the released version.

- **CHANGELOG.md** — new `[0.3.0]` entry covering native gRPC and
  protocol-agnostic client construction (#58), plus updated compare links.
- **Version bump `0.2.0` → `0.3.0`** across `Directory.Build.props`, the
  codegen Gradle version, the `NSmithy.MSBuild` targets, templates, all
  examples, conformance `smithy-build.json`, and website docs.
- **AGENTS.md** "currently `0.2.0`" note refreshed.

The npm `website/package-lock.json` is intentionally left untouched (its
`0.2.0` entries are unrelated transitive deps, per the AGENTS.md note).

## What 0.3.0 shipped (#58)

Native gRPC — NSmithy's own proto3 codec (`NSmithy.Codecs.Proto`) and gRPC
protocol (`NSmithy.Protocols.Grpc`) over the shared HTTP transport, no
`protoc` / `Grpc.Tools` / `Grpc.Net` dependency — plus protocol-agnostic
client construction (one `{Service}Client` speaks any declared protocol)
and an opt-in generated DI extension. The two new packages are flagged as
new in the changelog's Packages section.

## Notes

- Example/template *code* was already migrated to the new construction in
  #58; this PR only catches the leftover version strings and the changelog.
- No conformance numbers changed.
