### PR TITLE
chore: add Error Prone (Java) and globalization analyzers (C#)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,11 +18,30 @@ dotnet_style_qualification_for_property = false:warning
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
 
+# Globalization rules on top of AnalysisMode=Recommended. This is a wire-protocol
+# and serialization toolkit, so string comparisons and formatting must be
+# culture-independent (Ordinal / InvariantCulture). Require an explicit
+# StringComparison / IFormatProvider; promoted to build errors by
+# TreatWarningsAsErrors. (Scoped off for test code below.)
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+dotnet_diagnostic.CA1310.severity = warning
+dotnet_diagnostic.CA1311.severity = warning
+
 [CSharpShapeGenerator.*.cs]
 max_line_length = 140
 
 [CSharpShapeGenerator.cs]
 max_line_length = 140
+
+# Test and conformance code uses controlled, ASCII inputs where culture-sensitive
+# string behavior is not a real concern, so the globalization rules above would be
+# pure noise here.
+[tests/**/*.cs]
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1307.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none
 
 [*.{csproj,props,targets,slnx,yml,json,md}]
 indent_size = 2

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -5,9 +5,15 @@
 // implementations. See codegen/README.md for the rationale and how it relates
 // to docs/architecture/hybrid-codegen.md.
 
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     `java-library`
     id("com.vanniktech.maven.publish") version "0.30.0" apply false
+    // Error Prone: javac-integrated static analysis for correctness bugs the
+    // Java compiler does not report. Runs on every compile, locally and in CI.
+    // See roadmap §4 "Improve generator clarity and diagnostics".
+    id("net.ltgt.errorprone") version "4.1.0" apply false
 }
 
 allprojects {
@@ -21,6 +27,7 @@ allprojects {
 
 subprojects {
     apply(plugin = "java-library")
+    apply(plugin = "net.ltgt.errorprone")
 
     repositories {
         mavenCentral()
@@ -32,10 +39,41 @@ subprojects {
         }
     }
 
+    dependencies {
+        "errorprone"("com.google.errorprone:error_prone_core:2.36.0")
+    }
+
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
         // Target Java 17 bytecode so the plugin loads inside the JRE bundled
         // with the Smithy CLI.
         options.release.set(17)
+
+        options.errorprone {
+            // Error Prone's default-ERROR checks (real correctness bugs) stay
+            // build-breaking — that's the gate that earns its keep.
+
+            // Dead private methods are cheap to catch and worth blocking on now
+            // that the existing ones are removed.
+            error("UnusedMethod")
+
+            // StringSplitter is low-signal for this codebase: every call splits
+            // on a fixed literal delimiter and iterates, where String.split's
+            // trailing-empty trimming is harmless. Switching to Guava's Splitter
+            // would just add a dependency for no behavioral gain.
+            disable("StringSplitter")
+
+            // UnusedVariable stays a non-blocking warning: the findings are the
+            // uniformly-threaded `context` fields and `sp` parameters across the
+            // generators, so removing them would fight that deliberate signature
+            // pattern more than it would clean anything up.
+            warn("UnusedVariable")
+        }
+    }
+
+    // Don't gate test compilation on Error Prone — keep the signal focused on
+    // shipped generator code.
+    tasks.named<JavaCompile>("compileTestJava") {
+        options.errorprone.isEnabled.set(false)
     }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpCodegenPlugin.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpCodegenPlugin.java
@@ -5,6 +5,7 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
@@ -42,7 +43,9 @@ public final class CSharpCodegenPlugin implements SmithyBuildPlugin {
   }
 
   private static final String NULL_DEVICE =
-      System.getProperty("os.name", "").toLowerCase().contains("win") ? "NUL" : "/dev/null";
+      System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win")
+          ? "NUL"
+          : "/dev/null";
 
   private static void formatGeneratedCode(Path outputDir) {
     String dir = outputDir.toAbsolutePath().toString();

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -24,10 +24,8 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
@@ -590,88 +588,6 @@ public final class ServerGenerator implements Runnable {
     }
 
     writer.write("");
-  }
-
-  private String bodyProjectionConstructorArguments(List<MemberShape> bodyMembers) {
-    List<String> args = new java.util.ArrayList<>();
-    for (MemberShape m : bodyMembers) {
-      String local = CSharpNaming.parameterName(m.getMemberName());
-      if (ShapeSupport.isOptionalParameter(m)) {
-        args.add(local);
-      } else {
-        args.add(
-            local
-                + " ?? throw new System.InvalidOperationException("
-                + CSharpNaming.formatString("Missing required member '" + m.getMemberName() + "'.")
-                + ")");
-      }
-    }
-    return String.join(", ", args);
-  }
-
-  private String writeValueStatement(
-      Shape target, String serializerVar, String schemaVar, String valueExpr) {
-    return switch (target.getType()) {
-      case BOOLEAN -> serializerVar + ".WriteBoolean(" + schemaVar + ", " + valueExpr + ");";
-      case BYTE -> serializerVar + ".WriteByte(" + schemaVar + ", " + valueExpr + ");";
-      case SHORT -> serializerVar + ".WriteShort(" + schemaVar + ", " + valueExpr + ");";
-      case INTEGER -> serializerVar + ".WriteInteger(" + schemaVar + ", " + valueExpr + ");";
-      case LONG -> serializerVar + ".WriteLong(" + schemaVar + ", " + valueExpr + ");";
-      case FLOAT -> serializerVar + ".WriteFloat(" + schemaVar + ", " + valueExpr + ");";
-      case DOUBLE -> serializerVar + ".WriteDouble(" + schemaVar + ", " + valueExpr + ");";
-      case BIG_INTEGER -> serializerVar + ".WriteBigInteger(" + schemaVar + ", " + valueExpr + ");";
-      case BIG_DECIMAL -> serializerVar + ".WriteBigDecimal(" + schemaVar + ", " + valueExpr + ");";
-      case TIMESTAMP -> serializerVar + ".WriteTimestamp(" + schemaVar + ", " + valueExpr + ");";
-      case STRING -> serializerVar + ".WriteString(" + schemaVar + ", " + valueExpr + ");";
-      case ENUM -> serializerVar + ".WriteString(" + schemaVar + ", " + valueExpr + ".Value);";
-      case BLOB -> serializerVar + ".WriteBlob(" + schemaVar + ", " + valueExpr + ");";
-      case DOCUMENT -> serializerVar + ".WriteDocument(" + schemaVar + ", " + valueExpr + ");";
-      case INT_ENUM -> serializerVar + ".WriteInteger(" + schemaVar + ", (int)" + valueExpr + ");";
-      case STRUCTURE -> serializerVar + ".WriteStruct(" + schemaVar + ", " + valueExpr + ");";
-      case UNION, LIST, SET, MAP ->
-          valueExpr + ".Serialize(" + serializerVar + ", " + schemaVar + ");";
-      default ->
-          throw new IllegalArgumentException(
-              "Unsupported body projection member shape: " + target.getId());
-    };
-  }
-
-  private static String stripTrailingSemicolon(String statement) {
-    return statement.endsWith(";") ? statement.substring(0, statement.length() - 1) : statement;
-  }
-
-  private String readValueExpression(Shape target, String deserializerVar, String schemaVar) {
-    return switch (target.getType()) {
-      case BOOLEAN -> deserializerVar + ".ReadBoolean(" + schemaVar + ")";
-      case BYTE -> deserializerVar + ".ReadByte(" + schemaVar + ")";
-      case SHORT -> deserializerVar + ".ReadShort(" + schemaVar + ")";
-      case INTEGER -> deserializerVar + ".ReadInteger(" + schemaVar + ")";
-      case LONG -> deserializerVar + ".ReadLong(" + schemaVar + ")";
-      case FLOAT -> deserializerVar + ".ReadFloat(" + schemaVar + ")";
-      case DOUBLE -> deserializerVar + ".ReadDouble(" + schemaVar + ")";
-      case BIG_INTEGER -> deserializerVar + ".ReadBigInteger(" + schemaVar + ")";
-      case BIG_DECIMAL -> deserializerVar + ".ReadBigDecimal(" + schemaVar + ")";
-      case TIMESTAMP -> deserializerVar + ".ReadTimestamp(" + schemaVar + ")";
-      case STRING -> deserializerVar + ".ReadString(" + schemaVar + ")";
-      case BLOB -> deserializerVar + ".ReadBlob(" + schemaVar + ")";
-      case DOCUMENT -> deserializerVar + ".ReadDocument(" + schemaVar + ")";
-      case ENUM, STRUCTURE, UNION, LIST, SET, MAP ->
-          CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(target))
-              + ".Deserialize("
-              + deserializerVar
-              + ")";
-      case INT_ENUM ->
-          "("
-              + CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(target))
-              + ")"
-              + deserializerVar
-              + ".ReadInteger("
-              + schemaVar
-              + ")";
-      default ->
-          throw new IllegalArgumentException(
-              "Unsupported body projection member shape: " + target.getId());
-    };
   }
 
   // ---------------- helpers ----------------

--- a/codegen/smithy-proto-codegen/src/main/java/io/github/thomaslaich/nsmithy/proto/codegen/ProtoGenerator.java
+++ b/codegen/smithy-proto-codegen/src/main/java/io/github/thomaslaich/nsmithy/proto/codegen/ProtoGenerator.java
@@ -344,7 +344,7 @@ public final class ProtoGenerator {
       sb.append("  ")
           .append(name)
           .append("_")
-          .append(entry.getKey().toUpperCase())
+          .append(entry.getKey().toUpperCase(Locale.ROOT))
           .append(" = ")
           .append(idx++)
           .append(";\n");
@@ -364,7 +364,7 @@ public final class ProtoGenerator {
       sb.append("  ")
           .append(name)
           .append("_")
-          .append(entry.getKey().toUpperCase())
+          .append(entry.getKey().toUpperCase(Locale.ROOT))
           .append(" = ")
           .append(entry.getValue())
           .append(";\n");

--- a/packages/NSmithy.Aws/AwsSigV4Middleware.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Middleware.cs
@@ -213,10 +213,14 @@ public sealed class AwsSigV4Middleware(
                     var value = equals >= 0 ? part[(equals + 1)..] : "";
                     return (
                         Name: EscapeQueryComponent(
-                            Uri.UnescapeDataString(name.Replace("+", "%20"))
+                            Uri.UnescapeDataString(
+                                name.Replace("+", "%20", StringComparison.Ordinal)
+                            )
                         ),
                         Value: EscapeQueryComponent(
-                            Uri.UnescapeDataString(value.Replace("+", "%20"))
+                            Uri.UnescapeDataString(
+                                value.Replace("+", "%20", StringComparison.Ordinal)
+                            )
                         )
                     );
                 })

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -930,7 +930,7 @@ public static class RestProtocol
         object value
     )
     {
-        builder.Append(builder.ToString().Contains('?') ? '&' : '?');
+        builder.Append(builder.ToString().Contains('?', StringComparison.Ordinal) ? '&' : '?');
         builder.Append(Uri.EscapeDataString(name));
         builder.Append('=');
         builder.Append(Uri.EscapeDataString(FormatHttpValue(schema, traits, value)));

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -75,10 +75,6 @@ model's documentation rather than being empty.
 - Improve unsupported-shape and unsupported-trait diagnostics.
 - Continue simplifying generator internals where semantics are harder to follow
   than they need to be.
-- Evaluate Java static analysis for the codegen modules. Start with
-  Error Prone for correctness checks, then consider SonarCloud, PMD, or similar
-  tooling for dead-code and maintainability findings that the Java compiler does
-  not report.
 - Revisit the generated server mapping API so service mapping can be
   protocol-selectable, for example `MapFooService(protocols)`, while preserving
   protocol-specific internals and handling route conflicts explicitly.


### PR DESCRIPTION
## Summary

Adds static analysis to both toolchains, addressing roadmap §4 ("Evaluate Java static analysis for the codegen modules. Start with Error Prone…").

### Java (codegen)
- Wire `net.ltgt.errorprone` into the Gradle build for both subprojects. Runs as a `javac` plugin on every compile — local and CI (`just codegen` / `just test`), no extra step or server.
- **Policy:** default-ERROR checks gate the build (0 currently fire); `UnusedMethod` promoted to error; `StringSplitter` disabled (low signal — every site splits on a fixed literal); `UnusedVariable` kept as an advisory warning (the 9 hits are the deliberately uniform `context`/`sp` threading across generators).
- Removed 4 dead helper methods in `ServerGenerator`; fixed 3 `StringCaseLocaleUsage` findings (`Locale.ROOT`).

### C#
- Kept `AnalysisMode=Recommended` — `All` floods a *library* with inapplicable rules (CA1515 "make public internal" ×216, CA1034 ×212).
- Additively enabled the globalization family `CA1305/1307/1310/1311` via `.editorconfig` (culture-independent string ops matter for a wire-protocol/serialization library — the C# analogue of the Java locale fix), scoped **off for `tests/**`** where the inputs are controlled.
- Fixed the 3 runtime sites (SigV4 canonical-query encoding, REST query delimiter check) with `StringComparison.Ordinal`.

## Verification
- Full solution build: **0 warnings, 0 errors**
- `treefmt --ci`: clean
- Test suites: all pass (Java `gradle test` + .NET conformance suites)
