### PR TITLE
chore: update Smithy CLI to 1.71.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
    <a href="LICENSE">
       <img src="https://img.shields.io/github/license/thomaslaich/smithy-dotnet" alt="License" />
    </a>
-   <a href="https://github.com/smithy-lang/smithy/releases/tag/1.68.0">
-      <img src="https://img.shields.io/badge/smithy--cli-1.68.0-orange" alt="Smithy CLI" />
+   <a href="https://github.com/smithy-lang/smithy/releases/tag/1.71.0">
+      <img src="https://img.shields.io/badge/smithy--cli-1.71.0-orange" alt="Smithy CLI" />
    </a>
 </p>
 

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 
-smithyVersion=1.68.0
+smithyVersion=1.71.0

--- a/examples/aws-localstack/smithy-build.json
+++ b/examples/aws-localstack/smithy-build.json
@@ -7,7 +7,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT"
     ]
   },

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -7,7 +7,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT"
     ]
   },

--- a/examples/rest-json1/contracts/smithy-build.json
+++ b/examples/rest-json1/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.68.0"
+      "software.amazon.smithy:smithy-aws-traits:1.71.0"
     ]
   }
 }

--- a/examples/rpcv2cbor/contracts/smithy-build.json
+++ b/examples/rpcv2cbor/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-protocol-traits:1.68.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
     ]
   }
 }

--- a/nix/smithy-cli.nix
+++ b/nix/smithy-cli.nix
@@ -6,28 +6,28 @@
 }:
 
 let
-  version = "1.68.0";
+  version = "1.71.0";
 
   platform =
     if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
       {
         name = "darwin-aarch64";
-        hash = "e836bb468eb117f05597fa263864681728950e32c10a85592eb4dd643cfdee88";
+        hash = "447e1d3e08b54e1787fedd10057a259ed48954ed950f2909713de28d8ea0d3dc";
       }
     else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
       {
         name = "darwin-x86_64";
-        hash = "55b5e397fd42fea407326e512daf9bcd38819c03534e1243e4a0fc71a9ec5ded";
+        hash = "dcda65061f51687ccded52ede603ea66381e3ca2eeaf708bdf96f93df9eb535d";
       }
     else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64 then
       {
         name = "linux-aarch64";
-        hash = "2bbed6177b0c4fc2f75c4266a5cf72571ca35ce66da8800a90d4cf03c6bb2d42";
+        hash = "1de152a114bcb96a31bb1b3596df5b65794a2c81e292149596e5f065330d6816";
       }
     else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
       {
         name = "linux-x86_64";
-        hash = "ee6e6d24416b53624ba7f323628b2ca8aa67a349fbe3b2e92e98172c3f3d6a45";
+        hash = "5bddf40fb64fd0581d85b6bdc51ae67bdc4dff0297b3db92cb800b324fa3b2ea";
       }
     else
       throw "Unsupported platform for smithy-cli: ${stdenv.hostPlatform.system}";

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
@@ -12,7 +12,7 @@
       Smithy CLI version bundled in this package. software.amazon.smithy:* Maven
       artifacts in your contracts smithy-build.json should use this version.
     -->
-    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
+    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.3.0-SNAPSHOT</SmithyCSharpCodegenVersion>
     <!--
       Set to 'true' to inject the smithy-docgen plugin into the synthesized smithy-build.json

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -35,7 +35,7 @@
        always wins.
        ================================================================ -->
   <PropertyGroup>
-    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.68.0</SmithyVersion>
+    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''"
       >0.3.0-SNAPSHOT</SmithyCSharpCodegenVersion
     >

--- a/packages/NSmithy.MSBuild/tools/download-smithy-cli.sh
+++ b/packages/NSmithy.MSBuild/tools/download-smithy-cli.sh
@@ -10,18 +10,18 @@
 # Usage: bash tools/download-smithy-cli.sh
 set -euo pipefail
 
-SMITHY_VERSION="1.68.0"
+SMITHY_VERSION="1.71.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$SCRIPT_DIR/smithy-cli"
 BASE_URL="https://github.com/smithy-lang/smithy/releases/download/${SMITHY_VERSION}"
 
 # SHA256 hashes for smithy-cli-{platform}.zip — update when bumping SMITHY_VERSION.
 declare -A PLATFORM_SHA256=(
-  ["darwin-aarch64"]="e836bb468eb117f05597fa263864681728950e32c10a85592eb4dd643cfdee88"
-  ["darwin-x86_64"]="55b5e397fd42fea407326e512daf9bcd38819c03534e1243e4a0fc71a9ec5ded"
-  ["linux-aarch64"]="2bbed6177b0c4fc2f75c4266a5cf72571ca35ce66da8800a90d4cf03c6bb2d42"
-  ["linux-x86_64"]="ee6e6d24416b53624ba7f323628b2ca8aa67a349fbe3b2e92e98172c3f3d6a45"
-  ["windows-x64"]="604f7017f4dfc50b802fa8d74401bbb4604ccbec5af2df39639897f467aaf663"
+  ["darwin-aarch64"]="447e1d3e08b54e1787fedd10057a259ed48954ed950f2909713de28d8ea0d3dc"
+  ["darwin-x86_64"]="dcda65061f51687ccded52ede603ea66381e3ca2eeaf708bdf96f93df9eb535d"
+  ["linux-aarch64"]="1de152a114bcb96a31bb1b3596df5b65794a2c81e292149596e5f065330d6816"
+  ["linux-x86_64"]="5bddf40fb64fd0581d85b6bdc51ae67bdc4dff0297b3db92cb800b324fa3b2ea"
+  ["windows-x64"]="173299c5f3b380c027a0c2d17cdec65f3cd2f756ee46d6ade0eb0cc53c6e0047"
 )
 
 all_platforms=(

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
@@ -4,7 +4,7 @@
   "maven": {
     "dependencies": [
       //#if (IsRestJson1)
-      "software.amazon.smithy:smithy-aws-traits:1.68.0"
+      "software.amazon.smithy:smithy-aws-traits:1.71.0"
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38"
       //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -4,7 +4,7 @@
   "maven": {
     "dependencies": [
       //#if (IsRestJson1)
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif

--- a/tests/Conformance/AwsJson/smithy-build.json
+++ b/tests/Conformance/AwsJson/smithy-build.json
@@ -11,8 +11,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -14,8 +14,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -11,8 +11,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.68.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.68.0"
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -11,8 +11,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.3.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-protocol-traits:1.68.0",
-      "software.amazon.smithy:smithy-protocol-tests:1.68.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
+      "software.amazon.smithy:smithy-protocol-tests:1.71.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
+++ b/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
@@ -21,7 +21,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!--
       alloy-protocol-tests 0.3.38 uses HttpRequestTestCase#code and HttpResponseTestCase#{uri,method}
-      which don't exist in smithy-model 1.68.0. The "Error validating trait" text in the WARNING
+      which don't exist in smithy-model 1.71.0. The "Error validating trait" text in the WARNING
       message body causes MSBuild's Exec task to treat it as a build error, so suppress it here.
     -->
     <SmithyExtraArgs>--hide-validators TraitValue.UnknownMember.smithy.test#HttpRequestTestCase.code,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.uri,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.method</SmithyExtraArgs>

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -19,7 +19,7 @@ numbers.
 ## Maven Dependency
 
 ```json
-"software.amazon.smithy:smithy-aws-traits:1.68.0"
+"software.amazon.smithy:smithy-aws-traits:1.71.0"
 ```
 
 ## NuGet Package

--- a/website/src/content/docs/protocols/aws-rest-json1.md
+++ b/website/src/content/docs/protocols/aws-rest-json1.md
@@ -17,7 +17,7 @@ numbers.
 ## Maven Dependency
 
 ```json
-"software.amazon.smithy:smithy-aws-traits:1.68.0"
+"software.amazon.smithy:smithy-aws-traits:1.71.0"
 ```
 
 ## NuGet Packages

--- a/website/src/content/docs/reference/msbuild.md
+++ b/website/src/content/docs/reference/msbuild.md
@@ -75,7 +75,7 @@ cross-team model sharing outside the solution.
 
 ## Smithy CLI
 
-NSmithy bundles the Smithy CLI (version 1.68.0) inside `NSmithy.MSBuild` and
+NSmithy bundles the Smithy CLI (version 1.71.0) inside `NSmithy.MSBuild` and
 selects the correct platform binary automatically. No separate installation is
 required. The bundle is self-contained and includes a JRE, so Java does not
 need to be installed either.


### PR DESCRIPTION
Bumps the bundled Smithy CLI and all related version pins from **1.68.0 → 1.71.0**.

## What changed

- **MSBuild packaging** — `download-smithy-cli.sh` (version + all 5 platform SHA256s), `NSmithy.MSBuild.props` / `.targets` `SmithyVersion` defaults. Bundled binaries re-downloaded and verified (`smithy --version` → `1.71.0`).
- **Local dev (devenv)** — `nix/smithy-cli.nix` version + 4 platform hashes (nix derivation builds clean at 1.71.0).
- **Gradle** — `codegen/gradle.properties` `smithyVersion`.
- **Maven pins** — `software.amazon.smithy:*` (`smithy-aws-traits`, `smithy-protocol-traits`, `*-protocol-tests`) in every `smithy-build.json` across tests, examples, and templates.
- **Docs/README** — CLI badge, msbuild reference, protocol doc snippets.

## Notes

- **alloy left at 0.3.38** — it's an independent dependency, not tied to the Smithy CLI version (latest 0.3.39 is a trivial patch).
- The SimpleRestJson `--hide-validators` workaround is **still required**: alloy 0.3.38's protocol-test members (`uri`/`method`/`code`) still don't exist in smithy-model 1.71.0. Only the stale `1.68.0` reference in its comment was corrected.

## Validation

Fresh codegen against 1.71.0; all conformance suites pass:

| Suite | Tests |
|---|---|
| SimpleRestJson | 87 ✅ |
| RestJson1 | 480 ✅ |
| AwsJson | 28 ✅ |
| RestXml | 49 ✅ |
| RpcV2Cbor | 133 ✅ |
