### PR TITLE
feat: add client runtime interceptor pipeline

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -123,7 +123,7 @@ public final class ClientGenerator implements Runnable {
         "}",
         () -> {
           if (hasUnaryOperations) {
-            writer.write("private readonly SmithyOperationInvoker invoker;");
+            writer.write("private readonly SmithyClientRuntime runtime;");
           }
           if (wiresEventStreamOperations) {
             writer.write("private readonly SmithyEventStreamOperationInvoker eventStreamInvoker;");
@@ -188,8 +188,9 @@ public final class ClientGenerator implements Runnable {
                 }
                 if (hasUnaryOperations) {
                   writer.write(
-                      "this.invoker = new SmithyOperationInvoker(new"
+                      "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient, endpoint),"
+                          + " config.Interceptors,"
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L, ModeledAuthSchemes,"
                           + " config.AuthSchemes, config.Middleware));",
                       serviceSchema);
@@ -233,8 +234,9 @@ public final class ClientGenerator implements Runnable {
                 }
                 if (hasUnaryOperations) {
                   writer.write(
-                      "this.invoker = new SmithyOperationInvoker(new"
+                      "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient, endpoint),"
+                          + " config.Interceptors,"
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L, ModeledAuthSchemes,"
                           + " config.AuthSchemes, config.Middleware));",
                       serviceSchema);
@@ -252,12 +254,12 @@ public final class ClientGenerator implements Runnable {
           writer.write("");
 
           if (!wiresEventStreamOperations) {
-            // Constructor: bring your own invoker (custom transport/middleware, DI, testing). The
-            // invoker already owns the pipeline, so config.AuthSchemes/Middleware do not apply
-            // here; only Protocol and IdempotencyTokenProvider are read.
+            // Constructor: bring your own runtime (custom transport/pipeline, DI, testing). The
+            // runtime already owns the pipeline, so config.AuthSchemes/Middleware/Interceptors do
+            // not apply here; only Protocol and IdempotencyTokenProvider are read.
             if (hasUnaryOperations) {
               writer.write(
-                  "public $L(SmithyOperationInvoker invoker, $LConfig? config = null)",
+                  "public $L(SmithyClientRuntime runtime, $LConfig? config = null)",
                   typeName,
                   typeName);
               writer.openBlock(
@@ -265,8 +267,8 @@ public final class ClientGenerator implements Runnable {
                   "}",
                   () -> {
                     writer.write(
-                        "this.invoker = invoker ?? throw new"
-                            + " System.ArgumentNullException(nameof(invoker));");
+                        "this.runtime = runtime ?? throw new"
+                            + " System.ArgumentNullException(nameof(runtime));");
                     writer.write("config ??= new $LConfig();", typeName);
                     writer.write(
                         "var resolvedProtocol = config.Protocol ?? new $L();", primaryProtocol);
@@ -279,7 +281,7 @@ public final class ClientGenerator implements Runnable {
             }
           } else if (hasUnaryOperations) {
             writer.write(
-                "public $L(SmithyOperationInvoker invoker, SmithyEventStreamOperationInvoker"
+                "public $L(SmithyClientRuntime runtime, SmithyEventStreamOperationInvoker"
                     + " eventStreamInvoker, $LConfig? config = null)",
                 typeName,
                 typeName);
@@ -288,8 +290,8 @@ public final class ClientGenerator implements Runnable {
                 "}",
                 () -> {
                   writer.write(
-                      "this.invoker = invoker ?? throw new"
-                          + " System.ArgumentNullException(nameof(invoker));");
+                      "this.runtime = runtime ?? throw new"
+                          + " System.ArgumentNullException(nameof(runtime));");
                   writer.write(
                       "this.eventStreamInvoker = eventStreamInvoker ?? throw new"
                           + " System.ArgumentNullException(nameof(eventStreamInvoker));");
@@ -370,7 +372,7 @@ public final class ClientGenerator implements Runnable {
           writer.write("");
 
           // Disposes the HttpClient the client created itself; a no-op when the caller supplied the
-          // HttpClient or invoker (ownedHttpClient is null), so injected transports are never
+          // HttpClient or runtime (ownedHttpClient is null), so injected transports are never
           // closed.
           if (needsHttpClient) {
             writer.write("public void Dispose() => ownedHttpClient?.Dispose();");
@@ -382,7 +384,7 @@ public final class ClientGenerator implements Runnable {
           for (OperationShape op : operations) writeOperationMethod(sp, model, op);
           for (OperationShape op : operations) {
             if (!isEventStreamOperation(model, op)) {
-              writeErrorDeserializer(sp, model, op);
+              writeErrorDeserializer(model, op);
             }
           }
         });
@@ -543,31 +545,26 @@ public final class ClientGenerator implements Runnable {
                 model.expectShape(op.getInputShape(), StructureShape.class));
           }
 
-          // The operation-bound protocol owns request serialization (and, for rpc, the path).
-          writer.write("var request = $LProtocol.SerializeRequest($L);", opName, inputArg);
-
-          if (op.findTrait(TraitIds.REQUEST_COMPRESSION).isPresent()) {
-            writer.write(
-                "SmithyRequestModifiers.ApplyRequestCompression(request, $L);",
-                requestCompressionEncoding(op));
-          }
-          if (op.findTrait(TraitIds.HTTP_CHECKSUM_REQUIRED).isPresent()) {
-            writer.write("SmithyRequestModifiers.ApplyContentMd5(request);");
-          }
-
-          writer.write("");
-          writer.write(
-              "var response = await invoker.InvokeAsync($L, $L, request, $L,"
-                  + " $LProtocol.IsErrorResponse, cancellationToken).ConfigureAwait(false);",
-              CSharpNaming.formatString(service.getId().getName()),
-              CSharpNaming.formatString(op.getId().getName()),
-              deserName,
-              opName);
-
           if (hasOutput) {
-            writer.write("");
-            writer.write("return $LProtocol.DeserializeResponse(response);", opName);
+            writer.write(
+                "return await runtime.InvokeAsync($L, $L, $LProtocol, $L, $L, $L,"
+                    + " cancellationToken).ConfigureAwait(false);",
+                CSharpNaming.formatString(service.getId().getName()),
+                CSharpNaming.formatString(op.getId().getName()),
+                opName,
+                inputArg,
+                requestModifier(op),
+                deserName);
           } else {
+            writer.write(
+                "await runtime.InvokeAsync($L, $L, $LProtocol, $L, $L, $L,"
+                    + " cancellationToken).ConfigureAwait(false);",
+                CSharpNaming.formatString(service.getId().getName()),
+                CSharpNaming.formatString(op.getId().getName()),
+                opName,
+                inputArg,
+                requestModifier(op),
+                deserName);
             writer.write("return;");
           }
         });
@@ -700,9 +697,29 @@ public final class ClientGenerator implements Runnable {
                         + " has no encodings — trait requires at least one"));
   }
 
+  private String requestModifier(OperationShape op) {
+    boolean hasCompression = op.findTrait(TraitIds.REQUEST_COMPRESSION).isPresent();
+    boolean hasMd5 = op.findTrait(TraitIds.HTTP_CHECKSUM_REQUIRED).isPresent();
+    if (!hasCompression && !hasMd5) {
+      return "null";
+    }
+
+    List<String> statements = new ArrayList<>();
+    if (hasCompression) {
+      statements.add(
+          "SmithyRequestModifiers.ApplyRequestCompression(request, "
+              + requestCompressionEncoding(op)
+              + ")");
+    }
+    if (hasMd5) {
+      statements.add("SmithyRequestModifiers.ApplyContentMd5(request)");
+    }
+    return "request => { " + String.join("; ", statements) + "; }";
+  }
+
   // ---------------- error deserializer ----------------
 
-  private void writeErrorDeserializer(SymbolProvider sp, Model model, OperationShape op) {
+  private void writeErrorDeserializer(Model model, OperationShape op) {
     String opName = CSharpNaming.typeName(op.getId().getName());
     String methodName = "Deserialize" + opName + "ErrorAsync";
     String receiver = opName + "Protocol";
@@ -751,7 +768,7 @@ public final class ClientGenerator implements Runnable {
                           + " || string.Equals(errorType, $L, System.StringComparison.Ordinal))",
                       CSharpNaming.formatString(errId.getName()),
                       CSharpNaming.formatString(errId.toString()));
-                  writer.openBlock("{", "}", () -> writeErrorReturn(sp, err, receiver));
+                  writer.openBlock("{", "}", () -> writeErrorReturn(err, receiver));
                 }
               });
 
@@ -770,7 +787,7 @@ public final class ClientGenerator implements Runnable {
                   for (ShapeId errId : statusErrors) {
                     StructureShape err = model.expectShape(errId, StructureShape.class);
                     writer.write("if ((int)response.StatusCode == $L)", httpErrorCode(err));
-                    writer.openBlock("{", "}", () -> writeErrorReturn(sp, err, receiver));
+                    writer.openBlock("{", "}", () -> writeErrorReturn(err, receiver));
                   }
                 });
           }
@@ -795,7 +812,7 @@ public final class ClientGenerator implements Runnable {
                             + " System.Threading.Tasks.ValueTask.FromResult<System.Exception?>(null);"));
             writer.write("");
           }
-          writeErrorReturn(sp, err, receiver);
+          writeErrorReturn(err, receiver);
         });
     writer.write("");
   }
@@ -805,7 +822,7 @@ public final class ClientGenerator implements Runnable {
    * body for REST, whole CBOR/proto body for rpc/gRPC) via {@code receiver.DeserializeError(...)},
    * where the receiver is the operation-bound protocol field.
    */
-  private void writeErrorReturn(SymbolProvider sp, StructureShape err, String receiver) {
+  private void writeErrorReturn(StructureShape err, String receiver) {
     writer.write(
         "return System.Threading.Tasks.ValueTask.FromResult<System.Exception?>("
             + "$L.DeserializeError($L, response));",

--- a/justfile
+++ b/justfile
@@ -55,6 +55,8 @@ refresh-examples:
     rm -rf examples/grpc-streaming/contracts/obj
     rm -rf examples/grpc-streaming/server/obj
     rm -rf examples/grpc-streaming/client/obj
+    rm -rf examples/grpc-streaming/grpcnet-server/obj
+    rm -rf examples/grpc-streaming/grpcnet-client/obj
     rm -rf examples/polyglot/dotnet/obj
     dotnet clean examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj --verbosity minimal
     dotnet clean examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj --verbosity minimal
@@ -84,13 +86,16 @@ refresh-examples:
     dotnet restore examples/grpc-streaming/contracts/Streaming.Contracts.csproj --no-cache --force
     dotnet restore examples/grpc-streaming/server/NSmithy.Examples.GrpcStreaming.Server.csproj --no-cache --force
     dotnet restore examples/grpc-streaming/client/NSmithy.Examples.GrpcStreaming.Client.csproj --no-cache --force
+    dotnet restore examples/grpc-streaming/grpcnet-server/NSmithy.Examples.GrpcStreaming.GrpcNetServer.csproj --no-cache --force
+    dotnet restore examples/grpc-streaming/grpcnet-client/NSmithy.Examples.GrpcStreaming.GrpcNetClient.csproj --no-cache --force
     dotnet restore examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj --no-cache --force
     # gRPC examples need two build passes: the first generates the .proto file via the
     # smithy build, the second picks it up via the static <Protobuf> glob and compiles
     # it with Grpc.Tools. (MSBuild evaluates Protobuf_Compile's item condition at
     # graph-build time, before dynamic items added inside target bodies are visible.)
-    dotnet build examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj --verbosity minimal 2>/dev/null || true
-    dotnet build examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj --verbosity minimal 2>/dev/null || true
+    dotnet build examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj --verbosity minimal >/dev/null 2>&1 || true
+    dotnet build examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj --verbosity minimal >/dev/null 2>&1 || true
+    dotnet build examples/grpc-streaming/grpc-streaming.slnx --verbosity minimal >/dev/null 2>&1 || true
     dotnet build examples/grpc-streaming/grpc-streaming.slnx --verbosity minimal
 
 ci: check-format build test pack

--- a/packages/NSmithy.Client/ContextKey.cs
+++ b/packages/NSmithy.Client/ContextKey.cs
@@ -1,0 +1,23 @@
+namespace NSmithy.Client;
+
+public abstract class ContextKey(string name, Type valueType) : IEquatable<ContextKey>
+{
+    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+
+    public Type ValueType { get; } =
+        valueType ?? throw new ArgumentNullException(nameof(valueType));
+
+    public bool Equals(ContextKey? other) =>
+        other is not null
+        && ValueType == other.ValueType
+        && StringComparer.Ordinal.Equals(Name, other.Name);
+
+    public override bool Equals(object? obj) => obj is ContextKey other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(ValueType, StringComparer.Ordinal.GetHashCode(Name));
+
+    public override string ToString() => Name;
+}
+
+public sealed class ContextKey<T>(string name) : ContextKey(name, typeof(T));

--- a/packages/NSmithy.Client/IClientInterceptor.cs
+++ b/packages/NSmithy.Client/IClientInterceptor.cs
@@ -1,0 +1,20 @@
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+public interface IClientInterceptor
+{
+    void OnBeforeExecution(SmithyContext context) { }
+
+    void OnBeforeSerialization(SmithyContext context, object? input) { }
+
+    SmithyHttpRequest OnBeforeSigning(SmithyContext context, SmithyHttpRequest request) => request;
+
+    SmithyHttpRequest OnBeforeTransmit(SmithyContext context, SmithyHttpRequest request) => request;
+
+    void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response) { }
+
+    void OnAfterDeserialization(SmithyContext context, object? output) { }
+
+    void OnAfterExecution(SmithyContext context) { }
+}

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -22,6 +22,9 @@ public class SmithyClientConfig
     /// <summary>Extra middleware prepended to the operation pipeline.</summary>
     public IList<ISmithyClientMiddleware> Middleware { get; } = [];
 
+    /// <summary>Protocol-agnostic hooks for observing and modifying client execution.</summary>
+    public IList<IClientInterceptor> Interceptors { get; } = [];
+
     /// <summary>
     /// Configured auth schemes. The resolver installs the first scheme the service models for which
     /// a matching scheme is configured here; an empty list means anonymous access.

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -1,0 +1,198 @@
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+public sealed class SmithyClientRuntime(
+    IHttpTransport transport,
+    IEnumerable<IClientInterceptor>? interceptors = null,
+    IEnumerable<ISmithyClientMiddleware>? middlewares = null
+)
+{
+    private readonly IHttpTransport transport =
+        transport ?? throw new ArgumentNullException(nameof(transport));
+    private readonly IReadOnlyList<IClientInterceptor> interceptors = [.. interceptors ?? []];
+    private readonly IReadOnlyList<ISmithyClientMiddleware> middlewares = [.. middlewares ?? []];
+
+    public async Task<TOutput> InvokeAsync<TInput, TOutput>(
+        string serviceName,
+        string operationName,
+        IOperationProtocol<TInput, TOutput> protocol,
+        TInput input,
+        Action<SmithyHttpRequest>? modifyRequest = null,
+        SmithyErrorDeserializer? errorDeserializer = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentNullException.ThrowIfNull(protocol);
+
+        var context = CreateContext(serviceName, operationName);
+        foreach (var interceptor in interceptors)
+        {
+            interceptor.OnBeforeExecution(context);
+        }
+
+        try
+        {
+            foreach (var interceptor in interceptors)
+            {
+                interceptor.OnBeforeSerialization(context, input);
+            }
+
+            var request = protocol.SerializeRequest(input);
+            modifyRequest?.Invoke(request);
+            var response = await SendAsync(
+                    context,
+                    serviceName,
+                    operationName,
+                    request,
+                    errorDeserializer,
+                    protocol.IsErrorResponse,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            var output = protocol.DeserializeResponse(response);
+            for (var i = interceptors.Count - 1; i >= 0; i--)
+            {
+                interceptors[i].OnAfterDeserialization(context, output);
+            }
+
+            return output;
+        }
+        finally
+        {
+            for (var i = interceptors.Count - 1; i >= 0; i--)
+            {
+                interceptors[i].OnAfterExecution(context);
+            }
+        }
+    }
+
+    public Task<SmithyHttpResponse> InvokeAsync(
+        string serviceName,
+        string operationName,
+        SmithyHttpRequest request,
+        SmithyErrorDeserializer? errorDeserializer = null,
+        Func<SmithyHttpResponse, bool>? isErrorResponse = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var context = CreateContext(serviceName, operationName);
+        foreach (var interceptor in interceptors)
+        {
+            interceptor.OnBeforeExecution(context);
+        }
+
+        return InvokeWithCompletionAsync();
+
+        async Task<SmithyHttpResponse> InvokeWithCompletionAsync()
+        {
+            try
+            {
+                return await SendAsync(
+                        context,
+                        serviceName,
+                        operationName,
+                        request,
+                        errorDeserializer,
+                        isErrorResponse,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                for (var i = interceptors.Count - 1; i >= 0; i--)
+                {
+                    interceptors[i].OnAfterExecution(context);
+                }
+            }
+        }
+    }
+
+    private async Task<SmithyHttpResponse> SendAsync(
+        SmithyContext context,
+        string serviceName,
+        string operationName,
+        SmithyHttpRequest request,
+        SmithyErrorDeserializer? errorDeserializer,
+        Func<SmithyHttpResponse, bool>? isErrorResponse,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var interceptor in interceptors)
+        {
+            request = interceptor.OnBeforeSigning(context, request);
+        }
+
+        foreach (var interceptor in interceptors)
+        {
+            request = interceptor.OnBeforeTransmit(context, request);
+        }
+
+        var operationRequest = new SmithyOperationRequest(serviceName, operationName, request);
+        var operationResponse = await BuildPipeline(0)
+            .Invoke(operationRequest, cancellationToken)
+            .ConfigureAwait(false);
+        var response = operationResponse.Response;
+
+        for (var i = interceptors.Count - 1; i >= 0; i--)
+        {
+            interceptors[i].OnAfterTransmit(context, response);
+        }
+
+        var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
+        if (!isError)
+        {
+            return response;
+        }
+
+        if (errorDeserializer is not null)
+        {
+            var error = await errorDeserializer(response, cancellationToken).ConfigureAwait(false);
+            if (error is not null)
+            {
+                throw error;
+            }
+        }
+
+        throw new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+    }
+
+    private SmithyOperationNext BuildPipeline(int index)
+    {
+        if (index >= middlewares.Count)
+        {
+            return async (request, cancellationToken) =>
+            {
+                var response = await transport
+                    .SendAsync(request.Request, cancellationToken)
+                    .ConfigureAwait(false);
+                return new SmithyOperationResponse(
+                    request.ServiceName,
+                    request.OperationName,
+                    response
+                );
+            };
+        }
+
+        var current = middlewares[index];
+        var next = BuildPipeline(index + 1);
+        return (request, cancellationToken) =>
+            current.InvokeAsync(request, next, cancellationToken);
+    }
+
+    private static SmithyContext CreateContext(string serviceName, string operationName)
+    {
+        var context = new SmithyContext();
+        context.Set(SmithyContextKeys.ServiceName, serviceName);
+        context.Set(SmithyContextKeys.OperationName, operationName);
+        return context;
+    }
+}

--- a/packages/NSmithy.Client/SmithyContext.cs
+++ b/packages/NSmithy.Client/SmithyContext.cs
@@ -1,0 +1,48 @@
+namespace NSmithy.Client;
+
+public sealed class SmithyContext
+{
+    private readonly Dictionary<ContextKey, object?> values = [];
+
+    public void Set<T>(ContextKey<T> key, T value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        values[key] = value;
+    }
+
+    public bool TryGet<T>(ContextKey<T> key, out T value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (!values.TryGetValue(key, out var rawValue))
+        {
+            value = default!;
+            return false;
+        }
+
+        if (rawValue is T typedValue)
+        {
+            value = typedValue;
+            return true;
+        }
+
+        if (rawValue is null && default(T) is null)
+        {
+            value = default!;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    public T Get<T>(ContextKey<T> key)
+    {
+        if (TryGet(key, out T value))
+        {
+            return value;
+        }
+
+        throw new KeyNotFoundException($"No Smithy context value was found for '{key.Name}'.");
+    }
+}

--- a/packages/NSmithy.Client/SmithyContextKeys.cs
+++ b/packages/NSmithy.Client/SmithyContextKeys.cs
@@ -1,0 +1,8 @@
+namespace NSmithy.Client;
+
+public static class SmithyContextKeys
+{
+    public static ContextKey<string> ServiceName { get; } = new("smithy.serviceName");
+
+    public static ContextKey<string> OperationName { get; } = new("smithy.operationName");
+}

--- a/packages/NSmithy.Client/SmithyOperationInvoker.cs
+++ b/packages/NSmithy.Client/SmithyOperationInvoker.cs
@@ -7,70 +7,22 @@ public sealed class SmithyOperationInvoker(
     IEnumerable<ISmithyClientMiddleware>? middlewares = null
 )
 {
-    private readonly IHttpTransport transport =
-        transport ?? throw new ArgumentNullException(nameof(transport));
-    private readonly IReadOnlyList<ISmithyClientMiddleware> middlewares = [.. middlewares ?? []];
+    private readonly SmithyClientRuntime runtime = new(transport, middlewares: middlewares);
 
-    public async Task<SmithyHttpResponse> InvokeAsync(
+    public Task<SmithyHttpResponse> InvokeAsync(
         string serviceName,
         string operationName,
         SmithyHttpRequest request,
         SmithyErrorDeserializer? errorDeserializer = null,
         Func<SmithyHttpResponse, bool>? isErrorResponse = null,
         CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
-        ArgumentNullException.ThrowIfNull(request);
-
-        var operationRequest = new SmithyOperationRequest(serviceName, operationName, request);
-        var operationResponse = await BuildPipeline(0)
-            .Invoke(operationRequest, cancellationToken)
-            .ConfigureAwait(false);
-        var response = operationResponse.Response;
-
-        // Whether a response is an error is a protocol decision (HTTP status for REST/rpcv2Cbor,
-        // the grpc-status trailer for gRPC), supplied by the caller. The default preserves the
-        // HTTP convention for callers that don't provide one.
-        var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
-        if (!isError)
-        {
-            return response;
-        }
-
-        if (errorDeserializer is not null)
-        {
-            var error = await errorDeserializer(response, cancellationToken).ConfigureAwait(false);
-            if (error is not null)
-            {
-                throw error;
-            }
-        }
-
-        throw new SmithyClientException(response.StatusCode, response.ReasonPhrase);
-    }
-
-    private SmithyOperationNext BuildPipeline(int index)
-    {
-        if (index >= middlewares.Count)
-        {
-            return async (request, cancellationToken) =>
-            {
-                var response = await transport
-                    .SendAsync(request.Request, cancellationToken)
-                    .ConfigureAwait(false);
-                return new SmithyOperationResponse(
-                    request.ServiceName,
-                    request.OperationName,
-                    response
-                );
-            };
-        }
-
-        var current = middlewares[index];
-        var next = BuildPipeline(index + 1);
-        return (request, cancellationToken) =>
-            current.InvokeAsync(request, next, cancellationToken);
-    }
+    ) =>
+        runtime.InvokeAsync(
+            serviceName,
+            operationName,
+            request,
+            errorDeserializer,
+            isErrorResponse,
+            cancellationToken
+        );
 }

--- a/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using NSmithy.Client;
+using NSmithy.Core.Serde;
 using NSmithy.Http;
 
 namespace NSmithy.Tests.Client;
@@ -121,6 +122,94 @@ public sealed class SmithyOperationInvokerTests
         Assert.Equal(2, transport.Attempts);
     }
 
+    [Fact]
+    public async Task RuntimeRunsInterceptorsAroundTypedUnaryExecution()
+    {
+        List<string> calls = [];
+        var interceptor = new RecordingInterceptor("one", calls);
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(transport, [interceptor]);
+
+        var output = await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("output", output);
+        Assert.Equal(
+            [
+                "one:before-execution:Weather.GetForecast",
+                "one:before-serialization:input",
+                "one:before-signing:/input",
+                "one:before-transmit:/input",
+                "one:after-transmit:OK",
+                "one:after-deserialization:output",
+                "one:after-execution",
+            ],
+            calls
+        );
+        Assert.Equal("/input", transport.Request.RequestUri);
+        Assert.Equal(["signed"], transport.Request.Headers["x-smithy-test"]);
+    }
+
+    [Fact]
+    public async Task RuntimeRunsAfterInterceptorsInReverseOrder()
+    {
+        List<string> calls = [];
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            [new RecordingInterceptor("one", calls), new RecordingInterceptor("two", calls)]
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal(
+            [
+                "one:before-execution:Weather.GetForecast",
+                "two:before-execution:Weather.GetForecast",
+                "one:before-serialization:input",
+                "two:before-serialization:input",
+                "one:before-signing:/input",
+                "two:before-signing:/input",
+                "one:before-transmit:/input",
+                "two:before-transmit:/input",
+                "two:after-transmit:OK",
+                "one:after-transmit:OK",
+                "two:after-deserialization:output",
+                "one:after-deserialization:output",
+                "two:after-execution",
+                "one:after-execution",
+            ],
+            calls
+        );
+    }
+
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -167,5 +256,87 @@ public sealed class SmithyOperationInvokerTests
             Attempts++;
             return Task.FromResult(responses[index]);
         }
+    }
+
+    private sealed class RecordingInterceptor(string name, List<string> calls) : IClientInterceptor
+    {
+        public void OnBeforeExecution(SmithyContext context)
+        {
+            calls.Add(
+                $"{name}:before-execution:{context.Get(SmithyContextKeys.ServiceName)}.{context.Get(SmithyContextKeys.OperationName)}"
+            );
+        }
+
+        public void OnBeforeSerialization(SmithyContext context, object? input)
+        {
+            calls.Add($"{name}:before-serialization:{input}");
+        }
+
+        public SmithyHttpRequest OnBeforeSigning(SmithyContext context, SmithyHttpRequest request)
+        {
+            calls.Add($"{name}:before-signing:{request.RequestUri}");
+            request.Headers["x-smithy-test"] = ["signed"];
+            return request;
+        }
+
+        public SmithyHttpRequest OnBeforeTransmit(SmithyContext context, SmithyHttpRequest request)
+        {
+            calls.Add($"{name}:before-transmit:{request.RequestUri}");
+            return request;
+        }
+
+        public void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response)
+        {
+            calls.Add($"{name}:after-transmit:{response.ReasonPhrase}");
+        }
+
+        public void OnAfterDeserialization(SmithyContext context, object? output)
+        {
+            calls.Add($"{name}:after-deserialization:{output}");
+        }
+
+        public void OnAfterExecution(SmithyContext context)
+        {
+            calls.Add($"{name}:after-execution");
+        }
+    }
+
+    private sealed class TextProtocol : IOperationProtocol<string, string>
+    {
+        public SmithyHttpRequest SerializeRequest(string input) =>
+            new(HttpMethod.Post, $"/{input}");
+
+        public string DeserializeResponse(SmithyHttpResponse response) => "output";
+
+        public string DeserializeRequest(SmithyHttpRequest request) => request.RequestUri;
+
+        public SmithyHttpResponse SerializeResponse(string output) =>
+            new(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes(output),
+                EmptyHeaders,
+                EmptyHeaders
+            );
+
+        public bool IsErrorResponse(SmithyHttpResponse response) => (int)response.StatusCode >= 400;
+
+        public string? GetErrorDiscriminator(SmithyHttpResponse response) => null;
+
+        public bool RequiresErrorDiscriminator => false;
+
+        public bool SupportsHttpStatusErrorFallback => true;
+
+        public TError DeserializeError<TError>(
+            Schema<TError> errorSchema,
+            SmithyHttpResponse response
+        ) => throw new NotSupportedException();
+
+        public SmithyHttpResponse SerializeError<TError>(
+            Schema<TError> errorSchema,
+            TError value,
+            string errorShapeId,
+            int statusCode
+        ) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- add SmithyClientRuntime plus typed context/interceptor primitives for unary client execution
- generate unary clients against the new runtime while keeping SmithyOperationInvoker as a compatibility wrapper
- fix refresh-examples cleanup/priming for grpc-streaming grpcnet projects

## Verification
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj
- just build
- just refresh-examples