### PR TITLE
feat: resolve client auth as interceptors

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -190,9 +190,9 @@ public final class ClientGenerator implements Runnable {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient, endpoint),"
-                          + " config.Interceptors,"
-                          + " SmithyAuthSchemeResolver.Resolve(endpoint, $L, ModeledAuthSchemes,"
-                          + " config.AuthSchemes, config.Middleware));",
+                          + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
+                          + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
+                          + " config.Middleware);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -236,9 +236,9 @@ public final class ClientGenerator implements Runnable {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient, endpoint),"
-                          + " config.Interceptors,"
-                          + " SmithyAuthSchemeResolver.Resolve(endpoint, $L, ModeledAuthSchemes,"
-                          + " config.AuthSchemes, config.Middleware));",
+                          + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
+                          + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
+                          + " config.Middleware);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {

--- a/packages/NSmithy.Aws/AwsSigV4AuthScheme.cs
+++ b/packages/NSmithy.Aws/AwsSigV4AuthScheme.cs
@@ -26,4 +26,10 @@ public sealed class AwsSigV4AuthScheme(
         ArgumentNullException.ThrowIfNull(context);
         return new AwsSigV4Middleware(context.Endpoint, service, region, credentialsProvider);
     }
+
+    public IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return new AwsSigV4Middleware(context.Endpoint, service, region, credentialsProvider);
+    }
 }

--- a/packages/NSmithy.Aws/AwsSigV4Middleware.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Middleware.cs
@@ -12,7 +12,7 @@ public sealed class AwsSigV4Middleware(
     string region,
     IAwsCredentialsProvider credentialsProvider,
     TimeProvider? timeProvider = null
-) : ISmithyClientMiddleware
+) : ISmithyClientMiddleware, IClientInterceptor
 {
     private const string Algorithm = "AWS4-HMAC-SHA256";
     private static readonly DateTimeFormatInfo InvariantDateTime = CultureInfo
@@ -50,6 +50,19 @@ public sealed class AwsSigV4Middleware(
             .ConfigureAwait(false);
         Sign(request.Request, credentials, timeProvider.GetUtcNow());
         return await nextOperation(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var credentials = await credentialsProvider
+            .GetCredentialsAsync(cancellationToken)
+            .ConfigureAwait(false);
+        Sign(request, credentials, timeProvider.GetUtcNow());
+        return request;
     }
 
     internal void Sign(SmithyHttpRequest request, AwsCredentials credentials, DateTimeOffset now)

--- a/packages/NSmithy.Client/HeaderAuthMiddleware.cs
+++ b/packages/NSmithy.Client/HeaderAuthMiddleware.cs
@@ -1,8 +1,10 @@
+using NSmithy.Http;
+
 namespace NSmithy.Client;
 
 /// <summary>Installs a single request header carrying a credential, then calls the next middleware.</summary>
 internal sealed class HeaderAuthMiddleware(string headerName, string headerValue)
-    : ISmithyClientMiddleware
+    : ISmithyAuthHandler
 {
     private readonly string headerName = string.IsNullOrWhiteSpace(headerName)
         ? throw new ArgumentException("Header name must be set.", nameof(headerName))
@@ -22,5 +24,15 @@ internal sealed class HeaderAuthMiddleware(string headerName, string headerValue
 
         request.Request.Headers[headerName] = [headerValue];
         return nextOperation(request, cancellationToken);
+    }
+
+    public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        request.Headers[headerName] = [headerValue];
+        return ValueTask.FromResult(request);
     }
 }

--- a/packages/NSmithy.Client/HttpApiKeyAuthScheme.cs
+++ b/packages/NSmithy.Client/HttpApiKeyAuthScheme.cs
@@ -48,6 +48,17 @@ public sealed class HttpApiKeyAuthScheme : ISmithyAuthScheme
     public ISmithyClientMiddleware CreateMiddleware(SmithyAuthSchemeContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    public IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    private ISmithyAuthHandler CreateAuthHandler()
+    {
         return location switch
         {
             ApiKeyLocation.Header => new HeaderAuthMiddleware(
@@ -55,7 +66,7 @@ public sealed class HttpApiKeyAuthScheme : ISmithyAuthScheme
                 scheme is null ? apiKey : $"{scheme} {apiKey}"
             ),
             ApiKeyLocation.Query => new QueryParameterAuthMiddleware(name, apiKey),
-            _ => throw new ArgumentOutOfRangeException(nameof(context)),
+            _ => throw new ArgumentOutOfRangeException(nameof(location)),
         };
     }
 }

--- a/packages/NSmithy.Client/HttpBasicAuthScheme.cs
+++ b/packages/NSmithy.Client/HttpBasicAuthScheme.cs
@@ -20,6 +20,17 @@ public sealed class HttpBasicAuthScheme(string username, string password) : ISmi
     public ISmithyClientMiddleware CreateMiddleware(SmithyAuthSchemeContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    public IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    private HeaderAuthMiddleware CreateAuthHandler()
+    {
         var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
         return new HeaderAuthMiddleware("Authorization", $"Basic {credentials}");
     }

--- a/packages/NSmithy.Client/HttpBearerAuthScheme.cs
+++ b/packages/NSmithy.Client/HttpBearerAuthScheme.cs
@@ -14,6 +14,17 @@ public sealed class HttpBearerAuthScheme(string token) : ISmithyAuthScheme
     public ISmithyClientMiddleware CreateMiddleware(SmithyAuthSchemeContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    public IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return CreateAuthHandler();
+    }
+
+    private HeaderAuthMiddleware CreateAuthHandler()
+    {
         return new HeaderAuthMiddleware("Authorization", $"Bearer {token}");
     }
 }

--- a/packages/NSmithy.Client/IClientInterceptor.cs
+++ b/packages/NSmithy.Client/IClientInterceptor.cs
@@ -8,9 +8,17 @@ public interface IClientInterceptor
 
     void OnBeforeSerialization(SmithyContext context, object? input) { }
 
-    SmithyHttpRequest OnBeforeSigning(SmithyContext context, SmithyHttpRequest request) => request;
+    ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    ) => ValueTask.FromResult(request);
 
-    SmithyHttpRequest OnBeforeTransmit(SmithyContext context, SmithyHttpRequest request) => request;
+    ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    ) => ValueTask.FromResult(request);
 
     void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response) { }
 

--- a/packages/NSmithy.Client/ISmithyAuthHandler.cs
+++ b/packages/NSmithy.Client/ISmithyAuthHandler.cs
@@ -1,0 +1,3 @@
+namespace NSmithy.Client;
+
+internal interface ISmithyAuthHandler : ISmithyClientMiddleware, IClientInterceptor;

--- a/packages/NSmithy.Client/ISmithyAuthScheme.cs
+++ b/packages/NSmithy.Client/ISmithyAuthScheme.cs
@@ -13,6 +13,9 @@ public interface ISmithyAuthScheme
     string SchemeId { get; }
 
     ISmithyClientMiddleware CreateMiddleware(SmithyAuthSchemeContext context);
+
+    IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context) =>
+        new MiddlewareClientInterceptor(CreateMiddleware(context));
 }
 
 public sealed record SmithyAuthSchemeContext(Uri Endpoint, ServiceSchema Service);

--- a/packages/NSmithy.Client/MiddlewareClientInterceptor.cs
+++ b/packages/NSmithy.Client/MiddlewareClientInterceptor.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+internal sealed class MiddlewareClientInterceptor(ISmithyClientMiddleware middleware)
+    : IClientInterceptor
+{
+    private readonly ISmithyClientMiddleware middleware =
+        middleware ?? throw new ArgumentNullException(nameof(middleware));
+
+    public async ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        SmithyHttpRequest? modifiedRequest = null;
+        var operationRequest = new SmithyOperationRequest(
+            context.Get(SmithyContextKeys.ServiceName),
+            context.Get(SmithyContextKeys.OperationName),
+            request
+        );
+
+        await middleware
+            .InvokeAsync(
+                operationRequest,
+                (nextRequest, _) =>
+                {
+                    modifiedRequest = nextRequest.Request;
+                    return Task.FromResult(
+                        new SmithyOperationResponse(
+                            nextRequest.ServiceName,
+                            nextRequest.OperationName,
+                            new SmithyHttpResponse(
+                                HttpStatusCode.OK,
+                                "OK",
+                                [],
+                                new Dictionary<string, IReadOnlyList<string>>(
+                                    StringComparer.OrdinalIgnoreCase
+                                ),
+                                new Dictionary<string, IReadOnlyList<string>>(
+                                    StringComparer.OrdinalIgnoreCase
+                                )
+                            )
+                        )
+                    );
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return modifiedRequest ?? request;
+    }
+}

--- a/packages/NSmithy.Client/QueryParameterAuthMiddleware.cs
+++ b/packages/NSmithy.Client/QueryParameterAuthMiddleware.cs
@@ -7,8 +7,7 @@ namespace NSmithy.Client;
 /// middleware. The request URI is immutable, so this rebuilds the HTTP request, carrying over
 /// method, body and headers.
 /// </summary>
-internal sealed class QueryParameterAuthMiddleware(string name, string value)
-    : ISmithyClientMiddleware
+internal sealed class QueryParameterAuthMiddleware(string name, string value) : ISmithyAuthHandler
 {
     private readonly string name = string.IsNullOrWhiteSpace(name)
         ? throw new ArgumentException("Query parameter name must be set.", nameof(name))
@@ -25,7 +24,18 @@ internal sealed class QueryParameterAuthMiddleware(string name, string value)
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(nextOperation);
 
-        var original = request.Request;
+        var signed = AddQueryParameter(request.Request);
+        return nextOperation(request with { Request = signed }, cancellationToken);
+    }
+
+    public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    ) => ValueTask.FromResult(AddQueryParameter(request));
+
+    private SmithyHttpRequest AddQueryParameter(SmithyHttpRequest original)
+    {
         var separator = original.RequestUri.Contains('?', StringComparison.Ordinal) ? '&' : '?';
         var requestUri =
             $"{original.RequestUri}{separator}{Uri.EscapeDataString(name)}={Uri.EscapeDataString(value)}";
@@ -34,6 +44,9 @@ internal sealed class QueryParameterAuthMiddleware(string name, string value)
         {
             Content = original.Content,
             ContentType = original.ContentType,
+            ExpectStreamingResponse = original.ExpectStreamingResponse,
+            StreamingContent = original.StreamingContent,
+            StreamingContentLength = original.StreamingContentLength,
         };
         foreach (var header in original.Headers)
         {
@@ -45,6 +58,6 @@ internal sealed class QueryParameterAuthMiddleware(string name, string value)
             signed.ContentHeaders[header.Key] = header.Value;
         }
 
-        return nextOperation(request with { Request = signed }, cancellationToken);
+        return signed;
     }
 }

--- a/packages/NSmithy.Client/SmithyAuthSchemeResolver.cs
+++ b/packages/NSmithy.Client/SmithyAuthSchemeResolver.cs
@@ -3,7 +3,8 @@ using NSmithy.Core.Serde;
 namespace NSmithy.Client;
 
 /// <summary>
-/// Resolves the client middleware pipeline, selecting at most one auth scheme.
+/// Resolves client auth, selecting at most one auth scheme for either the legacy middleware
+/// pipeline or the runtime interceptor pipeline.
 ///
 /// Selection follows Smithy's effective-auth-scheme order: <paramref name="modeledAuthSchemes"/>
 /// is the priority-ordered list of auth scheme ids the service models (computed at codegen time
@@ -48,6 +49,53 @@ public static class SmithyAuthSchemeResolver
             {
                 resolved.Add(
                     match.CreateMiddleware(new SmithyAuthSchemeContext(endpoint, service))
+                );
+                return resolved;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"None of the configured auth schemes [{string.Join(", ", configured.Select(s => s.SchemeId))}] "
+                + $"match the auth schemes modeled by service '{service.Id}' "
+                + $"[{string.Join(", ", modeledAuthSchemes)}]. Configure a scheme the service supports, "
+                + "or omit auth schemes for anonymous access."
+        );
+    }
+
+    public static IReadOnlyList<IClientInterceptor> ResolveInterceptors(
+        Uri endpoint,
+        ServiceSchema service,
+        IReadOnlyList<string> modeledAuthSchemes,
+        IEnumerable<ISmithyAuthScheme>? authSchemes,
+        IEnumerable<IClientInterceptor>? interceptors = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(modeledAuthSchemes);
+
+        var resolved = new List<IClientInterceptor>();
+        if (interceptors is not null)
+        {
+            resolved.AddRange(interceptors);
+        }
+
+        var configured = authSchemes?.ToList();
+        if (configured is null || configured.Count == 0)
+        {
+            // No auth configured: send anonymously. Services that require auth will reject the call.
+            return resolved;
+        }
+
+        foreach (var schemeId in modeledAuthSchemes)
+        {
+            var match = configured.FirstOrDefault(s =>
+                string.Equals(s.SchemeId, schemeId, StringComparison.Ordinal)
+            );
+            if (match is not null)
+            {
+                resolved.Add(
+                    match.CreateInterceptor(new SmithyAuthSchemeContext(endpoint, service))
                 );
                 return resolved;
             }

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -128,12 +128,16 @@ public sealed class SmithyClientRuntime(
     {
         foreach (var interceptor in interceptors)
         {
-            request = interceptor.OnBeforeSigning(context, request);
+            request = await interceptor
+                .OnBeforeSigningAsync(context, request, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         foreach (var interceptor in interceptors)
         {
-            request = interceptor.OnBeforeTransmit(context, request);
+            request = await interceptor
+                .OnBeforeTransmitAsync(context, request, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         var operationRequest = new SmithyOperationRequest(serviceName, operationName, request);

--- a/tests/NSmithy.Tests/Aws/AwsSigV4MiddlewareTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsSigV4MiddlewareTests.cs
@@ -103,6 +103,28 @@ public sealed class AwsSigV4MiddlewareTests
         Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
     }
 
+    [Fact]
+    public async Task InterceptorSignsBeforeTransmit()
+    {
+        var interceptor = new AwsSigV4Middleware(
+            new Uri("http://localhost:4566"),
+            "s3",
+            "us-east-1",
+            new StaticAwsCredentialsProvider(new AwsCredentials("test", "test", "token")),
+            TimeProvider.System
+        );
+        var context = new SmithyContext();
+        context.Set(SmithyContextKeys.ServiceName, "S3");
+        context.Set(SmithyContextKeys.OperationName, "ListBuckets");
+        var request = new SmithyHttpRequest(HttpMethod.Get, "/");
+
+        var signed = await interceptor.OnBeforeTransmitAsync(context, request);
+
+        Assert.Same(request, signed);
+        Assert.True(request.Headers.ContainsKey("Authorization"));
+        Assert.Equal(["token"], request.Headers["X-Amz-Security-Token"]);
+    }
+
     private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => utcNow;

--- a/tests/NSmithy.Tests/Client/HttpAuthSchemeTests.cs
+++ b/tests/NSmithy.Tests/Client/HttpAuthSchemeTests.cs
@@ -23,6 +23,14 @@ public sealed class HttpAuthSchemeTests
     }
 
     [Fact]
+    public async Task BearerSchemeInterceptorSetsAuthorizationHeader()
+    {
+        var request = await InterceptAsync(new HttpBearerAuthScheme("my-token"), "/");
+
+        Assert.Equal(["Bearer my-token"], request.Headers["Authorization"]);
+    }
+
+    [Fact]
     public async Task BasicSchemeSetsBase64AuthorizationHeader()
     {
         var request = await SignAsync(new HttpBasicAuthScheme("alice", "s3cret"), "/");
@@ -54,6 +62,17 @@ public sealed class HttpAuthSchemeTests
     public async Task ApiKeyQuerySchemeAppendsQueryParameter()
     {
         var request = await SignAsync(
+            new HttpApiKeyAuthScheme("api_key", "se cret", ApiKeyLocation.Query),
+            "/list?limit=10"
+        );
+
+        Assert.Equal("/list?limit=10&api_key=se%20cret", request.RequestUri);
+    }
+
+    [Fact]
+    public async Task ApiKeyQueryInterceptorAppendsQueryParameter()
+    {
+        var request = await InterceptAsync(
             new HttpApiKeyAuthScheme("api_key", "se cret", ApiKeyLocation.Query),
             "/list?limit=10"
         );
@@ -104,5 +123,20 @@ public sealed class HttpAuthSchemeTests
         );
 
         return captured!;
+    }
+
+    private static async Task<SmithyHttpRequest> InterceptAsync(
+        ISmithyAuthScheme scheme,
+        string uri
+    )
+    {
+        var context = new SmithyContext();
+        context.Set(SmithyContextKeys.ServiceName, "Svc");
+        context.Set(SmithyContextKeys.OperationName, "Op");
+
+        return await scheme
+            .CreateInterceptor(Context)
+            .OnBeforeTransmitAsync(context, new SmithyHttpRequest(HttpMethod.Get, uri))
+            .ConfigureAwait(false);
     }
 }

--- a/tests/NSmithy.Tests/Client/SmithyAuthSchemeResolverTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyAuthSchemeResolverTests.cs
@@ -26,6 +26,22 @@ public sealed class SmithyAuthSchemeResolverTests
     }
 
     [Fact]
+    public void ResolveInterceptorsWithoutAuthSchemesReturnsInterceptorsOnly()
+    {
+        var existing = new MarkerInterceptor("existing");
+
+        var resolved = SmithyAuthSchemeResolver.ResolveInterceptors(
+            Endpoint,
+            Service,
+            ["aws.auth#sigv4"],
+            authSchemes: null,
+            interceptors: [existing]
+        );
+
+        Assert.Equal([existing], resolved);
+    }
+
+    [Fact]
     public void ResolvePicksFirstModeledSchemeRegardlessOfConfiguredOrder()
     {
         // Configured in B, A order; modeled prefers A — modeled order wins.
@@ -77,6 +93,26 @@ public sealed class SmithyAuthSchemeResolverTests
     }
 
     [Fact]
+    public void ResolveInterceptorsAppendsAuthAfterUserInterceptors()
+    {
+        var existing = new MarkerInterceptor("existing");
+        var auth = new MarkerInterceptor("auth");
+        var scheme = new FakeInterceptorScheme("scheme#a", auth);
+
+        var resolved = SmithyAuthSchemeResolver.ResolveInterceptors(
+            Endpoint,
+            Service,
+            ["scheme#a"],
+            authSchemes: [scheme],
+            interceptors: [existing]
+        );
+
+        Assert.Equal(2, resolved.Count);
+        Assert.Equal("existing", Assert.IsType<MarkerInterceptor>(resolved[0]).Tag);
+        Assert.Equal("auth", Assert.IsType<MarkerInterceptor>(resolved[1]).Tag);
+    }
+
+    [Fact]
     public void ResolveThrowsWhenNoConfiguredSchemeMatchesModeledSchemes()
     {
         var scheme = new FakeScheme("scheme#c", new MarkerMiddleware("c"));
@@ -103,6 +139,17 @@ public sealed class SmithyAuthSchemeResolverTests
             middleware;
     }
 
+    private sealed class FakeInterceptorScheme(string schemeId, IClientInterceptor interceptor)
+        : ISmithyAuthScheme
+    {
+        public string SchemeId => schemeId;
+
+        public ISmithyClientMiddleware CreateMiddleware(SmithyAuthSchemeContext context) =>
+            new MarkerMiddleware("unused");
+
+        public IClientInterceptor CreateInterceptor(SmithyAuthSchemeContext context) => interceptor;
+    }
+
     private sealed class MarkerMiddleware(string tag) : ISmithyClientMiddleware
     {
         public string Tag => tag;
@@ -112,5 +159,10 @@ public sealed class SmithyAuthSchemeResolverTests
             SmithyOperationNext nextOperation,
             CancellationToken cancellationToken = default
         ) => nextOperation(request, cancellationToken);
+    }
+
+    private sealed class MarkerInterceptor(string tag) : IClientInterceptor
+    {
+        public string Tag => tag;
     }
 }

--- a/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
@@ -272,17 +272,25 @@ public sealed class SmithyOperationInvokerTests
             calls.Add($"{name}:before-serialization:{input}");
         }
 
-        public SmithyHttpRequest OnBeforeSigning(SmithyContext context, SmithyHttpRequest request)
+        public ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
         {
             calls.Add($"{name}:before-signing:{request.RequestUri}");
             request.Headers["x-smithy-test"] = ["signed"];
-            return request;
+            return ValueTask.FromResult(request);
         }
 
-        public SmithyHttpRequest OnBeforeTransmit(SmithyContext context, SmithyHttpRequest request)
+        public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
         {
             calls.Add($"{name}:before-transmit:{request.RequestUri}");
-            return request;
+            return ValueTask.FromResult(request);
         }
 
         public void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response)


### PR DESCRIPTION
## Summary
- add runtime-native auth interceptor resolution while preserving legacy middleware resolution
- wire generated unary clients to pass auth schemes as interceptors and keep config middleware as the legacy transport pipeline
- make built-in HTTP auth and SigV4 auth usable as interceptors, with middleware compatibility retained

## Verification
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj
- just build
- dotnet test NSmithy.slnx --configuration Release --no-build
- gradle :smithy-csharp-codegen:test