### PR TITLE
feat: add runtime-owned client retry

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -192,7 +192,8 @@ public final class ClientGenerator implements Runnable {
                           + " HttpClientTransport(httpClient, endpoint),"
                           + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
-                          + " config.Middleware);",
+                          + " config.Middleware,"
+                          + " config.RetryStrategy);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -238,7 +239,8 @@ public final class ClientGenerator implements Runnable {
                           + " HttpClientTransport(httpClient, endpoint),"
                           + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
-                          + " config.Middleware);",
+                          + " config.Middleware,"
+                          + " config.RetryStrategy);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -77,7 +77,7 @@ public class SmithyClientConfig
     public IEndpointResolver? EndpointResolver { get; set; }
     public IList<IClientInterceptor> Interceptors { get; }
     public IList<ISmithyAuthScheme> AuthSchemes { get; }
-    public RetryStrategy? RetryStrategy { get; set; }
+    public ISmithyRetryStrategy? RetryStrategy { get; set; }
     public TimeSpan? OperationTimeout { get; set; }
     public Func<string>? IdempotencyTokenProvider { get; set; }
 }

--- a/packages/NSmithy.Client/ISmithyRetryStrategy.cs
+++ b/packages/NSmithy.Client/ISmithyRetryStrategy.cs
@@ -1,0 +1,18 @@
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+public interface ISmithyRetryStrategy
+{
+    int MaxAttempts { get; }
+
+    bool ShouldRetry(SmithyRetryContext context);
+
+    ValueTask DelayAsync(SmithyRetryContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record SmithyRetryContext(
+    int Attempt,
+    SmithyHttpResponse Response,
+    SmithyContext ExecutionContext
+);

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -26,7 +26,7 @@ public class SmithyClientConfig
     public IList<IClientInterceptor> Interceptors { get; } = [];
 
     /// <summary>Runtime-owned retry policy. Null disables runtime retries.</summary>
-    public SmithyRetryStrategy? RetryStrategy { get; set; }
+    public ISmithyRetryStrategy? RetryStrategy { get; set; }
 
     /// <summary>
     /// Configured auth schemes. The resolver installs the first scheme the service models for which

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -25,6 +25,9 @@ public class SmithyClientConfig
     /// <summary>Protocol-agnostic hooks for observing and modifying client execution.</summary>
     public IList<IClientInterceptor> Interceptors { get; } = [];
 
+    /// <summary>Runtime-owned retry policy. Null disables runtime retries.</summary>
+    public SmithyRetryStrategy? RetryStrategy { get; set; }
+
     /// <summary>
     /// Configured auth schemes. The resolver installs the first scheme the service models for which
     /// a matching scheme is configured here; an empty list means anonymous access.

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -5,13 +5,15 @@ namespace NSmithy.Client;
 public sealed class SmithyClientRuntime(
     IHttpTransport transport,
     IEnumerable<IClientInterceptor>? interceptors = null,
-    IEnumerable<ISmithyClientMiddleware>? middlewares = null
+    IEnumerable<ISmithyClientMiddleware>? middlewares = null,
+    SmithyRetryStrategy? retryStrategy = null
 )
 {
     private readonly IHttpTransport transport =
         transport ?? throw new ArgumentNullException(nameof(transport));
     private readonly IReadOnlyList<IClientInterceptor> interceptors = [.. interceptors ?? []];
     private readonly IReadOnlyList<ISmithyClientMiddleware> middlewares = [.. middlewares ?? []];
+    private readonly SmithyRetryStrategy? retryStrategy = retryStrategy;
 
     public async Task<TOutput> InvokeAsync<TInput, TOutput>(
         string serviceName,
@@ -126,6 +128,68 @@ public sealed class SmithyClientRuntime(
         CancellationToken cancellationToken
     )
     {
+        for (var attempt = 1; ; attempt++)
+        {
+            context.Set(SmithyContextKeys.Attempt, attempt);
+            var attemptRequest = await ApplyRequestInterceptorsAsync(
+                    context,
+                    CloneRequest(request),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            var operationRequest = new SmithyOperationRequest(
+                serviceName,
+                operationName,
+                attemptRequest
+            );
+            var operationResponse = await BuildPipeline(0)
+                .Invoke(operationRequest, cancellationToken)
+                .ConfigureAwait(false);
+            var response = operationResponse.Response;
+
+            for (var i = interceptors.Count - 1; i >= 0; i--)
+            {
+                interceptors[i].OnAfterTransmit(context, response);
+            }
+
+            if (
+                retryStrategy is not null
+                && attempt < retryStrategy.MaxAttempts
+                && request.StreamingContent is null
+                && retryStrategy.ShouldRetry(response)
+            )
+            {
+                await retryStrategy.DelayAsync(attempt, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
+            if (!isError)
+            {
+                return response;
+            }
+
+            if (errorDeserializer is not null)
+            {
+                var error = await errorDeserializer(response, cancellationToken)
+                    .ConfigureAwait(false);
+                if (error is not null)
+                {
+                    throw error;
+                }
+            }
+
+            throw new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+        }
+    }
+
+    private async Task<SmithyHttpRequest> ApplyRequestInterceptorsAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken
+    )
+    {
         foreach (var interceptor in interceptors)
         {
             request = await interceptor
@@ -140,33 +204,31 @@ public sealed class SmithyClientRuntime(
                 .ConfigureAwait(false);
         }
 
-        var operationRequest = new SmithyOperationRequest(serviceName, operationName, request);
-        var operationResponse = await BuildPipeline(0)
-            .Invoke(operationRequest, cancellationToken)
-            .ConfigureAwait(false);
-        var response = operationResponse.Response;
+        return request;
+    }
 
-        for (var i = interceptors.Count - 1; i >= 0; i--)
+    private static SmithyHttpRequest CloneRequest(SmithyHttpRequest request)
+    {
+        var clone = new SmithyHttpRequest(request.Method, request.RequestUri)
         {
-            interceptors[i].OnAfterTransmit(context, response);
+            Content = request.Content,
+            StreamingContent = request.StreamingContent,
+            StreamingContentLength = request.StreamingContentLength,
+            ExpectStreamingResponse = request.ExpectStreamingResponse,
+            ContentType = request.ContentType,
+        };
+
+        foreach (var header in request.Headers)
+        {
+            clone.Headers[header.Key] = header.Value;
         }
 
-        var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
-        if (!isError)
+        foreach (var header in request.ContentHeaders)
         {
-            return response;
+            clone.ContentHeaders[header.Key] = header.Value;
         }
 
-        if (errorDeserializer is not null)
-        {
-            var error = await errorDeserializer(response, cancellationToken).ConfigureAwait(false);
-            if (error is not null)
-            {
-                throw error;
-            }
-        }
-
-        throw new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+        return clone;
     }
 
     private SmithyOperationNext BuildPipeline(int index)

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -6,14 +6,14 @@ public sealed class SmithyClientRuntime(
     IHttpTransport transport,
     IEnumerable<IClientInterceptor>? interceptors = null,
     IEnumerable<ISmithyClientMiddleware>? middlewares = null,
-    SmithyRetryStrategy? retryStrategy = null
+    ISmithyRetryStrategy? retryStrategy = null
 )
 {
     private readonly IHttpTransport transport =
         transport ?? throw new ArgumentNullException(nameof(transport));
     private readonly IReadOnlyList<IClientInterceptor> interceptors = [.. interceptors ?? []];
     private readonly IReadOnlyList<ISmithyClientMiddleware> middlewares = [.. middlewares ?? []];
-    private readonly SmithyRetryStrategy? retryStrategy = retryStrategy;
+    private readonly ISmithyRetryStrategy? retryStrategy = retryStrategy;
 
     public async Task<TOutput> InvokeAsync<TInput, TOutput>(
         string serviceName,
@@ -153,14 +153,17 @@ public sealed class SmithyClientRuntime(
                 interceptors[i].OnAfterTransmit(context, response);
             }
 
+            var retryContext = new SmithyRetryContext(attempt, response, context);
             if (
                 retryStrategy is not null
                 && attempt < retryStrategy.MaxAttempts
                 && request.StreamingContent is null
-                && retryStrategy.ShouldRetry(response)
+                && retryStrategy.ShouldRetry(retryContext)
             )
             {
-                await retryStrategy.DelayAsync(attempt, cancellationToken).ConfigureAwait(false);
+                await retryStrategy
+                    .DelayAsync(retryContext, cancellationToken)
+                    .ConfigureAwait(false);
                 continue;
             }
 

--- a/packages/NSmithy.Client/SmithyContextKeys.cs
+++ b/packages/NSmithy.Client/SmithyContextKeys.cs
@@ -5,4 +5,6 @@ public static class SmithyContextKeys
     public static ContextKey<string> ServiceName { get; } = new("smithy.serviceName");
 
     public static ContextKey<string> OperationName { get; } = new("smithy.operationName");
+
+    public static ContextKey<int> Attempt { get; } = new("smithy.attempt");
 }

--- a/packages/NSmithy.Client/SmithyRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithyRetryStrategy.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+public sealed class SmithyRetryStrategy
+{
+    private readonly Func<SmithyHttpResponse, bool> shouldRetry;
+
+    public SmithyRetryStrategy(
+        int maxAttempts = 3,
+        TimeSpan? delay = null,
+        Func<SmithyHttpResponse, bool>? shouldRetry = null
+    )
+    {
+        if (maxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxAttempts),
+                maxAttempts,
+                "Retry attempts must be greater than zero."
+            );
+        }
+
+        MaxAttempts = maxAttempts;
+        Delay = delay ?? TimeSpan.Zero;
+        this.shouldRetry = shouldRetry ?? DefaultShouldRetry;
+    }
+
+    public int MaxAttempts { get; }
+
+    public TimeSpan Delay { get; }
+
+    public bool ShouldRetry(SmithyHttpResponse response) => shouldRetry(response);
+
+    public ValueTask DelayAsync(int attempt, CancellationToken cancellationToken = default) =>
+        Delay > TimeSpan.Zero
+            ? new ValueTask(Task.Delay(Delay, cancellationToken))
+            : ValueTask.CompletedTask;
+
+    private static bool DefaultShouldRetry(SmithyHttpResponse response) =>
+        response.StatusCode == HttpStatusCode.TooManyRequests
+        || (int)response.StatusCode is >= 500 and <= 599;
+}

--- a/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
@@ -3,14 +3,14 @@ using NSmithy.Http;
 
 namespace NSmithy.Client;
 
-public sealed class SmithyRetryStrategy
+public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy
 {
-    private readonly Func<SmithyHttpResponse, bool> shouldRetry;
+    private readonly Func<SmithyRetryContext, bool> shouldRetry;
 
-    public SmithyRetryStrategy(
+    public SmithySimpleRetryStrategy(
         int maxAttempts = 3,
         TimeSpan? delay = null,
-        Func<SmithyHttpResponse, bool>? shouldRetry = null
+        Func<SmithyRetryContext, bool>? shouldRetry = null
     )
     {
         if (maxAttempts < 1)
@@ -31,14 +31,17 @@ public sealed class SmithyRetryStrategy
 
     public TimeSpan Delay { get; }
 
-    public bool ShouldRetry(SmithyHttpResponse response) => shouldRetry(response);
+    public bool ShouldRetry(SmithyRetryContext context) => shouldRetry(context);
 
-    public ValueTask DelayAsync(int attempt, CancellationToken cancellationToken = default) =>
+    public ValueTask DelayAsync(
+        SmithyRetryContext context,
+        CancellationToken cancellationToken = default
+    ) =>
         Delay > TimeSpan.Zero
             ? new ValueTask(Task.Delay(Delay, cancellationToken))
             : ValueTask.CompletedTask;
 
-    private static bool DefaultShouldRetry(SmithyHttpResponse response) =>
-        response.StatusCode == HttpStatusCode.TooManyRequests
-        || (int)response.StatusCode is >= 500 and <= 599;
+    private static bool DefaultShouldRetry(SmithyRetryContext context) =>
+        context.Response.StatusCode == HttpStatusCode.TooManyRequests
+        || (int)context.Response.StatusCode is >= 500 and <= 599;
 }

--- a/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
@@ -231,7 +231,7 @@ public sealed class SmithyOperationInvokerTests
         );
         var runtime = new SmithyClientRuntime(
             transport,
-            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
         var output = await runtime.InvokeAsync(
@@ -269,7 +269,7 @@ public sealed class SmithyOperationInvokerTests
         var runtime = new SmithyClientRuntime(
             transport,
             [new AttemptRecordingInterceptor(attempts)],
-            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
         await runtime.InvokeAsync(
@@ -305,7 +305,7 @@ public sealed class SmithyOperationInvokerTests
         var runtime = new SmithyClientRuntime(
             transport,
             [new QueryAppendingInterceptor()],
-            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
         await runtime.InvokeAsync(
@@ -343,7 +343,7 @@ public sealed class SmithyOperationInvokerTests
         );
         var runtime = new SmithyClientRuntime(
             transport,
-            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
         var request = new SmithyHttpRequest(HttpMethod.Post, "/upload")
         {

--- a/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyOperationInvokerTests.cs
@@ -210,6 +210,153 @@ public sealed class SmithyOperationInvokerTests
         );
     }
 
+    [Fact]
+    public async Task RuntimeCanRetryTransientResponses()
+    {
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            ),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+        );
+
+        var output = await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("output", output);
+        Assert.Equal(2, transport.Attempts);
+    }
+
+    [Fact]
+    public async Task RuntimeRunsRequestInterceptorsForEachRetryAttempt()
+    {
+        List<int> attempts = [];
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            ),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            [new AttemptRecordingInterceptor(attempts)],
+            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal([1, 2], attempts);
+    }
+
+    [Fact]
+    public async Task RuntimeStartsEachRetryAttemptFromSerializedRequest()
+    {
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            ),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            [new QueryAppendingInterceptor()],
+            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal(
+            ["/input?attempt=1", "/input?attempt=2"],
+            transport.Requests.Select(r => r.RequestUri)
+        );
+    }
+
+    [Fact]
+    public async Task RuntimeDoesNotRetryStreamingRequestBodies()
+    {
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            ),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithyRetryStrategy(maxAttempts: 2)
+        );
+        var request = new SmithyHttpRequest(HttpMethod.Post, "/upload")
+        {
+            StreamingContent = new MemoryStream("hello"u8.ToArray()),
+        };
+
+        await Assert.ThrowsAsync<SmithyClientException>(() =>
+            runtime.InvokeAsync("Weather", "Upload", request)
+        );
+
+        Assert.Equal(1, transport.Attempts);
+    }
+
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -247,6 +394,8 @@ public sealed class SmithyOperationInvokerTests
     {
         public int Attempts { get; private set; }
 
+        public List<SmithyHttpRequest> Requests { get; } = [];
+
         public Task<SmithyHttpResponse> SendAsync(
             SmithyHttpRequest request,
             CancellationToken cancellationToken = default
@@ -254,6 +403,7 @@ public sealed class SmithyOperationInvokerTests
         {
             var index = Math.Min(Attempts, responses.Length - 1);
             Attempts++;
+            Requests.Add(request);
             return Task.FromResult(responses[index]);
         }
     }
@@ -306,6 +456,41 @@ public sealed class SmithyOperationInvokerTests
         public void OnAfterExecution(SmithyContext context)
         {
             calls.Add($"{name}:after-execution");
+        }
+    }
+
+    private sealed class AttemptRecordingInterceptor(List<int> attempts) : IClientInterceptor
+    {
+        public ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            attempts.Add(context.Get(SmithyContextKeys.Attempt));
+            request.Headers["x-smithy-attempt"] =
+            [
+                context.Get(SmithyContextKeys.Attempt).ToString(),
+            ];
+            return ValueTask.FromResult(request);
+        }
+    }
+
+    private sealed class QueryAppendingInterceptor : IClientInterceptor
+    {
+        public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var separator = request.RequestUri.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+            return ValueTask.FromResult(
+                new SmithyHttpRequest(
+                    request.Method,
+                    $"{request.RequestUri}{separator}attempt={context.Get(SmithyContextKeys.Attempt)}"
+                )
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- add SmithyRetryStrategy and wire generated clients to pass retry config into SmithyClientRuntime
- move retry execution into the client runtime so request interceptors/auth run once per attempt
- add attempt context and avoid retrying streaming request bodies without replay support

## Verification
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj
- just build
- dotnet build NSmithy.slnx --configuration Release --no-restore
- dotnet test NSmithy.slnx --configuration Release --no-build
- gradle :smithy-csharp-codegen:test