### PR TITLE
feat: expose client endpoint in runtime context

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -189,10 +189,11 @@ public final class ClientGenerator implements Runnable {
                 if (hasUnaryOperations) {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
-                          + " HttpClientTransport(httpClient, endpoint),"
+                          + " HttpClientTransport(httpClient),"
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
-                          + " config.RetryStrategy);",
+                          + " config.RetryStrategy,"
+                          + " endpoint);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -235,10 +236,11 @@ public final class ClientGenerator implements Runnable {
                 if (hasUnaryOperations) {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
-                          + " HttpClientTransport(httpClient, endpoint),"
+                          + " HttpClientTransport(httpClient),"
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
-                          + " config.RetryStrategy);",
+                          + " config.RetryStrategy,"
+                          + " endpoint);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -60,7 +60,9 @@ new WeatherClient(runtime, config);       // caller owns full execution pipeline
 
 `Endpoint` lives on config internally. The endpoint convenience constructor is
 the common path and copies the supplied endpoint into config before delegating to
-the internal config-based construction path.
+the internal config-based construction path. For static endpoints, the effective
+endpoint is resolved during construction and placed into each invocation's
+`SmithyContext`.
 
 Generated clients implement `IDisposable`. Disposal releases only resources the
 client created itself.
@@ -128,7 +130,7 @@ concurrent calls unless explicitly documented otherwise.
 
 ## Endpoint Resolution
 
-Endpoint resolution is per operation. The resolver sees operation metadata,
+Endpoint resolution can be per operation. The resolver sees operation metadata,
 client config, and typed input:
 
 ```csharp
@@ -144,8 +146,9 @@ public sealed record Endpoint(
 ```
 
 A static `Config.Endpoint` is the simplest resolver and takes precedence when
-set explicitly. Protocols and generated code apply host labels and operation
-endpoint traits through the same resolution path.
+set explicitly. Static endpoints are resolved once at construction. Protocols
+and generated code apply host labels and operation endpoint traits through the
+same resolution path when an endpoint depends on operation metadata or input.
 
 Resolved endpoints may narrow auth schemes. That lets endpoint rules and auth
 selection compose without protocol-specific branches in generated clients.

--- a/designs/http-interfaces.md
+++ b/designs/http-interfaces.md
@@ -78,7 +78,9 @@ The protocol implementation composes the transport with the codec and the
 protocol binding to produce a complete request pipeline. The generated client
 passes operation schemas and typed values into the protocol adapter; for the
 endpoint/HttpClient constructors it wraps the `HttpClient` in an
-`IHttpTransport` (`HttpClientTransport`) internally.
+`IHttpTransport` (`HttpClientTransport`) internally. The client runtime applies
+the effective endpoint to relative request URIs before handing the request to the
+transport, so `HttpClientTransport` sends the URI it receives.
 
 ## Why Not `HttpClient` Directly
 
@@ -117,14 +119,14 @@ path, so generated-client config auth/interceptors do not apply there.
 
 ## URI Construction
 
-REST protocol implementations build the request URI by combining:
+REST protocol implementations build the request URI in two layers:
 
-1. The client's endpoint (`config.Endpoint`, the endpoint constructor argument,
-   or `HttpClient.BaseAddress` for bring-your-own-`HttpClient` construction).
-2. The operation's URI template (from `@http`), with `@httpLabel` members
-   substituted.
-3. `@httpQuery` and `@httpQueryParams` members appended as query string
-   parameters.
+1. The protocol builds the operation-relative URI template (from `@http`), with
+   `@httpLabel` members substituted and `@httpQuery` / `@httpQueryParams`
+   members appended.
+2. The client runtime resolves that relative URI against the effective endpoint
+   (`config.Endpoint`, the endpoint constructor argument, or
+   `HttpClient.BaseAddress` for bring-your-own-`HttpClient` construction).
 
 URI template expansion follows the rules in
 [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570) for the subset used by

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -5,13 +5,18 @@ namespace NSmithy.Client;
 public sealed class SmithyClientRuntime(
     IHttpTransport transport,
     IEnumerable<IClientInterceptor>? interceptors = null,
-    ISmithyRetryStrategy? retryStrategy = null
+    ISmithyRetryStrategy? retryStrategy = null,
+    Uri? endpoint = null
 )
 {
     private readonly IHttpTransport transport =
         transport ?? throw new ArgumentNullException(nameof(transport));
     private readonly IReadOnlyList<IClientInterceptor> interceptors = [.. interceptors ?? []];
     private readonly ISmithyRetryStrategy? retryStrategy = retryStrategy;
+    private readonly Uri? endpoint =
+        endpoint is null || endpoint.IsAbsoluteUri
+            ? endpoint
+            : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
 
     public async Task<TOutput> InvokeAsync<TInput, TOutput>(
         string serviceName,
@@ -129,9 +134,10 @@ public sealed class SmithyClientRuntime(
         for (var attempt = 1; ; attempt++)
         {
             context.Set(SmithyContextKeys.Attempt, attempt);
+            var resolvedRequest = ApplyEndpoint(CloneRequest(request));
             var attemptRequest = await ApplyRequestInterceptorsAsync(
                     context,
-                    CloneRequest(request),
+                    resolvedRequest,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -202,9 +208,22 @@ public sealed class SmithyClientRuntime(
         return request;
     }
 
-    private static SmithyHttpRequest CloneRequest(SmithyHttpRequest request)
+    private SmithyHttpRequest ApplyEndpoint(SmithyHttpRequest request)
     {
-        var clone = new SmithyHttpRequest(request.Method, request.RequestUri)
+        if (endpoint is null || IsHttpAbsoluteUri(request.RequestUri))
+        {
+            return request;
+        }
+
+        return CloneRequest(request, ResolveRequestUri(endpoint, request.RequestUri));
+    }
+
+    private static SmithyHttpRequest CloneRequest(SmithyHttpRequest request) =>
+        CloneRequest(request, request.RequestUri);
+
+    private static SmithyHttpRequest CloneRequest(SmithyHttpRequest request, string requestUri)
+    {
+        var clone = new SmithyHttpRequest(request.Method, requestUri)
         {
             Content = request.Content,
             StreamingContent = request.StreamingContent,
@@ -226,11 +245,30 @@ public sealed class SmithyClientRuntime(
         return clone;
     }
 
-    private static SmithyContext CreateContext(string serviceName, string operationName)
+    private static string ResolveRequestUri(Uri endpoint, string requestUri)
+    {
+        var endpointText = endpoint.ToString().TrimEnd('/');
+        var requestText = requestUri.TrimStart('/');
+        return $"{endpointText}/{requestText}";
+    }
+
+    private static bool IsHttpAbsoluteUri(string requestUri)
+    {
+        return Uri.TryCreate(requestUri, UriKind.Absolute, out var uri)
+            && uri.IsAbsoluteUri
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+
+    private SmithyContext CreateContext(string serviceName, string operationName)
     {
         var context = new SmithyContext();
         context.Set(SmithyContextKeys.ServiceName, serviceName);
         context.Set(SmithyContextKeys.OperationName, operationName);
+        if (endpoint is not null)
+        {
+            context.Set(SmithyContextKeys.Endpoint, endpoint);
+        }
+
         return context;
     }
 }

--- a/packages/NSmithy.Client/SmithyContextKeys.cs
+++ b/packages/NSmithy.Client/SmithyContextKeys.cs
@@ -6,5 +6,7 @@ public static class SmithyContextKeys
 
     public static ContextKey<string> OperationName { get; } = new("smithy.operationName");
 
+    public static ContextKey<Uri> Endpoint { get; } = new("smithy.endpoint");
+
     public static ContextKey<int> Attempt { get; } = new("smithy.attempt");
 }

--- a/packages/NSmithy.Http/HttpClientTransport.cs
+++ b/packages/NSmithy.Http/HttpClientTransport.cs
@@ -3,17 +3,10 @@ namespace NSmithy.Http;
 public sealed class HttpClientTransport : IHttpTransport
 {
     private readonly HttpClient httpClient;
-    private readonly Uri? endpoint;
 
-    public HttpClientTransport(HttpClient httpClient, Uri? endpoint = null)
+    public HttpClientTransport(HttpClient httpClient)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        if (endpoint is not null && !endpoint.IsAbsoluteUri)
-        {
-            throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
-        }
-
-        this.endpoint = endpoint;
     }
 
     public Task<SmithyHttpResponse> SendAsync(
@@ -30,10 +23,7 @@ public sealed class HttpClientTransport : IHttpTransport
         CancellationToken cancellationToken
     )
     {
-        using var message = new HttpRequestMessage(
-            request.Method,
-            ResolveRequestUri(request.RequestUri)
-        )
+        using var message = new HttpRequestMessage(request.Method, request.RequestUri)
         {
             // Honor the HttpClient's configured HTTP version/policy. A new HttpRequestMessage
             // defaults to HTTP/1.1, which would silently downgrade gRPC (HTTP/2) requests even when
@@ -119,25 +109,6 @@ public sealed class HttpClientTransport : IHttpTransport
                 ? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
                 : ToHeaderDictionary(response.Content.Headers)
         );
-    }
-
-    private string ResolveRequestUri(string requestUri)
-    {
-        if (endpoint is null || IsHttpAbsoluteUri(requestUri))
-        {
-            return requestUri;
-        }
-
-        var endpointText = endpoint.ToString().TrimEnd('/');
-        var requestText = requestUri.TrimStart('/');
-        return $"{endpointText}/{requestText}";
-    }
-
-    private static bool IsHttpAbsoluteUri(string requestUri)
-    {
-        return Uri.TryCreate(requestUri, UriKind.Absolute, out var uri)
-            && uri.IsAbsoluteUri
-            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
     }
 
     private static void MergeTrailingHeaders(

--- a/packages/NSmithy.Http/SmithyHttpRequest.cs
+++ b/packages/NSmithy.Http/SmithyHttpRequest.cs
@@ -1,5 +1,10 @@
 namespace NSmithy.Http;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "SmithyHttpRequest preserves protocol-relative request URI text before endpoint resolution."
+)]
 public sealed class SmithyHttpRequest(HttpMethod method, string requestUri)
 {
     public HttpMethod Method { get; } = method ?? throw new ArgumentNullException(nameof(method));
@@ -10,6 +15,11 @@ public sealed class SmithyHttpRequest(HttpMethod method, string requestUri)
     public IDictionary<string, IReadOnlyList<string>> Headers { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1819:Properties should not return arrays",
+        Justification = "SmithyHttpRequest is a mutable low-level transport DTO for buffered wire bytes."
+    )]
     public byte[]? Content { get; set; }
 
     public Stream? StreamingContent { get; set; }

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -104,6 +104,108 @@ public sealed class SmithyClientRuntimeTests
     }
 
     [Fact]
+    public async Task RuntimeExposesConstructorEndpointInContext()
+    {
+        List<Uri> endpoints = [];
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var endpoint = new Uri("https://api.example.com");
+        var runtime = new SmithyClientRuntime(
+            transport,
+            [new EndpointRecordingInterceptor(endpoints)],
+            endpoint: endpoint
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal([endpoint], endpoints);
+    }
+
+    [Fact]
+    public async Task RuntimeResolvesRelativeRequestUriAgainstEndpointBeforeTransmit()
+    {
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpoint: new Uri("https://api.example.com/base")
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("https://api.example.com/base/input", transport.Request.RequestUri);
+    }
+
+    [Fact]
+    public async Task RuntimeLeavesAbsoluteRequestUriUnchanged()
+    {
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpoint: new Uri("https://api.example.com")
+        );
+
+        await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new AbsoluteUriProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("https://override.example/input", transport.Request.RequestUri);
+    }
+
+    [Fact]
+    public void RuntimeRejectsRelativeEndpoint()
+    {
+        var error = Assert.Throws<ArgumentException>(() =>
+            new SmithyClientRuntime(
+                new RecordingTransport(
+                    new SmithyHttpResponse(HttpStatusCode.OK, "OK", [], EmptyHeaders, EmptyHeaders)
+                ),
+                endpoint: new Uri("/relative", UriKind.Relative)
+            )
+        );
+
+        Assert.Equal("endpoint", error.ParamName);
+    }
+
+    [Fact]
     public async Task RuntimeRunsAfterInterceptorsInReverseOrder()
     {
         List<string> calls = [];
@@ -400,6 +502,14 @@ public sealed class SmithyClientRuntimeTests
         }
     }
 
+    private sealed class EndpointRecordingInterceptor(List<Uri> endpoints) : IClientInterceptor
+    {
+        public void OnBeforeExecution(SmithyContext context)
+        {
+            endpoints.Add(context.Get(SmithyContextKeys.Endpoint));
+        }
+    }
+
     private sealed class QueryAppendingInterceptor : IClientInterceptor
     {
         public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
@@ -418,9 +528,9 @@ public sealed class SmithyClientRuntimeTests
         }
     }
 
-    private sealed class TextProtocol : IOperationProtocol<string, string>
+    private class TextProtocol : IOperationProtocol<string, string>
     {
-        public SmithyHttpRequest SerializeRequest(string input) =>
+        public virtual SmithyHttpRequest SerializeRequest(string input) =>
             new(HttpMethod.Post, $"/{input}");
 
         public string DeserializeResponse(SmithyHttpResponse response) => "output";
@@ -455,5 +565,11 @@ public sealed class SmithyClientRuntimeTests
             string errorShapeId,
             int statusCode
         ) => throw new NotSupportedException();
+    }
+
+    private sealed class AbsoluteUriProtocol : TextProtocol
+    {
+        public override SmithyHttpRequest SerializeRequest(string input) =>
+            new(HttpMethod.Post, $"https://override.example/{input}");
     }
 }

--- a/tests/NSmithy.Tests/Http/HttpClientTransportTests.cs
+++ b/tests/NSmithy.Tests/Http/HttpClientTransportTests.cs
@@ -6,25 +6,27 @@ namespace NSmithy.Tests.Http;
 public sealed class HttpClientTransportTests
 {
     [Fact]
-    public async Task SendAsyncResolvesRelativeRequestAgainstConfiguredEndpoint()
+    public async Task SendAsyncSendsRequestUriAsProvided()
     {
-        using var httpClient = new HttpClient(new Handler())
-        {
-            BaseAddress = new Uri("https://ignored.example"),
-        };
-        var transport = new HttpClientTransport(httpClient, new Uri("https://example.test/base"));
+        using var httpClient = new HttpClient(new Handler());
+        var transport = new HttpClientTransport(httpClient);
 
-        await transport.SendAsync(new SmithyHttpRequest(HttpMethod.Get, "/forecast?units=metric"));
+        await transport.SendAsync(
+            new SmithyHttpRequest(HttpMethod.Get, "https://example.test/base/forecast?units=metric")
+        );
     }
 
     [Fact]
     public async Task SendAsyncFoldsTrailingHeadersIntoResponseHeaders()
     {
         using var httpClient = new HttpClient(new TrailerHandler());
-        var transport = new HttpClientTransport(httpClient, new Uri("https://example.test"));
+        var transport = new HttpClientTransport(httpClient);
 
         var response = await transport.SendAsync(
-            new SmithyHttpRequest(HttpMethod.Post, "/example.greeter.Greeter/SayHello")
+            new SmithyHttpRequest(
+                HttpMethod.Post,
+                "https://example.test/example.greeter.Greeter/SayHello"
+            )
         );
 
         // grpc-status arrives as an HTTP/2 trailer; the transport surfaces it as a header.

--- a/website/src/content/docs/guides/client-configuration/interceptors.md
+++ b/website/src/content/docs/guides/client-configuration/interceptors.md
@@ -44,3 +44,7 @@ Available hooks:
 | `OnAfterExecution` | Run cleanup or final observation after the call completes. |
 
 Before hooks run in configured order. After hooks run in reverse order.
+
+The per-call `SmithyContext` includes `ServiceName`, `OperationName`, `Attempt`,
+and, for generated clients constructed with an endpoint or `HttpClient`,
+`Endpoint`.

--- a/website/src/content/docs/guides/client-configuration/transport.md
+++ b/website/src/content/docs/guides/client-configuration/transport.md
@@ -39,6 +39,9 @@ var client = new WeatherClient(httpClient);
 If both `config.Endpoint` and `HttpClient.BaseAddress` are set,
 `config.Endpoint` wins.
 
+For unary HTTP operations, the client runtime resolves operation-relative request
+URIs against the effective endpoint before handing the request to the transport.
+
 For long-lived applications, prefer the generated
 [`Add{Service}Client`](/smithy-dotnet/guides/client-configuration/dependency-injection/)
 helper. It uses `IHttpClientFactory` and applies protocol-specific HTTP settings,


### PR DESCRIPTION
## Summary
- add an Endpoint context key for client runtime invocations
- pass generated clients' effective constructor endpoint into SmithyClientRuntime
- expose the endpoint to interceptors while keeping endpoint resolution constructor-based
- document the scoped behavior and target endpoint-resolution direction

## Validation
- just fmt
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj
- gradle :smithy-csharp-codegen:test
- just codegen
- dotnet build NSmithy.slnx --configuration Release --no-restore
- dotnet test NSmithy.slnx --configuration Release --no-build
- npm run build