### PR TITLE
refactor: precompute client operation bindings

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -145,7 +145,7 @@ public final class ClientGenerator implements Runnable {
               }
             } else {
               writer.write(
-                  "private readonly IOperationProtocol<$L, $L> $LProtocol;",
+                  "private readonly SmithyOperationBinding<$L, $L> $LBinding;",
                   SchemaGenerator.operationShapeType(context, op.getInputShape()),
                   SchemaGenerator.operationShapeType(context, op.getOutputShape()),
                   CSharpNaming.typeName(op.getId().getName()));
@@ -466,9 +466,16 @@ public final class ClientGenerator implements Runnable {
         continue;
       }
       writer.write(
-          "this.$LProtocol = serviceProtocol.ForOperation($L);",
+          "this.$LBinding = new SmithyOperationBinding<$L, $L>($L, $L,"
+              + " serviceProtocol.ForOperation($L), $L, Deserialize$LErrorAsync);",
           CSharpNaming.typeName(op.getId().getName()),
-          SchemaGenerator.operationSchemaAccessor(context, op));
+          SchemaGenerator.operationShapeType(context, op.getInputShape()),
+          SchemaGenerator.operationShapeType(context, op.getOutputShape()),
+          CSharpNaming.formatString(service.getId().getName()),
+          CSharpNaming.formatString(op.getId().getName()),
+          SchemaGenerator.operationSchemaAccessor(context, op),
+          requestModifier(op),
+          CSharpNaming.typeName(op.getId().getName()));
     }
   }
 
@@ -534,7 +541,6 @@ public final class ClientGenerator implements Runnable {
     boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
     boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     String opName = CSharpNaming.typeName(op.getId().getName());
-    String deserName = "Deserialize" + opName + "ErrorAsync";
     String inputArg = hasInput ? "input" : "SmithyUnit.Value";
 
     writer.write("public async $L", operationSignature(sp, op));
@@ -550,24 +556,16 @@ public final class ClientGenerator implements Runnable {
 
           if (hasOutput) {
             writer.write(
-                "return await runtime.InvokeAsync($L, $L, $LProtocol, $L, $L, $L,"
+                "return await runtime.InvokeAsync($LBinding, $L,"
                     + " cancellationToken).ConfigureAwait(false);",
-                CSharpNaming.formatString(service.getId().getName()),
-                CSharpNaming.formatString(op.getId().getName()),
                 opName,
-                inputArg,
-                requestModifier(op),
-                deserName);
+                inputArg);
           } else {
             writer.write(
-                "await runtime.InvokeAsync($L, $L, $LProtocol, $L, $L, $L,"
+                "await runtime.InvokeAsync($LBinding, $L,"
                     + " cancellationToken).ConfigureAwait(false);",
-                CSharpNaming.formatString(service.getId().getName()),
-                CSharpNaming.formatString(op.getId().getName()),
                 opName,
-                inputArg,
-                requestModifier(op),
-                deserName);
+                inputArg);
             writer.write("return;");
           }
         });
@@ -725,7 +723,7 @@ public final class ClientGenerator implements Runnable {
   private void writeErrorDeserializer(Model model, OperationShape op) {
     String opName = CSharpNaming.typeName(op.getId().getName());
     String methodName = "Deserialize" + opName + "ErrorAsync";
-    String receiver = opName + "Protocol";
+    String receiver = opName + "Binding.Protocol";
     List<ShapeId> errorIds = new ArrayList<>(op.getErrors(service));
     errorIds.sort(Comparator.comparing(ShapeId::toString));
 

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -199,8 +199,11 @@ Protocols own wire behavior:
 - trailer interpretation
 
 Generated clients should not branch on protocol-specific wire rules. They bind
-operation schemas once, select the configured protocol, and pass protocol-bound
-delegates into the client lifecycle.
+operation schemas once, select the configured protocol, and precompute
+operation bindings that contain the service name, operation name,
+operation-bound protocol, request modifier, and modeled-error deserializer. The
+operation method hot path then passes the binding and typed input into the
+runtime.
 
 ## Observability
 

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -488,6 +488,12 @@ request/response codecs for rpcv2Cbor — is computed when the field is
 initialized and reused for every request. The hot path serializes through those
 precomputed objects instead of reanalyzing schema metadata.
 
+The generated client also precomputes a client-runtime operation binding per
+unary operation. That binding wraps the operation-bound protocol together with
+the service/operation names, request modifiers such as compression/checksum
+hooks, and the modeled-error deserializer. Runtime invocation receives the
+binding plus typed input, so per-call generated code stays thin.
+
 ### The client runtime
 
 `SmithyClientRuntime` owns the parts that are *not* protocol-specific:

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -19,20 +19,14 @@ public sealed class SmithyClientRuntime(
             : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
 
     public async Task<TOutput> InvokeAsync<TInput, TOutput>(
-        string serviceName,
-        string operationName,
-        IOperationProtocol<TInput, TOutput> protocol,
+        SmithyOperationBinding<TInput, TOutput> binding,
         TInput input,
-        Action<SmithyHttpRequest>? modifyRequest = null,
-        SmithyErrorDeserializer? errorDeserializer = null,
         CancellationToken cancellationToken = default
     )
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
-        ArgumentNullException.ThrowIfNull(protocol);
+        ArgumentNullException.ThrowIfNull(binding);
 
-        var context = CreateContext(serviceName, operationName);
+        var context = CreateContext(binding.ServiceName, binding.OperationName);
         foreach (var interceptor in interceptors)
         {
             interceptor.OnBeforeExecution(context);
@@ -45,20 +39,18 @@ public sealed class SmithyClientRuntime(
                 interceptor.OnBeforeSerialization(context, input);
             }
 
-            var request = protocol.SerializeRequest(input);
-            modifyRequest?.Invoke(request);
+            var request = binding.Protocol.SerializeRequest(input);
+            binding.ModifyRequest?.Invoke(request);
             var response = await SendAsync(
                     context,
-                    serviceName,
-                    operationName,
                     request,
-                    errorDeserializer,
-                    protocol.IsErrorResponse,
+                    binding.ErrorDeserializer,
+                    binding.Protocol.IsErrorResponse,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
 
-            var output = protocol.DeserializeResponse(response);
+            var output = binding.Protocol.DeserializeResponse(response);
             for (var i = interceptors.Count - 1; i >= 0; i--)
             {
                 interceptors[i].OnAfterDeserialization(context, output);
@@ -73,6 +65,29 @@ public sealed class SmithyClientRuntime(
                 interceptors[i].OnAfterExecution(context);
             }
         }
+    }
+
+    public Task<TOutput> InvokeAsync<TInput, TOutput>(
+        string serviceName,
+        string operationName,
+        IOperationProtocol<TInput, TOutput> protocol,
+        TInput input,
+        Action<SmithyHttpRequest>? modifyRequest = null,
+        SmithyErrorDeserializer? errorDeserializer = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return InvokeAsync(
+            new SmithyOperationBinding<TInput, TOutput>(
+                serviceName,
+                operationName,
+                protocol,
+                modifyRequest,
+                errorDeserializer
+            ),
+            input,
+            cancellationToken
+        );
     }
 
     public Task<SmithyHttpResponse> InvokeAsync(
@@ -102,8 +117,6 @@ public sealed class SmithyClientRuntime(
             {
                 return await SendAsync(
                         context,
-                        serviceName,
-                        operationName,
                         request,
                         errorDeserializer,
                         isErrorResponse,
@@ -123,8 +136,6 @@ public sealed class SmithyClientRuntime(
 
     private async Task<SmithyHttpResponse> SendAsync(
         SmithyContext context,
-        string serviceName,
-        string operationName,
         SmithyHttpRequest request,
         SmithyErrorDeserializer? errorDeserializer,
         Func<SmithyHttpResponse, bool>? isErrorResponse,

--- a/packages/NSmithy.Client/SmithyOperationBinding.cs
+++ b/packages/NSmithy.Client/SmithyOperationBinding.cs
@@ -1,0 +1,35 @@
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+public sealed class SmithyOperationBinding<TInput, TOutput>
+{
+    public SmithyOperationBinding(
+        string serviceName,
+        string operationName,
+        IOperationProtocol<TInput, TOutput> protocol,
+        Action<SmithyHttpRequest>? modifyRequest = null,
+        SmithyErrorDeserializer? errorDeserializer = null
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentNullException.ThrowIfNull(protocol);
+
+        ServiceName = serviceName;
+        OperationName = operationName;
+        Protocol = protocol;
+        ModifyRequest = modifyRequest;
+        ErrorDeserializer = errorDeserializer;
+    }
+
+    public string ServiceName { get; }
+
+    public string OperationName { get; }
+
+    public IOperationProtocol<TInput, TOutput> Protocol { get; }
+
+    public Action<SmithyHttpRequest>? ModifyRequest { get; }
+
+    public SmithyErrorDeserializer? ErrorDeserializer { get; }
+}

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -104,6 +104,33 @@ public sealed class SmithyClientRuntimeTests
     }
 
     [Fact]
+    public async Task RuntimeInvokesOperationBinding()
+    {
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(transport);
+        var binding = new SmithyOperationBinding<string, string>(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            request => request.Headers["x-test-binding"] = ["true"]
+        );
+
+        var output = await runtime.InvokeAsync(binding, "input");
+
+        Assert.Equal("output", output);
+        Assert.Equal("/input", transport.Request.RequestUri);
+        Assert.Equal(["true"], transport.Request.Headers["x-test-binding"]);
+    }
+
+    [Fact]
     public async Task RuntimeExposesConstructorEndpointInContext()
     {
         List<Uri> endpoints = [];


### PR DESCRIPTION
## Summary
- add SmithyOperationBinding for precomputed unary operation runtime metadata
- update SmithyClientRuntime and generated unary clients to invoke through bindings
- document the client-runtime binding boundary

## Validation
- dotnet build packages/NSmithy.Client/NSmithy.Client.csproj --configuration Release --no-restore
- gradle :smithy-csharp-codegen:test
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj --configuration Release --no-restore
- just codegen
- dotnet build NSmithy.slnx --configuration Release --no-restore
- dotnet test NSmithy.slnx --configuration Release --no-build
- just fmt
- git diff --check