### PR TITLE
refactor: move modeled error dispatch to operation protocols

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -385,11 +385,6 @@ public final class ClientGenerator implements Runnable {
           writer.write("");
 
           for (OperationShape op : operations) writeOperationMethod(sp, model, op);
-          for (OperationShape op : operations) {
-            if (!isEventStreamOperation(model, op)) {
-              writeErrorDeserializer(model, op);
-            }
-          }
         });
     writer.write("");
     writeConfigClass(typeName);
@@ -467,15 +462,14 @@ public final class ClientGenerator implements Runnable {
       }
       writer.write(
           "this.$LBinding = new SmithyOperationBinding<$L, $L>($L, $L,"
-              + " serviceProtocol.ForOperation($L), $L, Deserialize$LErrorAsync);",
+              + " serviceProtocol.ForOperation($L), $L);",
           CSharpNaming.typeName(op.getId().getName()),
           SchemaGenerator.operationShapeType(context, op.getInputShape()),
           SchemaGenerator.operationShapeType(context, op.getOutputShape()),
           CSharpNaming.formatString(service.getId().getName()),
           CSharpNaming.formatString(op.getId().getName()),
           SchemaGenerator.operationSchemaAccessor(context, op),
-          requestModifier(op),
-          CSharpNaming.typeName(op.getId().getName()));
+          requestModifier(op));
     }
   }
 
@@ -716,131 +710,6 @@ public final class ClientGenerator implements Runnable {
       statements.add("SmithyRequestModifiers.ApplyContentMd5(request)");
     }
     return "request => { " + String.join("; ", statements) + "; }";
-  }
-
-  // ---------------- error deserializer ----------------
-
-  private void writeErrorDeserializer(Model model, OperationShape op) {
-    String opName = CSharpNaming.typeName(op.getId().getName());
-    String methodName = "Deserialize" + opName + "ErrorAsync";
-    String receiver = opName + "Binding.Protocol";
-    List<ShapeId> errorIds = new ArrayList<>(op.getErrors(service));
-    errorIds.sort(Comparator.comparing(ShapeId::toString));
-
-    writer.write(
-        "private System.Threading.Tasks.ValueTask<System.Exception?> $L(SmithyHttpResponse"
-            + " response, System.Threading.CancellationToken cancellationToken)",
-        methodName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (errorIds.isEmpty()) {
-            writer.write("");
-            writer.write(
-                "return System.Threading.Tasks.ValueTask.FromResult<System.Exception?>(null);");
-            return;
-          }
-
-          // The bound protocol owns error discrimination; its RequiresErrorDiscriminator /
-          // SupportsHttpStatusErrorFallback flags adapt this uniform dispatch to REST vs rpc/gRPC.
-          writer.write("var errorType = $L.GetErrorDiscriminator(response);", receiver);
-          writer.write("if (errorType is null && $L.RequiresErrorDiscriminator)", receiver);
-          writer.openBlock(
-              "{",
-              "}",
-              () ->
-                  writer.write(
-                      "return"
-                          + " System.Threading.Tasks.ValueTask.FromResult<System.Exception?>(null);"));
-
-          writer.write("");
-          writer.write("if (errorType is not null)");
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                for (ShapeId errId : errorIds) {
-                  StructureShape err = model.expectShape(errId, StructureShape.class);
-                  // The discriminator may be a bare shape name (REST, rpcv2Cbor) or an absolute
-                  // shape id (rpcv2Cbor); accept either.
-                  writer.write(
-                      "if (string.Equals(errorType, $L, System.StringComparison.Ordinal)"
-                          + " || string.Equals(errorType, $L, System.StringComparison.Ordinal))",
-                      CSharpNaming.formatString(errId.getName()),
-                      CSharpNaming.formatString(errId.toString()));
-                  writer.openBlock("{", "}", () -> writeErrorReturn(err, receiver));
-                }
-              });
-
-          // REST-only fallback to the HTTP status code, gated at runtime by the bound protocol.
-          List<ShapeId> statusErrors =
-              errorIds.stream()
-                  .filter(id -> httpErrorCode(model.expectShape(id, StructureShape.class)) != null)
-                  .collect(Collectors.toList());
-          if (!statusErrors.isEmpty()) {
-            writer.write("");
-            writer.write("if ($L.SupportsHttpStatusErrorFallback)", receiver);
-            writer.openBlock(
-                "{",
-                "}",
-                () -> {
-                  for (ShapeId errId : statusErrors) {
-                    StructureShape err = model.expectShape(errId, StructureShape.class);
-                    writer.write("if ((int)response.StatusCode == $L)", httpErrorCode(err));
-                    writer.openBlock("{", "}", () -> writeErrorReturn(err, receiver));
-                  }
-                });
-          }
-
-          // Fallback: first error. For REST errors that carry body members, an empty body means we
-          // recognised nothing — return null so InvokeAsync throws a generic SmithyClientException.
-          // rpc/gRPC never guard on body emptiness (gated by SupportsHttpStatusErrorFallback).
-          ShapeId fallback = errorIds.get(0);
-          StructureShape err = model.expectShape(fallback, StructureShape.class);
-          boolean fallbackHasBody = !responseBodyMembers(err).isEmpty();
-          writer.write("");
-          if (fallbackHasBody) {
-            writer.write(
-                "if ($L.SupportsHttpStatusErrorFallback && response.Content.Length == 0)",
-                receiver);
-            writer.openBlock(
-                "{",
-                "}",
-                () ->
-                    writer.write(
-                        "return"
-                            + " System.Threading.Tasks.ValueTask.FromResult<System.Exception?>(null);"));
-            writer.write("");
-          }
-          writeErrorReturn(err, receiver);
-        });
-    writer.write("");
-  }
-
-  /**
-   * Functional error return: deserialize the error structure from the response (HTTP bindings +
-   * body for REST, whole CBOR/proto body for rpc/gRPC) via {@code receiver.DeserializeError(...)},
-   * where the receiver is the operation-bound protocol field.
-   */
-  private void writeErrorReturn(StructureShape err, String receiver) {
-    writer.write(
-        "return System.Threading.Tasks.ValueTask.FromResult<System.Exception?>("
-            + "$L.DeserializeError($L, response));",
-        receiver,
-        SchemaGenerator.shapeSchemaAccessor(context, err));
-  }
-
-  private static Integer httpErrorCode(StructureShape err) {
-    Integer explicit =
-        err.getTrait(software.amazon.smithy.model.traits.HttpErrorTrait.class)
-            .map(t -> t.getCode())
-            .orElse(null);
-    if (explicit != null) return explicit;
-    // Smithy default: @error("client") → 400, @error("server") → 500.
-    return err.getTrait(software.amazon.smithy.model.traits.ErrorTrait.class)
-        .map(t -> t.isClientError() ? 400 : 500)
-        .orElse(null);
   }
 
   // =====================================================================

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -4,7 +4,14 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.HttpErrorTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -26,6 +33,10 @@ public final class OperationSchemaGenerator implements Runnable {
     writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
 
     String typeName = CSharpNaming.typeName(shape.getId().getName());
+    List<ShapeId> errors =
+        shape.getErrors().stream()
+            .sorted(Comparator.comparing(ShapeId::toString))
+            .collect(Collectors.toList());
     writer.write("public static partial class $LSchema", typeName);
     writer.openBlock(
         "{",
@@ -37,12 +48,47 @@ public final class OperationSchemaGenerator implements Runnable {
               SchemaGenerator.operationShapeType(context, shape.getOutputShape()));
           writer.indent();
           writer.write(
-              "Schemas.Operation($L, $L, $L, $L);",
+              "Schemas.Operation($L, $L, $L, $L, $L);",
               SchemaGenerator.shapeIdExpr(shape.getId()),
               SchemaGenerator.operationShapeSchema(context, shape.getInputShape()),
               SchemaGenerator.operationShapeSchema(context, shape.getOutputShape()),
+              errorsLiteral(errors),
               SchemaGenerator.traitsExpr(shape.getAllTraits().values()));
           writer.dedent();
         });
+  }
+
+  private String errorsLiteral(List<ShapeId> errors) {
+    if (errors.isEmpty()) {
+      return "[]";
+    }
+
+    return "["
+        + errors.stream()
+            .map(
+                errorId -> {
+                  StructureShape error = context.model().expectShape(errorId, StructureShape.class);
+                  return "Schemas.OperationError("
+                      + SchemaGenerator.shapeIdExpr(errorId)
+                      + ", "
+                      + SchemaGenerator.shapeSchemaAccessor(context, error)
+                      + ", "
+                      + httpErrorCode(error)
+                      + ")";
+                })
+            .collect(Collectors.joining(", "))
+        + "]";
+  }
+
+  private static int httpErrorCode(StructureShape error) {
+    return error
+        .getTrait(HttpErrorTrait.class)
+        .map(HttpErrorTrait::getCode)
+        .orElseGet(
+            () ->
+                error
+                    .getTrait(ErrorTrait.class)
+                    .map(trait -> trait.isClientError() ? 400 : 500)
+                    .orElse(500));
   }
 }

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -201,9 +201,9 @@ Protocols own wire behavior:
 Generated clients should not branch on protocol-specific wire rules. They bind
 operation schemas once, select the configured protocol, and precompute
 operation bindings that contain the service name, operation name,
-operation-bound protocol, request modifier, and modeled-error deserializer. The
-operation method hot path then passes the binding and typed input into the
-runtime.
+operation-bound protocol, and request modifier. The operation-bound protocol
+owns modeled error deserialization. The operation method hot path then passes
+the binding and typed input into the runtime.
 
 ## Observability
 

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -491,20 +491,20 @@ precomputed objects instead of reanalyzing schema metadata.
 The generated client also precomputes a client-runtime operation binding per
 unary operation. That binding wraps the operation-bound protocol together with
 the service/operation names, request modifiers such as compression/checksum
-hooks, and the modeled-error deserializer. Runtime invocation receives the
-binding plus typed input, so per-call generated code stays thin.
+hooks, and other lifecycle metadata. The operation-bound protocol owns modeled
+error deserialization; operation schemas carry the modeled error descriptors it
+uses for dispatch. Runtime invocation receives the binding plus typed input, so
+per-call generated code stays thin.
 
 ### The client runtime
 
 `SmithyClientRuntime` owns the parts that are *not* protocol-specific:
 interceptors, auth signing, retry decisions, and the transport send. It is
-deliberately ignorant of wire formats. The one protocol decision it needs, "is
-this response an error?", is injected as `IOperationProtocol.IsErrorResponse`
-rather than assumed to be "HTTP 4xx", so a transport that signals failure
-differently (gRPC's `grpc-status` trailer over an HTTP 200) fits without
-changing the runtime. Error *dispatch* stays in the generated
-`Deserialize{Operation}ErrorAsync` delegate, since the set of modeled errors is
-operation-specific model data.
+deliberately ignorant of wire formats. Protocol decisions such as "is this
+response an error?" and "which modeled exception does this response represent?"
+come from the operation-bound protocol rather than runtime HTTP assumptions, so
+a transport that signals failure differently (gRPC's `grpc-status` trailer over
+an HTTP 200) fits without changing the runtime.
 
 ## HTTP Binding Values
 

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -18,15 +18,35 @@ public sealed class SmithyClientRuntime(
             ? endpoint
             : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
 
-    public async Task<TOutput> InvokeAsync<TInput, TOutput>(
+    public Task<TOutput> InvokeAsync<TInput, TOutput>(
         SmithyOperationBinding<TInput, TOutput> binding,
         TInput input,
         CancellationToken cancellationToken = default
     )
     {
         ArgumentNullException.ThrowIfNull(binding);
+        return InvokeTypedAsync(
+            binding.ServiceName,
+            binding.OperationName,
+            binding.Protocol,
+            input,
+            binding.ModifyRequest,
+            binding.Protocol.DeserializeErrorAsync,
+            cancellationToken
+        );
+    }
 
-        var context = CreateContext(binding.ServiceName, binding.OperationName);
+    private async Task<TOutput> InvokeTypedAsync<TInput, TOutput>(
+        string serviceName,
+        string operationName,
+        IOperationProtocol<TInput, TOutput> protocol,
+        TInput input,
+        Action<SmithyHttpRequest>? modifyRequest,
+        SmithyErrorDeserializer? errorDeserializer,
+        CancellationToken cancellationToken
+    )
+    {
+        var context = CreateContext(serviceName, operationName);
         foreach (var interceptor in interceptors)
         {
             interceptor.OnBeforeExecution(context);
@@ -39,18 +59,18 @@ public sealed class SmithyClientRuntime(
                 interceptor.OnBeforeSerialization(context, input);
             }
 
-            var request = binding.Protocol.SerializeRequest(input);
-            binding.ModifyRequest?.Invoke(request);
+            var request = protocol.SerializeRequest(input);
+            modifyRequest?.Invoke(request);
             var response = await SendAsync(
                     context,
                     request,
-                    binding.ErrorDeserializer,
-                    binding.Protocol.IsErrorResponse,
+                    errorDeserializer,
+                    protocol.IsErrorResponse,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
 
-            var output = binding.Protocol.DeserializeResponse(response);
+            var output = protocol.DeserializeResponse(response);
             for (var i = interceptors.Count - 1; i >= 0; i--)
             {
                 interceptors[i].OnAfterDeserialization(context, output);
@@ -77,15 +97,17 @@ public sealed class SmithyClientRuntime(
         CancellationToken cancellationToken = default
     )
     {
-        return InvokeAsync(
-            new SmithyOperationBinding<TInput, TOutput>(
-                serviceName,
-                operationName,
-                protocol,
-                modifyRequest,
-                errorDeserializer
-            ),
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentNullException.ThrowIfNull(protocol);
+
+        return InvokeTypedAsync(
+            serviceName,
+            operationName,
+            protocol,
             input,
+            modifyRequest,
+            errorDeserializer ?? protocol.DeserializeErrorAsync,
             cancellationToken
         );
     }

--- a/packages/NSmithy.Client/SmithyOperationBinding.cs
+++ b/packages/NSmithy.Client/SmithyOperationBinding.cs
@@ -8,8 +8,7 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
         string serviceName,
         string operationName,
         IOperationProtocol<TInput, TOutput> protocol,
-        Action<SmithyHttpRequest>? modifyRequest = null,
-        SmithyErrorDeserializer? errorDeserializer = null
+        Action<SmithyHttpRequest>? modifyRequest = null
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
@@ -20,7 +19,6 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
         OperationName = operationName;
         Protocol = protocol;
         ModifyRequest = modifyRequest;
-        ErrorDeserializer = errorDeserializer;
     }
 
     public string ServiceName { get; }
@@ -30,6 +28,4 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
     public IOperationProtocol<TInput, TOutput> Protocol { get; }
 
     public Action<SmithyHttpRequest>? ModifyRequest { get; }
-
-    public SmithyErrorDeserializer? ErrorDeserializer { get; }
 }

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -1053,6 +1053,7 @@ public sealed class OperationSchema<TInput, TOutput>
         ShapeId id,
         Schema<TInput> input,
         Schema<TOutput> output,
+        IEnumerable<IOperationErrorSchema>? errors = null,
         IEnumerable<Trait>? traits = null
     )
     {
@@ -1061,6 +1062,7 @@ public sealed class OperationSchema<TInput, TOutput>
         Id = id;
         Input = input;
         Output = output;
+        Errors = errors?.ToArray() ?? [];
         Traits = Schema.BuildTraits(traits);
     }
 
@@ -1072,11 +1074,39 @@ public sealed class OperationSchema<TInput, TOutput>
 
     public Schema<TOutput> Output { get; }
 
+    public IReadOnlyList<IOperationErrorSchema> Errors { get; }
+
     public IReadOnlyDictionary<ShapeId, Trait> Traits { get; }
 
     public Trait? GetTrait(ShapeId id) => Traits.TryGetValue(id, out var trait) ? trait : null;
 
     public bool HasTrait(ShapeId id) => Traits.ContainsKey(id);
+}
+
+public interface IOperationErrorSchema
+{
+    ShapeId Id { get; }
+
+    Schema UntypedSchema { get; }
+
+    int HttpStatusCode { get; }
+}
+
+public sealed class OperationErrorSchema<TError>(
+    ShapeId id,
+    Schema<TError> schema,
+    int httpStatusCode
+) : IOperationErrorSchema
+    where TError : Exception
+{
+    public ShapeId Id { get; } = id;
+
+    public Schema<TError> Schema { get; } =
+        schema ?? throw new ArgumentNullException(nameof(schema));
+
+    public Schema UntypedSchema => Schema;
+
+    public int HttpStatusCode { get; } = httpStatusCode;
 }
 
 /// <summary>
@@ -1281,7 +1311,22 @@ public static class Schemas
         Schema<TInput> input,
         Schema<TOutput> output,
         IEnumerable<Trait>? traits = null
-    ) => new(id, input, output, traits);
+    ) => new(id, input, output, null, traits);
+
+    public static OperationSchema<TInput, TOutput> Operation<TInput, TOutput>(
+        ShapeId id,
+        Schema<TInput> input,
+        Schema<TOutput> output,
+        IEnumerable<IOperationErrorSchema>? errors,
+        IEnumerable<Trait>? traits = null
+    ) => new(id, input, output, errors, traits);
+
+    public static OperationErrorSchema<TError> OperationError<TError>(
+        ShapeId id,
+        Schema<TError> schema,
+        int httpStatusCode
+    )
+        where TError : Exception => new(id, schema, httpStatusCode);
 
     public static ServiceSchema Service(ShapeId id, IEnumerable<Trait>? traits = null) =>
         new(id, traits);

--- a/packages/NSmithy.Http/IOperationProtocol.cs
+++ b/packages/NSmithy.Http/IOperationProtocol.cs
@@ -38,9 +38,6 @@ public interface IOperationProtocol<TInput, TOutput>
     SmithyHttpResponse SerializeResponse(TOutput output);
 
     // ---- errors ----
-    // The *set* of an operation's errors is model data, so dispatch stays generated; the
-    // protocol-specific mechanism (when a response is an error, header vs __type, status fallback)
-    // is hidden here.
 
     /// <summary>
     /// Decides whether a response represents an error, by the protocol's own rules — HTTP status
@@ -68,6 +65,17 @@ public interface IOperationProtocol<TInput, TOutput>
     bool SupportsHttpStatusErrorFallback { get; }
 
     TError DeserializeError<TError>(Schema<TError> errorSchema, SmithyHttpResponse response);
+
+    IReadOnlyList<IOperationErrorSchema> ModeledErrors => [];
+
+    /// <summary>
+    /// Attempts to deserialize the response into one of the operation's modeled exceptions.
+    /// Returns null when the protocol cannot resolve a modeled error from the response.
+    /// </summary>
+    ValueTask<Exception?> DeserializeErrorAsync(
+        SmithyHttpResponse response,
+        CancellationToken cancellationToken = default
+    ) => ValueTask.FromResult(OperationProtocolErrors.DeserializeModeledError(this, response));
 
     SmithyHttpResponse SerializeError<TError>(
         Schema<TError> errorSchema,

--- a/packages/NSmithy.Http/OperationProtocolErrors.cs
+++ b/packages/NSmithy.Http/OperationProtocolErrors.cs
@@ -1,0 +1,68 @@
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Http;
+
+internal static class OperationProtocolErrors
+{
+    public static Exception? DeserializeModeledError<TInput, TOutput>(
+        IOperationProtocol<TInput, TOutput> protocol,
+        SmithyHttpResponse response
+    )
+    {
+        ArgumentNullException.ThrowIfNull(protocol);
+        ArgumentNullException.ThrowIfNull(response);
+
+        var errors = protocol.ModeledErrors;
+        if (errors.Count == 0)
+        {
+            return null;
+        }
+
+        var errorType = protocol.GetErrorDiscriminator(response);
+        if (errorType is null && protocol.RequiresErrorDiscriminator)
+        {
+            return null;
+        }
+
+        if (errorType is not null)
+        {
+            var matched = errors.FirstOrDefault(error =>
+                string.Equals(errorType, error.Id.Name, StringComparison.Ordinal)
+                || string.Equals(errorType, error.Id.ToString(), StringComparison.Ordinal)
+            );
+            if (matched is not null)
+            {
+                return DeserializeError(protocol, matched, response);
+            }
+        }
+
+        if (protocol.SupportsHttpStatusErrorFallback)
+        {
+            var statusMatched = errors.FirstOrDefault(error =>
+                error.HttpStatusCode == (int)response.StatusCode
+            );
+            if (statusMatched is not null)
+            {
+                return DeserializeError(protocol, statusMatched, response);
+            }
+        }
+
+        var fallback = errors[0];
+        return protocol.SupportsHttpStatusErrorFallback && response.Content.Length == 0
+            ? null
+            : DeserializeError(protocol, fallback, response);
+    }
+
+    private static Exception DeserializeError<TInput, TOutput>(
+        IOperationProtocol<TInput, TOutput> protocol,
+        IOperationErrorSchema error,
+        SmithyHttpResponse response
+    ) => DeserializeError(protocol, (dynamic)error, response);
+
+    private static Exception DeserializeError<TInput, TOutput, TError>(
+        IOperationProtocol<TInput, TOutput> protocol,
+        OperationErrorSchema<TError> error,
+        SmithyHttpResponse response
+    )
+        where TError : Exception => protocol.DeserializeError(error.Schema, response);
+}

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -73,7 +73,10 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             outputSchema = operation.Output;
             requestCodec = JsonCodec.FromSchema(operation.Input);
             responseCodec = JsonCodec.FromSchema(operation.Output);
+            ModeledErrors = operation.Errors;
         }
+
+        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -129,7 +129,10 @@ public sealed class GrpcProtocol : IProtocol
             outputIsUnit = IsUnit<TOutput>(operation.Output);
             requestCodec = inputIsUnit ? null : ProtoCodec.FromSchema(operation.Input);
             responseCodec = outputIsUnit ? null : ProtoCodec.FromSchema(operation.Output);
+            ModeledErrors = operation.Errors;
         }
+
+        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {

--- a/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
@@ -26,6 +26,7 @@ public sealed class RestServiceProtocol(
         ArgumentNullException.ThrowIfNull(operation);
         return new RestOperationProtocol<TInput, TOutput>(
             RestOperationBinding.From(operation, codecFactory, rawStringPayloads),
+            operation.Errors,
             codecFactory,
             errorDiscriminator,
             rawStringPayloads,
@@ -41,6 +42,7 @@ public sealed class RestServiceProtocol(
 /// </summary>
 public sealed class RestOperationProtocol<TInput, TOutput>(
     RestOperationBinding<TInput, TOutput> binding,
+    IReadOnlyList<IOperationErrorSchema> modeledErrors,
     IRestBodyCodecFactory codecFactory,
     Func<SmithyHttpResponse, string?> errorDiscriminator,
     bool rawStringPayloads,
@@ -67,6 +69,8 @@ public sealed class RestOperationProtocol<TInput, TOutput>(
     public bool RequiresErrorDiscriminator => false;
 
     public bool SupportsHttpStatusErrorFallback => true;
+
+    public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; } = modeledErrors;
 
     public TError DeserializeError<TError>(
         Schema<TError> errorSchema,

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -70,7 +70,10 @@ public sealed class RpcV2CborProtocol : IProtocol
                 operation.Output,
                 materializeTopLevelDefaults: true
             );
+            ModeledErrors = operation.Errors;
         }
+
+        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {

--- a/tests/NSmithy.Tests/Core/SchemaTests.cs
+++ b/tests/NSmithy.Tests/Core/SchemaTests.cs
@@ -11,6 +11,13 @@ public sealed class SchemaTests
 
     public sealed record Address(string City);
 
+    public sealed class TestException(string? message) : Exception(message);
+
+    public sealed class TestExceptionBuilder
+    {
+        public string? Message { get; set; }
+    }
+
     public sealed class PersonBuilder
     {
         public string? Name { get; set; }
@@ -558,5 +565,34 @@ public sealed class SchemaTests
         Assert.False(
             inputSchema.GetMember("displayName")!.Traits.ContainsKey(RestTraits.HttpLabel)
         );
+    }
+
+    [Fact]
+    public void OperationSchemaCarriesModeledErrors()
+    {
+        var errorSchema = Schemas
+            .Structure<TestException, TestExceptionBuilder>(new ShapeId("example", "BadRequest"))
+            .Optional(
+                "message",
+                static error => error.Message,
+                static (builder, value) => builder.Message = value,
+                Schemas.String
+            )
+            .Build(
+                static () => new TestExceptionBuilder(),
+                static builder => new TestException(builder.Message)
+            );
+
+        var error = Schemas.OperationError(new ShapeId("example", "BadRequest"), errorSchema, 400);
+        var operation = Schemas.Operation(
+            new ShapeId("example", "GetUser"),
+            Schemas.Unit,
+            Schemas.Unit,
+            [error]
+        );
+
+        Assert.Same(error, operation.Errors[0]);
+        Assert.Same(errorSchema, ((OperationErrorSchema<TestException>)operation.Errors[0]).Schema);
+        Assert.Equal(400, operation.Errors[0].HttpStatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- add modeled error descriptors to OperationSchema so operation metadata includes declared errors
- generate Schemas.OperationError(...) entries for operation error shapes
- expose modeled errors through operation-bound protocols and dispatch errors via IOperationProtocol.DeserializeErrorAsync(...)
- remove generated per-operation client error deserializer methods and the temporary client protocol adapter
- update design docs to describe schema-backed, protocol-owned modeled error deserialization

## Stacked On
- #73

## Validation
- dotnet build packages/NSmithy.Client/NSmithy.Client.csproj --configuration Release --no-restore
- gradle :smithy-csharp-codegen:test
- just codegen
- dotnet build NSmithy.slnx --configuration Release --no-restore
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj --configuration Release --no-restore
- dotnet test NSmithy.slnx --configuration Release --no-build
- just fmt
- git diff --check