### PR TITLE
docs: simplify README badges, fix landing widget height on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,9 @@
-<p align="center">
-   <img src="https://raw.githubusercontent.com/thomaslaich/smithy-dotnet/main/website/public/brand/nsmithy_logo_1.png" alt="NSmithy logo" width="320" />
-</p>
-
-<p align="center">
-   <a href="https://github.com/thomaslaich/smithy-dotnet/actions/workflows/ci.yml">
-      <img src="https://github.com/thomaslaich/smithy-dotnet/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" />
-   </a>
-   <a href="https://thomaslaich.github.io/smithy-dotnet/">
-      <img src="https://github.com/thomaslaich/smithy-dotnet/actions/workflows/docs.yml/badge.svg?branch=main" alt="Docs" />
-   </a>
-   <a href="https://www.nuget.org/packages/NSmithy.Client">
-      <img src="https://img.shields.io/nuget/v/NSmithy.Client" alt="NuGet" />
-   </a>
-   <a href="https://dotnet.microsoft.com/">
-      <img src="https://img.shields.io/badge/.NET-net10.0-512BD4" alt=".NET 10" />
-   </a>
-   <a href="LICENSE">
-      <img src="https://img.shields.io/github/license/thomaslaich/smithy-dotnet" alt="License" />
-   </a>
-   <a href="https://github.com/smithy-lang/smithy/releases/tag/1.71.0">
-      <img src="https://img.shields.io/badge/smithy--cli-1.71.0-orange" alt="Smithy CLI" />
-   </a>
-</p>
+[![CI](https://github.com/thomaslaich/smithy-dotnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thomaslaich/smithy-dotnet/actions/workflows/ci.yml)
+[![Docs](https://github.com/thomaslaich/smithy-dotnet/actions/workflows/docs.yml/badge.svg?branch=main)](https://thomaslaich.github.io/smithy-dotnet/)
+[![NuGet](https://img.shields.io/nuget/v/NSmithy.Client)](https://www.nuget.org/packages/NSmithy.Client)
+[![.NET 10](https://img.shields.io/badge/.NET-net10.0-512BD4)](https://dotnet.microsoft.com/)
+[![License](https://img.shields.io/github/license/thomaslaich/smithy-dotnet)](https://github.com/thomaslaich/smithy-dotnet/blob/main/LICENSE)
+[![Smithy CLI](https://img.shields.io/badge/smithy--cli-1.71.0-orange)](https://github.com/smithy-lang/smithy/releases/tag/1.71.0)
 
 > **Preview:** NSmithy is in preview — expect some API changes before 1.0. Protocol implementations are not yet on par with the [Smithy reference implementations](https://github.com/smithy-lang/smithy).
 

--- a/website/src/components/landing/Walkthrough.astro
+++ b/website/src/components/landing/Walkthrough.astro
@@ -133,11 +133,13 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
           ))
         }
       </div>
-      {
-        tabsHtml.map((t, i) => (
-          <pre class={`wt__code wt__outcode${i === 0 ? ' is-active' : ''}`} data-idx={i} hidden={i !== 0} set:html={t.codeHtml} />
-        ))
-      }
+      <div class="wt__panels">
+        {
+          tabsHtml.map((t, i) => (
+            <pre class={`wt__code wt__outcode${i === 0 ? ' is-active' : ''}`} data-idx={i} set:html={t.codeHtml} />
+          ))
+        }
+      </div>
     </div>
   </div>
 
@@ -298,6 +300,21 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     font-weight: 600;
   }
 
+  /* Output code panels — all stacked in one grid cell so the widget height is
+     fixed to the tallest tab (Server) and never jumps as it auto-cycles or the
+     visitor switches between Server and Client. */
+  .wt__panels {
+    display: grid;
+  }
+  .wt__outcode {
+    grid-area: 1 / 1;
+    min-width: 0;
+  }
+  .wt__outcode:not(.is-active) {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
   /* Code */
   .wt__code {
     margin: 0;
@@ -309,9 +326,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     line-height: 1.75;
     color: #c9d1d9;
     white-space: pre;
-  }
-  .wt__outcode[hidden] {
-    display: none;
   }
   .wt__code::-webkit-scrollbar {
     height: 7px;
@@ -410,7 +424,7 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
         });
       tabs.forEach((t, i) => t.setAttribute('aria-selected', i === n ? 'true' : 'false'));
       toggle(tabs, false);
-      toggle(outs, true);
+      toggle(outs, false);
       toggle(dots, false);
       toggle(caps, true);
     }


### PR DESCRIPTION
## Summary

Two follow-ups to the landing-page redesign (#72):

- **README (NuGet-friendly):** removed the centered logo `<img>` and converted the `<p align="center">` HTML badge block to plain markdown badges. Same six badges, no HTML — renders cleanly on nuget.org. The License badge now links to an absolute URL since relative links don't resolve there.
- **Walkthrough widget — fixed height on mobile:** the Server/Client tabs toggled panels via `hidden`/`display:none`, so the shorter Client tab collapsed the widget and the page below jumped on mobile. The output panels now stack in one grid cell with inactive panels using `visibility: hidden` — the same technique `ProtocolSwitch` already uses. Height is now fixed to the tallest (Server) tab. Desktop was already fine and is unaffected.

## Verification

- `npm run build` succeeds.
- Headless-Chrome measurement at mobile width: the widget's panel container is **453px in both the Server and Client tabs** (no jump).
