### PR TITLE
perf: precompute modeled error deserializers

### DIFF
--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -493,8 +493,10 @@ unary operation. That binding wraps the operation-bound protocol together with
 the service/operation names, request modifiers such as compression/checksum
 hooks, and other lifecycle metadata. The operation-bound protocol owns modeled
 error deserialization; operation schemas carry the modeled error descriptors it
-uses for dispatch. Runtime invocation receives the binding plus typed input, so
-per-call generated code stays thin.
+uses for dispatch. Protocol implementations compile those descriptors into
+protocol-specific error deserializers when the operation protocol is built, so
+per-call generated code stays thin and error codec construction stays off the
+deserialization path.
 
 ### The client runtime
 

--- a/packages/NSmithy.Http/HttpOperationError.cs
+++ b/packages/NSmithy.Http/HttpOperationError.cs
@@ -1,0 +1,19 @@
+using NSmithy.Core;
+
+namespace NSmithy.Http;
+
+public sealed class HttpOperationError(
+    ShapeId id,
+    int httpStatusCode,
+    Func<SmithyHttpResponse, Exception> deserialize
+)
+{
+    private readonly Func<SmithyHttpResponse, Exception> deserialize =
+        deserialize ?? throw new ArgumentNullException(nameof(deserialize));
+
+    public ShapeId Id { get; } = id;
+
+    public int HttpStatusCode { get; } = httpStatusCode;
+
+    public Exception Deserialize(SmithyHttpResponse response) => deserialize(response);
+}

--- a/packages/NSmithy.Http/IOperationProtocol.cs
+++ b/packages/NSmithy.Http/IOperationProtocol.cs
@@ -64,9 +64,7 @@ public interface IOperationProtocol<TInput, TOutput>
     /// </summary>
     bool SupportsHttpStatusErrorFallback { get; }
 
-    TError DeserializeError<TError>(Schema<TError> errorSchema, SmithyHttpResponse response);
-
-    IReadOnlyList<IOperationErrorSchema> ModeledErrors => [];
+    IReadOnlyList<HttpOperationError> HttpErrors => [];
 
     /// <summary>
     /// Attempts to deserialize the response into one of the operation's modeled exceptions.

--- a/packages/NSmithy.Http/OperationProtocolErrors.cs
+++ b/packages/NSmithy.Http/OperationProtocolErrors.cs
@@ -12,7 +12,19 @@ internal static class OperationProtocolErrors
         ArgumentNullException.ThrowIfNull(protocol);
         ArgumentNullException.ThrowIfNull(response);
 
-        var errors = protocol.ModeledErrors;
+        return DeserializeModeledError(protocol, protocol.HttpErrors, response);
+    }
+
+    public static Exception? DeserializeModeledError<TInput, TOutput>(
+        IOperationProtocol<TInput, TOutput> protocol,
+        IReadOnlyList<HttpOperationError> errors,
+        SmithyHttpResponse response
+    )
+    {
+        ArgumentNullException.ThrowIfNull(protocol);
+        ArgumentNullException.ThrowIfNull(errors);
+        ArgumentNullException.ThrowIfNull(response);
+
         if (errors.Count == 0)
         {
             return null;
@@ -32,7 +44,7 @@ internal static class OperationProtocolErrors
             );
             if (matched is not null)
             {
-                return DeserializeError(protocol, matched, response);
+                return matched.Deserialize(response);
             }
         }
 
@@ -43,26 +55,13 @@ internal static class OperationProtocolErrors
             );
             if (statusMatched is not null)
             {
-                return DeserializeError(protocol, statusMatched, response);
+                return statusMatched.Deserialize(response);
             }
         }
 
         var fallback = errors[0];
         return protocol.SupportsHttpStatusErrorFallback && response.Content.Length == 0
             ? null
-            : DeserializeError(protocol, fallback, response);
+            : fallback.Deserialize(response);
     }
-
-    private static Exception DeserializeError<TInput, TOutput>(
-        IOperationProtocol<TInput, TOutput> protocol,
-        IOperationErrorSchema error,
-        SmithyHttpResponse response
-    ) => DeserializeError(protocol, (dynamic)error, response);
-
-    private static Exception DeserializeError<TInput, TOutput, TError>(
-        IOperationProtocol<TInput, TOutput> protocol,
-        OperationErrorSchema<TError> error,
-        SmithyHttpResponse response
-    )
-        where TError : Exception => protocol.DeserializeError(error.Schema, response);
 }

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -73,10 +73,10 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             outputSchema = operation.Output;
             requestCodec = JsonCodec.FromSchema(operation.Input);
             responseCodec = JsonCodec.FromSchema(operation.Output);
-            ModeledErrors = operation.Errors;
+            HttpErrors = CompileErrors(operation.Errors);
         }
 
-        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
+        public IReadOnlyList<HttpOperationError> HttpErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {
@@ -135,11 +135,6 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
 
         public bool SupportsHttpStatusErrorFallback => true;
 
-        public TError DeserializeError<TError>(
-            Schema<TError> errorSchema,
-            SmithyHttpResponse response
-        ) => AwsJsonProtocol.DeserializeError(errorSchema, response);
-
         public SmithyHttpResponse SerializeError<TError>(
             Schema<TError> errorSchema,
             TError value,
@@ -156,6 +151,24 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             }
 
             return default!;
+        }
+
+        private static HttpOperationError[] CompileErrors(
+            IReadOnlyList<IOperationErrorSchema> errors
+        ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
+
+        private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
+            where TError : Exception
+        {
+            var codec = JsonCodec.FromSchema(error.Schema);
+            return new HttpOperationError(
+                error.Id,
+                error.HttpStatusCode,
+                response =>
+                    response.Content.Length == 0
+                        ? CreateEmptyError<TError>()
+                        : codec.Deserialize(response.Content)
+            );
         }
     }
 
@@ -206,22 +219,6 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
         }
 
         return null;
-    }
-
-    public static TError DeserializeError<TError>(
-        Schema<TError> errorSchema,
-        SmithyHttpResponse response
-    )
-    {
-        ArgumentNullException.ThrowIfNull(errorSchema);
-        ArgumentNullException.ThrowIfNull(response);
-
-        if (response.Content.Length == 0)
-        {
-            return CreateEmptyError<TError>();
-        }
-
-        return JsonCodec.FromSchema(errorSchema).Deserialize(response.Content);
     }
 
     private static TError CreateEmptyError<TError>()

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -129,10 +129,10 @@ public sealed class GrpcProtocol : IProtocol
             outputIsUnit = IsUnit<TOutput>(operation.Output);
             requestCodec = inputIsUnit ? null : ProtoCodec.FromSchema(operation.Input);
             responseCodec = outputIsUnit ? null : ProtoCodec.FromSchema(operation.Output);
-            ModeledErrors = operation.Errors;
+            HttpErrors = CompileErrors(operation.Errors);
         }
 
-        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
+        public IReadOnlyList<HttpOperationError> HttpErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {
@@ -215,17 +215,6 @@ public sealed class GrpcProtocol : IProtocol
 
         public bool SupportsHttpStatusErrorFallback => false;
 
-        public TError DeserializeError<TError>(
-            Schema<TError> errorSchema,
-            SmithyHttpResponse response
-        )
-        {
-            ArgumentNullException.ThrowIfNull(errorSchema);
-            ArgumentNullException.ThrowIfNull(response);
-            var payload = GrpcMessageFraming.ReadSingle(response.Content);
-            return ProtoCodec.FromSchema(errorSchema).Deserialize(payload);
-        }
-
         public SmithyHttpResponse SerializeError<TError>(
             Schema<TError> errorSchema,
             TError value,
@@ -253,6 +242,25 @@ public sealed class GrpcProtocol : IProtocol
                 new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
                 {
                     ["Content-Type"] = [ContentType],
+                }
+            );
+        }
+
+        private static HttpOperationError[] CompileErrors(
+            IReadOnlyList<IOperationErrorSchema> errors
+        ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
+
+        private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
+            where TError : Exception
+        {
+            var codec = ProtoCodec.FromSchema(error.Schema);
+            return new HttpOperationError(
+                error.Id,
+                error.HttpStatusCode,
+                response =>
+                {
+                    var payload = GrpcMessageFraming.ReadSingle(response.Content);
+                    return codec.Deserialize(payload);
                 }
             );
         }

--- a/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
@@ -49,6 +49,9 @@ public sealed class RestOperationProtocol<TInput, TOutput>(
     string? errorTypeHeader
 ) : IOperationProtocol<TInput, TOutput>
 {
+    public IReadOnlyList<HttpOperationError> HttpErrors { get; } =
+        RestProtocol.CompileErrorDeserializers(modeledErrors, codecFactory, rawStringPayloads);
+
     public SmithyHttpRequest SerializeRequest(TInput input) =>
         RestProtocol.SerializeRequest(binding, input);
 
@@ -69,13 +72,6 @@ public sealed class RestOperationProtocol<TInput, TOutput>(
     public bool RequiresErrorDiscriminator => false;
 
     public bool SupportsHttpStatusErrorFallback => true;
-
-    public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; } = modeledErrors;
-
-    public TError DeserializeError<TError>(
-        Schema<TError> errorSchema,
-        SmithyHttpResponse response
-    ) => RestProtocol.DeserializeError(errorSchema, response, codecFactory, rawStringPayloads);
 
     public SmithyHttpResponse SerializeError<TError>(
         Schema<TError> errorSchema,

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -235,71 +235,64 @@ public static class RestProtocol
         return (TOutput)binding.OutputSchema.BuildObject(builder);
     }
 
-    /// <summary>
-    /// Deserializes an error structure (the same HTTP binding rules as an output) from a
-    /// response. Error members are partitioned per call; errors are off the hot path.
-    /// </summary>
-    public static TError DeserializeError<TError>(
-        Schema<TError> errorSchema,
-        SmithyHttpResponse response,
+    internal static HttpOperationError[] CompileErrorDeserializers(
+        IReadOnlyList<IOperationErrorSchema> errors,
         IRestBodyCodecFactory codecFactory,
         bool rawStringPayloads
     )
     {
-        ArgumentNullException.ThrowIfNull(errorSchema);
-        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(errors);
         ArgumentNullException.ThrowIfNull(codecFactory);
+        return errors
+            .Select(error =>
+                (HttpOperationError)CompileErrorDeserializer(
+                    (dynamic)error,
+                    codecFactory,
+                    rawStringPayloads
+                )
+            )
+            .ToArray();
+    }
 
-        if (errorSchema.Resolved is not IStructSchema<TError> schema)
+    private static HttpOperationError CompileErrorDeserializer<TError>(
+        OperationErrorSchema<TError> error,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads
+    )
+        where TError : Exception
+    {
+        if (error.Schema.Resolved is not IStructSchema<TError> schema)
         {
             throw new InvalidOperationException(
-                $"Error schema '{errorSchema.Id}' must be a structure schema."
+                $"Error schema '{error.Schema.Id}' must be a structure schema."
             );
         }
 
-        var builder = schema.CreateBuilder();
+        IMemberSchema<TError>? responseCodeMember = null;
+        var headerMembers = new List<HeaderMemberBinding>();
+        var prefixHeaderMembers = new List<PrefixHeaderMemberBinding>();
+        RestPayloadReader? payloadReader = null;
         var bodyMembers = new List<IMemberSchema<TError>>();
 
         foreach (var member in schema.TypedMembers)
         {
             if (member.Traits.ContainsKey(RestTraits.HttpResponseCode))
             {
-                member.SetObject(
-                    builder,
-                    ParseHttpValue(
-                        member.Target,
-                        ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)
-                    )
-                );
+                responseCodeMember = member;
             }
             else if (member.Traits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
             {
-                var name = headerTrait.Value.AsString();
-                if (
-                    TryGetFirstHeader(response.Headers, name, out var header)
-                    || TryGetFirstHeader(response.ContentHeaders, name, out header)
-                )
-                {
-                    member.SetObject(
-                        builder,
-                        ParseHttpBindingValue(member.Target, member.Traits, header)
-                    );
-                }
+                headerMembers.Add(new HeaderMemberBinding(member, headerTrait.Value.AsString()));
             }
             else if (member.Traits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait))
             {
-                member.SetObject(
-                    builder,
-                    ReadPrefixedHeaders(member, response.Headers, prefixTrait.Value.AsString())
+                prefixHeaderMembers.Add(
+                    new PrefixHeaderMemberBinding(member, prefixTrait.Value.AsString())
                 );
             }
             else if (member.Traits.ContainsKey(RestTraits.HttpPayload))
             {
-                BuildPayloadReader(member, codecFactory, rawStringPayloads)(
-                    response.Content,
-                    response.StreamingContent,
-                    builder
-                );
+                payloadReader = BuildPayloadReader(member, codecFactory, rawStringPayloads);
             }
             else
             {
@@ -307,15 +300,62 @@ public static class RestProtocol
             }
         }
 
-        if (bodyMembers.Count > 0 && response.Content.Length > 0)
-        {
-            var projection = Schemas.Project(schema, bodyMembers);
-            codecFactory
-                .CodecFor(projection, materializeTopLevelDefaults: true)
-                .ReadInto(response.Content, builder);
-        }
+        var bodyCodec =
+            bodyMembers.Count > 0
+                ? codecFactory.CodecFor(
+                    Schemas.Project(schema, bodyMembers),
+                    materializeTopLevelDefaults: true
+                )
+                : null;
 
-        return (TError)schema.BuildObject(builder);
+        return new HttpOperationError(
+            error.Id,
+            error.HttpStatusCode,
+            response =>
+            {
+                var builder = schema.CreateBuilder();
+                if (responseCodeMember is not null)
+                {
+                    responseCodeMember.SetObject(
+                        builder,
+                        ParseHttpValue(
+                            responseCodeMember.Target,
+                            ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)
+                        )
+                    );
+                }
+
+                foreach (var (member, headerName) in headerMembers)
+                {
+                    if (
+                        TryGetFirstHeader(response.Headers, headerName, out var header)
+                        || TryGetFirstHeader(response.ContentHeaders, headerName, out header)
+                    )
+                    {
+                        member.SetObject(
+                            builder,
+                            ParseHttpBindingValue(member.Target, member.Traits, header)
+                        );
+                    }
+                }
+
+                foreach (var (member, prefix) in prefixHeaderMembers)
+                {
+                    member.SetObject(
+                        builder,
+                        ReadPrefixedHeaders(member, response.Headers, prefix)
+                    );
+                }
+
+                payloadReader?.Invoke(response.Content, response.StreamingContent, builder);
+                if (bodyCodec is not null && response.Content.Length > 0)
+                {
+                    bodyCodec.ReadInto(response.Content, builder);
+                }
+
+                return (TError)schema.BuildObject(builder);
+            }
+        );
     }
 
     /// <summary>

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -70,10 +70,10 @@ public sealed class RpcV2CborProtocol : IProtocol
                 operation.Output,
                 materializeTopLevelDefaults: true
             );
-            ModeledErrors = operation.Errors;
+            HttpErrors = CompileErrors(operation.Errors);
         }
 
-        public IReadOnlyList<IOperationErrorSchema> ModeledErrors { get; }
+        public IReadOnlyList<HttpOperationError> HttpErrors { get; }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {
@@ -160,28 +160,27 @@ public sealed class RpcV2CborProtocol : IProtocol
 
         public bool SupportsHttpStatusErrorFallback => false;
 
-        public TError DeserializeError<TError>(
-            Schema<TError> errorSchema,
-            SmithyHttpResponse response
-        ) => RpcV2CborProtocol.DeserializeError(errorSchema, response);
-
         public SmithyHttpResponse SerializeError<TError>(
             Schema<TError> errorSchema,
             TError error,
             string errorShapeId,
             int statusCode
         ) => RpcV2CborProtocol.SerializeError(errorSchema, error, errorShapeId, statusCode);
-    }
 
-    public static TError DeserializeError<TError>(
-        Schema<TError> errorSchema,
-        SmithyHttpResponse response
-    )
-    {
-        ArgumentNullException.ThrowIfNull(errorSchema);
-        ArgumentNullException.ThrowIfNull(response);
+        private static HttpOperationError[] CompileErrors(
+            IReadOnlyList<IOperationErrorSchema> errors
+        ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
 
-        return DeserializeRequiredBody(CborCodec.FromSchema(errorSchema), response.Content);
+        private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
+            where TError : Exception
+        {
+            var codec = CborCodec.FromSchema(error.Schema);
+            return new HttpOperationError(
+                error.Id,
+                error.HttpStatusCode,
+                response => DeserializeRequiredBody(codec, response.Content)
+            );
+        }
     }
 
     /// <summary>

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -581,11 +581,6 @@ public sealed class SmithyClientRuntimeTests
 
         public bool SupportsHttpStatusErrorFallback => true;
 
-        public TError DeserializeError<TError>(
-            Schema<TError> errorSchema,
-            SmithyHttpResponse response
-        ) => throw new NotSupportedException();
-
         public SmithyHttpResponse SerializeError<TError>(
             Schema<TError> errorSchema,
             TError value,

--- a/tests/NSmithy.Tests/Protocols/Grpc/GrpcProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/Grpc/GrpcProtocolTests.cs
@@ -25,6 +25,8 @@ public sealed class GrpcProtocolTests
 
     public sealed record Echo(string Message);
 
+    public sealed class TestGrpcException(string? message) : Exception(message);
+
     public abstract record ChatEvent
     {
         private ChatEvent() { }
@@ -37,11 +39,24 @@ public sealed class GrpcProtocolTests
         public string? Message { get; set; }
     }
 
+    public sealed class TestGrpcExceptionBuilder
+    {
+        public string? Message { get; set; }
+    }
+
     private static Schema<Echo> EchoSchema(string name) =>
         Schemas
             .Structure<Echo, EchoBuilder>(ShapeId.Parse($"example.greeter#{name}"))
             .Required("message", x => x.Message, (b, v) => b.Message = v, Schemas.String, Field(1))
             .Build(() => new EchoBuilder(), b => new Echo(b.Message!));
+
+    private static Schema<TestGrpcException> ErrorSchema(string name) =>
+        Schemas
+            .Structure<TestGrpcException, TestGrpcExceptionBuilder>(
+                ShapeId.Parse($"example.greeter#{name}")
+            )
+            .Required("message", x => x.Message, (b, v) => b.Message = v, Schemas.String, Field(1))
+            .Build(() => new TestGrpcExceptionBuilder(), b => new TestGrpcException(b.Message));
 
     private static Schema<ChatEvent> ChatEventSchema(string name) =>
         Schemas
@@ -62,7 +77,14 @@ public sealed class GrpcProtocolTests
         var operation = Schemas.Operation(
             ShapeId.Parse("example.greeter#SayHello"),
             EchoSchema("SayHelloInput"),
-            EchoSchema("SayHelloOutput")
+            EchoSchema("SayHelloOutput"),
+            [
+                Schemas.OperationError(
+                    ShapeId.Parse("example.greeter#ThrottlingError"),
+                    ErrorSchema("ThrottlingError"),
+                    429
+                ),
+            ]
         );
         return new GrpcProtocol().ForService(service).ForOperation(operation);
     }
@@ -130,14 +152,14 @@ public sealed class GrpcProtocolTests
     }
 
     [Fact]
-    public void SerializesAndDiscriminatesModeledErrors()
+    public async Task SerializesAndDiscriminatesModeledErrors()
     {
         var protocol = BuildProtocol();
-        var errorSchema = EchoSchema("ThrottlingError");
+        var errorSchema = ErrorSchema("ThrottlingError");
 
         var response = protocol.SerializeError(
             errorSchema,
-            new Echo("slow down"),
+            new TestGrpcException("slow down"),
             "example.greeter#ThrottlingError",
             429
         );
@@ -147,7 +169,10 @@ public sealed class GrpcProtocolTests
         string[] exhaustedStatus = ["8"];
         Assert.Equal(exhaustedStatus, response.Headers["grpc-status"]);
         Assert.Equal("example.greeter#ThrottlingError", protocol.GetErrorDiscriminator(response));
-        Assert.Equal(new Echo("slow down"), protocol.DeserializeError(errorSchema, response));
+        var error = Assert.IsType<TestGrpcException>(
+            await protocol.DeserializeErrorAsync(response)
+        );
+        Assert.Equal("slow down", error.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add HttpOperationError as the HTTP/protocol-compiled form of a modeled operation error
- precompute REST error HTTP bindings and body/payload readers once per operation protocol
- precompute AWS JSON, rpcv2Cbor, and gRPC error codecs once per operation protocol
- dispatch modeled errors through compiled HttpOperationError instances while keeping OperationSchema.Errors as the core metadata source
- remove the old schema-level IOperationProtocol.DeserializeError(...) API so operation protocols expose one modeled-error deserialization path
- update serialization design docs to describe construction-time error deserializer compilation

## Validation
- dotnet build packages/NSmithy.Protocols.Rest/NSmithy.Protocols.Rest.csproj --configuration Release --no-restore
- dotnet build packages/NSmithy.Protocols.RpcV2Cbor/NSmithy.Protocols.RpcV2Cbor.csproj --configuration Release --no-restore
- dotnet build packages/NSmithy.Protocols.AwsJson/NSmithy.Protocols.AwsJson.csproj --configuration Release --no-restore
- dotnet build packages/NSmithy.Protocols.Grpc/NSmithy.Protocols.Grpc.csproj --configuration Release --no-restore
- dotnet build NSmithy.slnx --configuration Release --no-restore
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj --configuration Release --no-restore
- dotnet test NSmithy.slnx --configuration Release --no-build
- just fmt
- git diff --check