### PR TITLE
docs: unify protocol pages on a shared usage example

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -71,6 +71,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Introduction', slug: 'getting-started/introduction' },
 						{ label: 'Quick Start', slug: 'getting-started/quick-start' },
+						{ label: 'Modeling', slug: 'guides/modeling' },
 						{
 							label: 'Client Configuration',
 							items: [
@@ -90,6 +91,7 @@ export default defineConfig({
 					label: 'Protocols',
 					items: [
 						{ label: 'Overview', slug: 'protocols/overview' },
+						{ label: 'Client & Server Usage', slug: 'protocols/usage' },
 						{ label: 'simpleRestJson', slug: 'protocols/simple-rest-json' },
 						{ label: 'RPC v2 CBOR', slug: 'protocols/rpc-v2-cbor' },
 						{ label: 'gRPC', slug: 'protocols/grpc' },

--- a/website/src/components/landing/ProtocolSwitch.astro
+++ b/website/src/components/landing/ProtocolSwitch.astro
@@ -197,7 +197,8 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
   }
 
   /* Panels — all stacked in one grid cell so the widget height is fixed to the
-     tallest protocol and never jumps as it auto-cycles. */
+     tallest protocol and never jumps as it auto-cycles. On mobile the auto-cycle
+     is disabled and this stacking is dropped (see the stacked media query). */
   .psw__panels {
     display: grid;
   }
@@ -302,6 +303,11 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
       border-left: none;
       border-top: 1px solid #17171f;
     }
+    /* Stacked: auto-cycle is off (see script), so the panel follows the active
+       protocol's natural height instead of reserving the tallest one's. */
+    .psw__panel:not(.is-active) {
+      display: none;
+    }
   }
 </style>
 
@@ -312,6 +318,10 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
     const dots = Array.from(root.querySelectorAll<HTMLElement>('.psw__dot'));
     const caps = Array.from(root.querySelectorAll<HTMLElement>('.psw__cap'));
     const interval = Number(root.dataset.cycle || '4200');
+    // On mobile the request/response columns stack vertically; the panels then
+    // take their natural height, so auto-cycling would make the page jump. Skip
+    // the auto-advance while stacked (manual tab/dot taps still work).
+    const stacked = window.matchMedia?.('(max-width: 40rem)');
     let idx = 0;
     let paused = false;
 
@@ -343,7 +353,7 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
 
     if (!window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       setInterval(() => {
-        if (!paused) show((idx + 1) % tabs.length);
+        if (!paused && !stacked?.matches) show((idx + 1) % tabs.length);
       }, interval);
     }
   });

--- a/website/src/components/landing/Walkthrough.astro
+++ b/website/src/components/landing/Walkthrough.astro
@@ -302,7 +302,8 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
 
   /* Output code panels — all stacked in one grid cell so the widget height is
      fixed to the tallest tab (Server) and never jumps as it auto-cycles or the
-     visitor switches between Server and Client. */
+     visitor switches between Server and Client. On mobile the auto-cycle is
+     disabled and this stacking is dropped (see the stacked media query below). */
   .wt__panels {
     display: grid;
   }
@@ -398,6 +399,11 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
       border-left: none;
       border-top: 1px solid #17171f;
     }
+    /* Stacked: auto-cycle is off (see script), so the output follows the active
+       tab's natural height instead of reserving the tallest tab's height. */
+    .wt__outcode:not(.is-active) {
+      display: none;
+    }
   }
 </style>
 
@@ -408,6 +414,10 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     const dots = Array.from(root.querySelectorAll<HTMLElement>('.wt__dot'));
     const caps = Array.from(root.querySelectorAll<HTMLElement>('.wt__cap'));
     const interval = Number(root.dataset.cycle || '3600');
+    // On mobile the source/output sections stack vertically; the panels then
+    // take their natural height, so auto-cycling would make the page jump. Skip
+    // the auto-advance while stacked (manual tab/dot taps still work).
+    const stacked = window.matchMedia?.('(max-width: 52rem)');
     let idx = 0;
     let paused = false;
 
@@ -440,7 +450,7 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
 
     if (!window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       setInterval(() => {
-        if (!paused) show((idx + 1) % tabs.length);
+        if (!paused && !stacked?.matches) show((idx + 1) % tabs.length);
       }, interval);
     }
   });

--- a/website/src/content/docs/guides/modeling.md
+++ b/website/src/content/docs/guides/modeling.md
@@ -1,0 +1,157 @@
+---
+title: Modeling
+description: Beyond a single operation — resources, pagination, and HTTP binding traits in a Smithy model.
+---
+
+The [protocol pages](/smithy-dotnet/protocols/overview/) each show one small
+operation to keep the focus on the wire format. Real services model more:
+resources, pagination, and richer HTTP bindings. This guide walks through those
+patterns with a fuller model.
+
+The example uses `@simpleRestJson`, but the modeling patterns — resources,
+pagination, and the HTTP binding traits — apply to any HTTP protocol
+(`simpleRestJson`, `restJson1`, `restXml`). The protocol trait only changes the
+wire format; see [Client & Server Usage](/smithy-dotnet/protocols/usage/) for the
+generated handler and client.
+
+## A fuller model
+
+Adapted from the [Smithy quickstart](https://smithy.io/2.0/quickstart.html), this
+model demonstrates resources, pagination, errors, and common HTTP binding traits.
+
+```smithy
+$version: "2"
+
+namespace example.weather
+
+use alloy#simpleRestJson
+
+/// Provides weather forecasts.
+@simpleRestJson
+@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
+service Weather {
+    version: "2006-03-01"
+    resources: [City]
+    operations: [GetCurrentTime]
+}
+
+resource City {
+    identifiers: { cityId: CityId }
+    properties: { coordinates: CityCoordinates }
+    read: GetCity
+    list: ListCities
+    resources: [Forecast]
+}
+
+resource Forecast {
+    identifiers: { cityId: CityId }
+    properties: { chanceOfRain: Float }
+    read: GetForecast
+}
+
+@pattern("^[A-Za-z0-9 ]+$")
+string CityId
+
+@readonly
+@http(method: "GET", uri: "/current-time")
+operation GetCurrentTime {
+    output := {
+        @required
+        time: Timestamp
+    }
+}
+
+@readonly
+@http(method: "GET", uri: "/cities/{cityId}")
+operation GetCity {
+    input := for City {
+        @required
+        @httpLabel
+        $cityId
+    }
+    output := for City {
+        @required
+        @notProperty
+        name: String
+
+        @required
+        $coordinates
+    }
+    errors: [NoSuchResource]
+}
+
+@readonly
+@paginated(items: "items")
+@http(method: "GET", uri: "/cities")
+operation ListCities {
+    input := {
+        @httpQuery("nextToken")
+        nextToken: String
+
+        @httpQuery("pageSize")
+        pageSize: Integer
+    }
+    output := {
+        nextToken: String
+
+        @required
+        items: CitySummaries
+    }
+}
+
+@readonly
+@http(method: "GET", uri: "/cities/{cityId}/forecast")
+operation GetForecast {
+    input := for Forecast {
+        @required
+        @httpLabel
+        $cityId
+    }
+    output := for Forecast {
+        $chanceOfRain
+    }
+}
+
+structure CityCoordinates {
+    @required
+    latitude: Float
+
+    @required
+    longitude: Float
+}
+
+list CitySummaries {
+    member: CitySummary
+}
+
+@references([{resource: City}])
+structure CitySummary {
+    @required
+    cityId: CityId
+
+    @required
+    name: String
+}
+
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
+}
+```
+
+## HTTP binding traits
+
+For HTTP protocols, these traits control where each member lives in the request
+or response. Members without an explicit binding go into the JSON (or XML) body.
+
+| Trait | Binds member to |
+| --- | --- |
+| `@httpLabel` | URI path segment |
+| `@httpQuery("key")` | query string parameter |
+| `@httpHeader("name")` | request or response header |
+| `@httpPayload` | raw request/response body |
+
+RPC protocols (`awsJson1_1`, `rpcv2Cbor`) and gRPC do not use HTTP binding
+traits — every member is carried in the body/message. See each
+[protocol page](/smithy-dotnet/protocols/overview/) for its modeling rules.

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -35,36 +35,41 @@ Apply the AWS JSON protocol trait to the service:
 ```smithy
 $version: "2"
 
-namespace example.jsonrpc
+namespace example.weather
 
 use aws.protocols#awsJson1_1
 
 @awsJson1_1
-service ControlPlane {
+service Weather {
     version: "2026-01-01"
-    operations: [GetWidget]
+    operations: [GetCity]
 }
 
-operation GetWidget {
+operation GetCity {
     input := {
-        id: String
+        @required
+        cityId: String
     }
     output := {
+        @required
         name: String
     }
+    errors: [NoSuchResource]
+}
+
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
 }
 ```
 
-## Client
+## Usage
 
-The generated client selects the declared protocol by default:
-
-```csharp
-using Example.Jsonrpc;
-
-var client = new ControlPlaneClient(new Uri("https://api.example.com"));
-var response = await client.GetWidgetAsync(new GetWidgetInput("abc"));
-```
+The generated client selects the declared protocol by default and is used
+exactly like every other NSmithy client — see [Client & Server
+Usage](/smithy-dotnet/protocols/usage/) for the client code. Only the
+`@awsJson1_1` (or `@awsJson1_0`) trait is specific to this protocol.
 
 AWS JSON support is client-only. NSmithy does not generate AWS JSON servers and
 does not yet provide AWS SDK-style endpoint resolution, credential chains,

--- a/website/src/content/docs/protocols/aws-rest-json1.md
+++ b/website/src/content/docs/protocols/aws-rest-json1.md
@@ -72,40 +72,14 @@ Members without an explicit HTTP binding are serialized in the JSON body.
 `@requestCompression`, `@httpChecksumRequired`, and AWS-style error
 deserialization.
 
-## Server
+## Usage
 
-```csharp
-using Example.Weather;
+The generated `IWeatherServiceHandler` and `WeatherClient` are identical to every
+other HTTP-JSON/CBOR protocol — see [Client & Server
+Usage](/smithy-dotnet/protocols/usage/) for the handler and client code. Only the
+`@restJson1` trait and the wire format above are specific to this protocol.
 
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddWeatherServiceHandler<WeatherHandler>();
-
-var app = builder.Build();
-app.MapWeatherServiceHttp();
-app.Run();
-
-internal sealed class WeatherHandler : IWeatherServiceHandler
-{
-    public Task<GetCityOutput> GetCityAsync(
-        GetCityInput input, CancellationToken ct = default)
-    {
-        if (input.CityId == "unknown")
-            throw new NoSuchResource(null, "City");
-
-        return Task.FromResult(new GetCityOutput("Seattle"));
-    }
-}
-```
-
-## Client
-
-```csharp
-using Example.Weather;
-
-var client = new WeatherClient(new Uri("https://api.example.com"));
-var city = await client.GetCityAsync(new GetCityInput("SEA"));
-Console.WriteLine(city.Name);
-```
+## AWS notes
 
 Explicit SigV4 signing exists in early preview; see
 [Authentication](/smithy-dotnet/guides/client-configuration/authentication/). NSmithy does not yet

--- a/website/src/content/docs/protocols/grpc.md
+++ b/website/src/content/docs/protocols/grpc.md
@@ -42,27 +42,27 @@ input or output:
 ```smithy
 $version: "2"
 
-namespace example.hello
+namespace example.weather
 
 use alloy.proto#grpc
 use alloy.proto#protoIndex
 
 @grpc
-service HelloService {
+service Weather {
     version: "2026-01-01"
-    operations: [SayHello]
+    operations: [GetCity]
 }
 
-operation SayHello {
+operation GetCity {
     input := {
         @required
         @protoIndex(1)
-        name: String
+        cityId: String
     }
     output := {
         @required
         @protoIndex(1)
-        message: String
+        name: String
     }
 }
 ```
@@ -73,13 +73,18 @@ member that appears in a proto message — omitting it is a model error.
 
 ## Server
 
+gRPC is the one protocol where the hosting and client code differs from the
+[shared usage example](/smithy-dotnet/protocols/usage/): it needs HTTP/2
+transport and a gRPC-specific client protocol. The generated handler interface
+itself works the same way — you implement one method per operation.
+
 Configure Kestrel to serve HTTP/2 on a dedicated port. Cleartext gRPC requires
 HTTP/2; mixing HTTP/1.1 REST and cleartext gRPC on the same port is unreliable
-without TLS/ALPN. There is no `AddGrpc()` call — the generated `MapHelloServiceGrpc`
+without TLS/ALPN. There is no `AddGrpc()` call — the generated `MapWeatherServiceGrpc`
 maps the gRPC method routes itself:
 
 ```csharp
-using Example.Hello;
+using Example.Weather;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -87,36 +92,36 @@ builder.WebHost.ConfigureKestrel(options =>
 {
     options.ListenLocalhost(5001, o => o.Protocols = HttpProtocols.Http2);
 });
-builder.Services.AddHelloServiceHandler<HelloHandler>();
+builder.Services.AddWeatherServiceHandler<WeatherHandler>();
 
 var app = builder.Build();
-app.MapHelloServiceGrpc();
+app.MapWeatherServiceGrpc();
 app.Run();
 
-internal sealed class HelloHandler : IHelloServiceHandler
+internal sealed class WeatherHandler : IWeatherServiceHandler
 {
-    public Task<SayHelloOutput> SayHelloAsync(
-        SayHelloInput input, CancellationToken ct = default) =>
-        Task.FromResult(new SayHelloOutput($"Hello, {input.Name}!"));
+    public Task<GetCityOutput> GetCityAsync(
+        GetCityInput input, CancellationToken ct = default) =>
+        Task.FromResult(new GetCityOutput("Seattle"));
 }
 ```
 
 ## Client
 
-The generated `HelloServiceClient` is a native NSmithy client over an HTTP/2
+The generated `WeatherClient` is a native NSmithy client over an HTTP/2
 `HttpClient` — no `GrpcChannel`. Pass `GrpcProtocol` to select gRPC; the client
 configures the HTTP/2 `HttpClient` for you:
 
 ```csharp
-using Example.Hello;
+using Example.Weather;
 using NSmithy.Protocols.Grpc;
 
-var client = new HelloServiceClient(
+var client = new WeatherClient(
     new Uri("http://localhost:5001"),
     new() { Protocol = new GrpcProtocol() });
 
-var response = await client.SayHelloAsync(new SayHelloInput("world"));
-Console.WriteLine(response.Message); // Hello, world!
+var city = await client.GetCityAsync(new GetCityInput("SEA"));
+Console.WriteLine(city.Name); // Seattle
 ```
 
 For a service that also declares an HTTP protocol (e.g. `@simpleRestJson` +
@@ -133,6 +138,63 @@ event union. Generated clients and handlers use `IAsyncEnumerable<TEvent>`:
 - server streaming returns `IAsyncEnumerable<TEvent>`
 - client streaming accepts `IAsyncEnumerable<TEvent>`
 - bidirectional streaming accepts and returns `IAsyncEnumerable<TEvent>`
+
+Model a streaming operation by targeting a `@streaming` union. Each event member
+carries a `@protoIndex`, the same as any other gRPC member:
+
+```smithy
+@streaming
+union ChatEvent {
+    @protoIndex(1)
+    message: MessageEvent
+}
+
+/// Server-streaming: one request, many events.
+operation WatchRoom {
+    input := {
+        @required
+        @protoIndex(1)
+        room: String
+    }
+    output := {
+        @protoIndex(1)
+        events: ChatEvent
+    }
+}
+```
+
+The handler returns an `IAsyncEnumerable<ChatEvent>` and yields events as they
+occur:
+
+```csharp
+public async IAsyncEnumerable<ChatEvent> WatchRoomAsync(
+    WatchRoomInput input,
+    [EnumeratorCancellation] CancellationToken ct = default)
+{
+    for (var i = 1; i <= 3; i++)
+    {
+        await Task.Delay(25, ct);
+        yield return ChatEvent.FromMessage(
+            new MessageEvent(User: "server", Text: $"{input.Room}: update {i}"));
+    }
+}
+```
+
+The client consumes the stream with `await foreach`:
+
+```csharp
+await foreach (var evt in client.WatchRoomAsync(new WatchRoomInput("general"), ct))
+{
+    if (evt is ChatEvent.Message m)
+        Console.WriteLine($"{m.Value.User}: {m.Value.Text}");
+}
+```
+
+Client-streaming and bidirectional operations follow the same shape — the
+streaming member becomes an `IAsyncEnumerable<TEvent>` parameter, a return
+value, or both. See the runnable
+[`examples/grpc-streaming`](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/grpc-streaming)
+project for all three.
 
 Streaming payload blobs are not implemented yet. The streaming support here is
 for event streams, matching the common gRPC shape.

--- a/website/src/content/docs/protocols/overview.md
+++ b/website/src/content/docs/protocols/overview.md
@@ -13,7 +13,9 @@ A Smithy protocol trait on a service definition controls two things:
 NSmithy reads the protocol trait and generates the matching client and server
 surfaces. Your handler implementation is protocol-agnostic: the same
 `IMyServiceHandler` interface is used regardless of which protocol annotates the
-service.
+service. See [Client & Server Usage](/smithy-dotnet/protocols/usage/) for the
+canonical handler and client code — the protocol pages below only cover what is
+specific to each protocol (its trait, modeling rules, and wire format).
 
 ## Supported Protocols
 
@@ -27,21 +29,5 @@ service.
 | `smithy.protocols#rpcv2Cbor` | `@rpcv2Cbor` | .NET client, ASP.NET Core server | Preview |
 | `alloy.proto#grpc` | `@grpc` | gRPC client, ASP.NET Core gRPC server | Experimental |
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for conformance numbers and maturity details.
-
-## Which Protocol Should I Use?
-
-**[AWS restJson1](/smithy-dotnet/protocols/aws-rest-json1/)** is the
-recommended choice for new cross-ecosystem HTTP services. It has broad
-compatibility — most official Smithy code generators (Java, TypeScript, Python,
-Swift, Rust, Go) target `restJson1` — and NSmithy generates OpenAPI from it,
-giving you Scalar UI and standard tooling out of the box.
-
-**[simpleRestJson](/smithy-dotnet/protocols/simple-rest-json/)** is a simpler
-alternative if your consumers are exclusively .NET or Scala (via
-[Smithy4s](https://disneystreaming.github.io/smithy4s/)). It is the smoothest
-current NSmithy end-to-end path, but it has narrower ecosystem reach.
-
-**`alloy.proto#grpc`** is available for teams that need gRPC transport, but
-treat it as an early adopter path. It has the least maturity and more explicit
-modeling requirements.
+See [Protocol Status](/smithy-dotnet/protocols/status/) for conformance numbers,
+maturity details, and guidance on which protocol to choose.

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -34,27 +34,36 @@ Apply `@restXml` to the service and `@http` to each operation, the same as
 ```smithy
 $version: "2"
 
-namespace example.hello
+namespace example.weather
 
 use aws.protocols#restXml
 
 @restXml
-service HelloService {
+service Weather {
     version: "2026-01-01"
-    operations: [SayHello]
+    operations: [GetCity]
 }
 
-@http(method: "POST", uri: "/hello")
-operation SayHello {
+@readonly
+@http(method: "GET", uri: "/cities/{cityId}")
+operation GetCity {
     input := {
         @required
-        name: String
+        @httpLabel
+        cityId: String
     }
     output := {
         @required
-        @xmlName("Message")
-        message: String
+        @xmlName("Name")
+        name: String
     }
+    errors: [NoSuchResource]
+}
+
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
 }
 ```
 
@@ -62,21 +71,17 @@ operation SayHello {
 member name is used as-is.
 
 HTTP binding traits (`@httpLabel`, `@httpQuery`, `@httpHeader`, `@httpPayload`)
-work the same way as in `simpleRestJson` — members without an explicit binding
-go into the XML body.
+work the same way as in `simpleRestJson` — members without an explicit binding go
+into the XML body. See the [Modeling guide](/smithy-dotnet/guides/modeling/) for
+the full set.
 
-## Client
+## Usage
 
-The XML codec is wired up automatically by the generated client:
-
-```csharp
-using Example.Hello;
-
-var client = new HelloServiceClient(new Uri("https://api.example.com"));
-
-var response = await client.SayHelloAsync(new SayHelloInput("world"));
-Console.WriteLine(response.Message);
-```
+The XML codec is wired up automatically by the generated client, which is used
+exactly like every other NSmithy client — see [Client & Server
+Usage](/smithy-dotnet/protocols/usage/). Only the `@restXml` trait and the XML
+wire format are specific to this protocol. NSmithy does not generate restXml
+servers.
 
 Explicit SigV4 signing exists in early preview; see
 [Authentication](/smithy-dotnet/guides/client-configuration/authentication/). For production calls to

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -31,78 +31,41 @@ the protocol maps each operation to a fixed
 ```smithy
 $version: "2"
 
-namespace example.hello
+namespace example.weather
 
 use smithy.protocols#rpcv2Cbor
 
 @rpcv2Cbor
-service HelloService {
+service Weather {
     version: "2026-01-01"
-    operations: [SayHello]
+    operations: [GetCity]
 }
 
-operation SayHello {
+operation GetCity {
     input := {
         @required
-        name: String
+        cityId: String
     }
     output := {
         @required
-        message: String
+        name: String
     }
-    errors: [InvalidName]
+    errors: [NoSuchResource]
 }
 
 @error("client")
-structure InvalidName {
-    message: String
+structure NoSuchResource {
+    @required
+    resourceType: String
 }
 ```
 
-## Server
+## Usage
 
-Add the generated server handler to your ASP.NET Core app. The protocol path
-(`POST /service/{Service}/operation/{Operation}`) is mapped automatically:
-
-```csharp
-using Example.Hello;
-
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddHelloServiceHandler<MyHelloHandler>();
-
-var app = builder.Build();
-app.MapHelloServiceHttp();
-app.Run();
-
-internal sealed class MyHelloHandler : IHelloServiceHandler
-{
-    public Task<SayHelloOutput> SayHelloAsync(
-        SayHelloInput input,
-        CancellationToken cancellationToken = default
-    ) => Task.FromResult(new SayHelloOutput("my-server", $"Hello, {input.Name}!"));
-}
-```
-
-## Client
-
-The CBOR codec is wired up automatically by the generated client — no manual
-configuration is required:
-
-```csharp
-using Example.Hello;
-
-var client = new HelloServiceClient(new Uri("https://api.example.com"));
-
-try
-{
-    var response = await client.SayHelloAsync(new SayHelloInput("world"));
-    Console.WriteLine(response.Message);
-}
-catch (InvalidName ex)
-{
-    Console.WriteLine($"Error: {ex.Message}");
-}
-```
+The generated handler and client are identical to every other HTTP-JSON/CBOR
+protocol — see [Client & Server Usage](/smithy-dotnet/protocols/usage/). The CBOR
+codec is wired up automatically; the only thing specific to this protocol is the
+`@rpcv2Cbor` trait and the binary wire format on the fixed operation path.
 
 ## Example
 

--- a/website/src/content/docs/protocols/simple-rest-json.md
+++ b/website/src/content/docs/protocols/simple-rest-json.md
@@ -31,8 +31,8 @@ numbers.
 
 ## Modeling
 
-The example below is adapted from the [Smithy quickstart](https://smithy.io/2.0/quickstart.html).
-It demonstrates resources, pagination, errors, and common HTTP binding traits.
+Apply `@simpleRestJson` to the service and Smithy's standard HTTP binding traits
+on operations and members:
 
 ```smithy
 $version: "2"
@@ -41,111 +41,25 @@ namespace example.weather
 
 use alloy#simpleRestJson
 
-/// Provides weather forecasts.
 @simpleRestJson
-@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
-    version: "2006-03-01"
-    resources: [City]
-    operations: [GetCurrentTime]
-}
-
-resource City {
-    identifiers: { cityId: CityId }
-    properties: { coordinates: CityCoordinates }
-    read: GetCity
-    list: ListCities
-    resources: [Forecast]
-}
-
-resource Forecast {
-    identifiers: { cityId: CityId }
-    properties: { chanceOfRain: Float }
-    read: GetForecast
-}
-
-@pattern("^[A-Za-z0-9 ]+$")
-string CityId
-
-@readonly
-@http(method: "GET", uri: "/current-time")
-operation GetCurrentTime {
-    output := {
-        @required
-        time: Timestamp
-    }
+    version: "2026-01-01"
+    operations: [GetCity]
 }
 
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}")
 operation GetCity {
-    input := for City {
+    input := {
         @required
         @httpLabel
-        $cityId
-    }
-    output := for City {
-        @required
-        @notProperty
-        name: String
-
-        @required
-        $coordinates
-    }
-    errors: [NoSuchResource]
-}
-
-@readonly
-@paginated(items: "items")
-@http(method: "GET", uri: "/cities")
-operation ListCities {
-    input := {
-        @httpQuery("nextToken")
-        nextToken: String
-
-        @httpQuery("pageSize")
-        pageSize: Integer
+        cityId: String
     }
     output := {
-        nextToken: String
-
         @required
-        items: CitySummaries
+        name: String
     }
-}
-
-@readonly
-@http(method: "GET", uri: "/cities/{cityId}/forecast")
-operation GetForecast {
-    input := for Forecast {
-        @required
-        @httpLabel
-        $cityId
-    }
-    output := for Forecast {
-        $chanceOfRain
-    }
-}
-
-structure CityCoordinates {
-    @required
-    latitude: Float
-
-    @required
-    longitude: Float
-}
-
-list CitySummaries {
-    member: CitySummary
-}
-
-@references([{resource: City}])
-structure CitySummary {
-    @required
-    cityId: CityId
-
-    @required
-    name: String
+    errors: [NoSuchResource]
 }
 
 @error("client")
@@ -155,81 +69,16 @@ structure NoSuchResource {
 }
 ```
 
-Key HTTP binding traits:
+Members without an explicit HTTP binding are serialized in the JSON body. For
+resources, pagination, and the full set of HTTP binding traits, see the
+[Modeling guide](/smithy-dotnet/guides/modeling/).
 
-| Trait | Binds member to |
-| --- | --- |
-| `@httpLabel` | URI path segment |
-| `@httpQuery("key")` | query string parameter |
-| `@httpHeader("name")` | request or response header |
-| `@httpPayload` | raw request/response body |
+## Usage
 
-Members without an explicit binding go into the JSON body.
-
-## Server
-
-NSmithy generates one `IWeatherServiceHandler` interface with a method for each
-operation. Implement it once; the generated ASP.NET Core minimal API adapter handles routing,
-serialization, and error dispatch.
-
-```csharp
-using Example.Weather;
-
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddWeatherServiceHandler<WeatherHandler>();
-
-var app = builder.Build();
-app.MapWeatherServiceHttp();
-app.Run();
-
-internal sealed class WeatherHandler : IWeatherServiceHandler
-{
-    public Task<GetCurrentTimeOutput> GetCurrentTimeAsync(
-        GetCurrentTimeInput input, CancellationToken ct = default) =>
-        Task.FromResult(new GetCurrentTimeOutput(DateTimeOffset.UtcNow));
-
-    public Task<GetCityOutput> GetCityAsync(
-        GetCityInput input, CancellationToken ct = default)
-    {
-        if (input.CityId == "unknown")
-            throw new NoSuchResource(null, "City");
-
-        return Task.FromResult(new GetCityOutput(
-            name: "Seattle",
-            coordinates: new CityCoordinates(47.6f, -122.3f)
-        ));
-    }
-
-    public Task<ListCitiesOutput> ListCitiesAsync(
-        ListCitiesInput input, CancellationToken ct = default) =>
-        Task.FromResult(new ListCitiesOutput(new CitySummaries([
-            new CitySummary("SEA", "Seattle"),
-            new CitySummary("NYC", "New York"),
-        ])));
-
-    public Task<GetForecastOutput> GetForecastAsync(
-        GetForecastInput input, CancellationToken ct = default) =>
-        Task.FromResult(new GetForecastOutput(chanceOfRain: 0.4f));
-}
-```
-
-Throwing a generated error type from a handler method causes the adapter to
-serialize it with the correct HTTP status code and JSON body.
-
-## Client
-
-```csharp
-using Example.Weather;
-
-var client = new WeatherClient(new Uri("http://localhost:5000"));
-
-var time = await client.GetCurrentTimeAsync(new GetCurrentTimeInput());
-Console.WriteLine(time.Time);
-
-var cities = await client.ListCitiesAsync(new ListCitiesInput(pageSize: 10));
-foreach (var c in cities.Items.Values)
-    Console.WriteLine($"{c.CityId}: {c.Name}");
-
-var seattle = await client.GetCityAsync(new GetCityInput("SEA"));
-Console.WriteLine($"{seattle.Name} ({seattle.Coordinates.Latitude}, {seattle.Coordinates.Longitude})");
-```
+NSmithy generates one `IWeatherServiceHandler` interface with a method per
+operation, plus a typed `WeatherClient`. Implement the handler once; the
+generated ASP.NET Core minimal API adapter handles routing, serialization, and
+error dispatch. This handler-and-client shape is the same across every
+HTTP-JSON/CBOR protocol — see [Client & Server
+Usage](/smithy-dotnet/protocols/usage/) for the full example. Only the
+`@simpleRestJson` trait is specific to this protocol.

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -51,9 +51,12 @@ Notes:
 
 ## Recommended Use
 
-- Prefer simpleRestJson if you want the smoothest end-to-end preview path.
+- Prefer simpleRestJson for the smoothest end-to-end preview path, especially
+  when your consumers are primarily .NET or Scala (via
+  [Smithy4s](https://disneystreaming.github.io/smithy4s/)).
 - Use AWS restJson1 when you need generated AWS-style REST/JSON clients or
-  ASP.NET Core server surfaces.
+  ASP.NET Core server surfaces, broad cross-ecosystem compatibility (most
+  official Smithy generators target it), or OpenAPI/Scalar generation.
 - Use `smithy.protocols#rpcv2Cbor` for binary CBOR-encoded services; client and
   server generation are both available.
 - Use AWS JSON or AWS restXml when you want to evaluate AWS-compatible client

--- a/website/src/content/docs/protocols/usage.md
+++ b/website/src/content/docs/protocols/usage.md
@@ -1,0 +1,119 @@
+---
+title: Client & Server Usage
+description: The generated handler and client are the same across every protocol — only the model's protocol trait and the wire format change.
+---
+
+The point of Smithy codegen is that your **application code doesn't change when
+the protocol does**. You implement one handler and call one typed client;
+swapping the protocol trait on the service swaps the wire format underneath
+without touching either side.
+
+This page is the canonical unary example. Each protocol page then documents only
+what is genuinely protocol-specific: the trait to apply, any modeling
+requirements, and the bytes on the wire.
+
+## Model
+
+A single read operation. The shapes below — and the C# that follows — are the
+same for every protocol. What changes per protocol is layered on top:
+
+- the **service's protocol trait** (`@simpleRestJson`, `@restJson1`,
+  `@rpcv2Cbor`, `@grpc`, …), and
+- for HTTP protocols, the **HTTP binding traits** on operations (`@http`,
+  `@httpLabel`, …); gRPC uses `@protoIndex` instead.
+
+```smithy
+$version: "2"
+
+namespace example.weather
+
+// Add a protocol trait here — @simpleRestJson, @restJson1, @rpcv2Cbor, @grpc, …
+service Weather {
+    version: "2026-01-01"
+    operations: [GetCity]
+}
+
+@readonly
+operation GetCity {
+    input := {
+        @required
+        cityId: String
+    }
+    output := {
+        @required
+        name: String
+    }
+    errors: [NoSuchResource]
+}
+
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
+}
+```
+
+A service generates nothing until it carries exactly one protocol trait, so this
+neutral shape isn't buildable on its own — each protocol page shows the complete,
+annotated model. The point is what *doesn't* change: the shapes, and the handler
+and client below.
+
+## Server
+
+NSmithy generates one `IWeatherServiceHandler` interface with a method per
+operation. Implement it once; the generated ASP.NET Core adapter handles
+routing, serialization, and error dispatch.
+
+```csharp
+using Example.Weather;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddWeatherServiceHandler<WeatherHandler>();
+
+var app = builder.Build();
+app.MapWeatherServiceHttp();
+app.Run();
+
+internal sealed class WeatherHandler : IWeatherServiceHandler
+{
+    public Task<GetCityOutput> GetCityAsync(
+        GetCityInput input, CancellationToken ct = default)
+    {
+        if (input.CityId == "unknown")
+            throw new NoSuchResource(null, "City");
+
+        return Task.FromResult(new GetCityOutput("Seattle"));
+    }
+}
+```
+
+Throwing a generated error type serializes it with the correct status code and
+body for whichever protocol the service declares.
+
+## Client
+
+```csharp
+using Example.Weather;
+
+var client = new WeatherClient(new Uri("https://api.example.com"));
+var city = await client.GetCityAsync(new GetCityInput("SEA"));
+Console.WriteLine(city.Name);
+```
+
+The generated client uses the service's declared protocol by default — no codec
+wiring is required.
+
+## Protocol-specific deltas
+
+The handler and client above are identical for `simpleRestJson`, `restJson1`,
+`awsJson1_1`, `awsJson1_0`, and `rpcv2Cbor`. The exceptions:
+
+- **Server generation** exists for `simpleRestJson`, `restJson1`, and
+  `rpcv2Cbor`. `awsJson1_1`/`awsJson1_0` and `restXml` are **client-only** today,
+  so only the client half applies.
+- **gRPC** needs a little transport setup (HTTP/2 Kestrel, `Protocol =
+  new GrpcProtocol()`) and is the one place the code differs — see
+  [gRPC](/smithy-dotnet/protocols/grpc/). It is also where **streaming** lives.
+
+See [Protocol Status](/smithy-dotnet/protocols/status/) for what is generated per
+protocol.

--- a/website/src/styles/docs-theme.css
+++ b/website/src/styles/docs-theme.css
@@ -17,6 +17,23 @@ html:not(.nsmithy-landing) .content-panel h1 {
   letter-spacing: -0.02em;
 }
 
+/* Site title: match the landing header (LandingPage.astro `.nsl-brand`) so the
+   brand looks the same moving between the two — Space Grotesk at a fixed 19px, a
+   tighter logo/text gap, and a 30px rounded logo. Starlight's SiteTitle styles
+   are component-scoped, so these need `!important` to win. */
+.site-title {
+  gap: 11px !important;
+  font-family: 'Space Grotesk', var(--sl-font) !important;
+  font-size: 19px !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em !important;
+}
+.site-title img {
+  height: 30px !important;
+  width: auto !important;
+  border-radius: 7px !important;
+}
+
 /* Dark mode: a cool, comfortable reading dark — clearly lifted off the
    landing's near-black (#08080c) for long-form reading, but tinted so it still
    feels part of the same family. Light is unchanged. */


### PR DESCRIPTION
## Summary

Two related landing/docs changes.

**Mobile landing widgets** — on mobile the two widget sections stack vertically and each panel takes its natural height, so the auto-carousel made the page jump. The auto-advance is now gated on a `matchMedia` check per widget's stacked breakpoint (pauses while stacked, resumes on resize; manual taps still work), and the fixed "tallest tab" height is dropped on mobile (inactive panels use `display:none`). This supersedes the fixed-height workaround from #75.

**Protocol docs overhaul** — the pages repeated near-identical handler/client code and each used a different bespoke model, which undercut the "same code, any protocol" message.

- New **Client & Server Usage** page (`protocols/usage.md`): one canonical unary handler + client, with a protocol-neutral model (no trait, no HTTP bindings).
- **Every protocol page's Modeling section now uses the same `Weather`/`GetCity` service**, differing only by traits: `@http`/`@httpLabel` (HTTP protocols), none (RPC), `@protoIndex` (gRPC), `@xmlName` demo (restXml).
- Server/Client sections dropped from the HTTP-JSON/CBOR pages (they link to Usage). gRPC keeps its own code (HTTP/2, `GrpcProtocol`) and owns the **streaming** example, since streaming is gRPC-only today.
- simpleRestJson's rich resources/pagination example moved to a new **Modeling** guide (`guides/modeling.md`).
- Removed Overview's "Which Protocol Should I Use?"; folded its unique guidance into the Status page's *Recommended Use*.

## Test plan

- [x] `npm run build` (website) is green; 28 pages build, no broken links.
- [ ] Spot-check mobile widgets don't auto-jump and follow the active panel's height.
- [ ] Verify sidebar shows new **Client & Server Usage** and **Modeling** entries (requires `astro dev` restart).
