### PR TITLE
feat: add explicit HTTP body model

### DIFF
--- a/packages/NSmithy.Aws/AwsSigV4Interceptor.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Interceptor.cs
@@ -57,7 +57,7 @@ public sealed class AwsSigV4Interceptor(
         var requestUri = ResolveRequestUri(request.RequestUri);
         var amzDate = now.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'", InvariantDateTime);
         var date = now.UtcDateTime.ToString("yyyyMMdd", InvariantDateTime);
-        var payloadHash = Sha256Hex(request.Content ?? []);
+        var payloadHash = Sha256Hex(SignablePayloadBytes(request.Body));
 
         request.Headers["Host"] = [HostHeader(requestUri)];
         request.Headers["X-Amz-Date"] = [amzDate];
@@ -113,6 +113,16 @@ public sealed class AwsSigV4Interceptor(
 
         return new Uri(endpoint, requestUri);
     }
+
+    private static byte[] SignablePayloadBytes(SmithyHttpBody body) =>
+        body switch
+        {
+            SmithyHttpBody.Bytes bytes => bytes.Content,
+            SmithyHttpBody.Streaming => throw new InvalidOperationException(
+                "AWS SigV4 signing for streaming request bodies is not supported yet."
+            ),
+            _ => [],
+        };
 
     private static string HostHeader(Uri uri)
     {

--- a/packages/NSmithy.Client/QueryParameterAuthInterceptor.cs
+++ b/packages/NSmithy.Client/QueryParameterAuthInterceptor.cs
@@ -28,11 +28,9 @@ internal sealed class QueryParameterAuthInterceptor(string name, string value) :
 
         var signed = new SmithyHttpRequest(original.Method, requestUri)
         {
-            Content = original.Content,
+            Body = original.Body,
             ContentType = original.ContentType,
             ExpectStreamingResponse = original.ExpectStreamingResponse,
-            StreamingContent = original.StreamingContent,
-            StreamingContentLength = original.StreamingContentLength,
         };
         foreach (var header in original.Headers)
         {

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -188,7 +188,7 @@ public sealed class SmithyClientRuntime(
             if (
                 retryStrategy is not null
                 && attempt < retryStrategy.MaxAttempts
-                && request.StreamingContent is null
+                && request.Body is not SmithyHttpBody.Streaming
                 && retryStrategy.ShouldRetry(retryContext)
             )
             {
@@ -258,9 +258,7 @@ public sealed class SmithyClientRuntime(
     {
         var clone = new SmithyHttpRequest(request.Method, requestUri)
         {
-            Content = request.Content,
-            StreamingContent = request.StreamingContent,
-            StreamingContentLength = request.StreamingContentLength,
+            Body = request.Body,
             ExpectStreamingResponse = request.ExpectStreamingResponse,
             ContentType = request.ContentType,
         };

--- a/packages/NSmithy.Http/HttpClientTransport.cs
+++ b/packages/NSmithy.Http/HttpClientTransport.cs
@@ -36,17 +36,17 @@ public sealed class HttpClientTransport : IHttpTransport
             message.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
-        if (request.StreamingContent is not null)
+        if (request.Body is SmithyHttpBody.Streaming streamBody)
         {
-            message.Content = new StreamContent(request.StreamingContent);
-            if (request.StreamingContentLength is { } contentLength)
+            message.Content = new StreamContent(streamBody.Content);
+            if (streamBody.ContentLength is { } contentLength)
             {
                 message.Content.Headers.ContentLength = contentLength;
             }
         }
-        else if (request.Content is not null)
+        else if (request.Body is SmithyHttpBody.Bytes bytesBody)
         {
-            message.Content = new ByteArrayContent(request.Content);
+            message.Content = new ByteArrayContent(bytesBody.Content);
         }
 
         if (message.Content is not null)
@@ -74,20 +74,20 @@ public sealed class HttpClientTransport : IHttpTransport
             return new SmithyHttpResponse(
                 response.StatusCode,
                 response.ReasonPhrase,
-                [],
+                new SmithyHttpBody.Streaming(
+                    new ResponseContentStream(
+                        response,
+                        response.Content is null
+                            ? Stream.Null
+                            : await response
+                                .Content.ReadAsStreamAsync(cancellationToken)
+                                .ConfigureAwait(false)
+                    ),
+                    response.Content?.Headers.ContentLength
+                ),
                 ToHeaderDictionary(response.Headers),
                 contentHeaders
-            )
-            {
-                StreamingContent = new ResponseContentStream(
-                    response,
-                    response.Content is null
-                        ? Stream.Null
-                        : await response
-                            .Content.ReadAsStreamAsync(cancellationToken)
-                            .ConfigureAwait(false)
-                ),
-            };
+            );
         }
 
         using var bufferedResponse = response;
@@ -103,7 +103,7 @@ public sealed class HttpClientTransport : IHttpTransport
         return new SmithyHttpResponse(
             response.StatusCode,
             response.ReasonPhrase,
-            content,
+            content.Length == 0 ? SmithyHttpBody.Empty : new SmithyHttpBody.Bytes(content),
             headers,
             response.Content is null
                 ? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)

--- a/packages/NSmithy.Http/SmithyHttpBody.cs
+++ b/packages/NSmithy.Http/SmithyHttpBody.cs
@@ -1,0 +1,23 @@
+namespace NSmithy.Http;
+
+public abstract record SmithyHttpBody
+{
+    private SmithyHttpBody() { }
+
+    public static SmithyHttpBody Empty { get; } = new EmptyBody();
+
+    public sealed record Bytes(byte[] Content) : SmithyHttpBody
+    {
+        public byte[] Content { get; } =
+            Content ?? throw new ArgumentNullException(nameof(Content));
+    }
+
+    public sealed record Streaming(System.IO.Stream Content, long? ContentLength = null)
+        : SmithyHttpBody
+    {
+        public System.IO.Stream Content { get; } =
+            Content ?? throw new ArgumentNullException(nameof(Content));
+    }
+
+    private sealed record EmptyBody : SmithyHttpBody;
+}

--- a/packages/NSmithy.Http/SmithyHttpRequest.cs
+++ b/packages/NSmithy.Http/SmithyHttpRequest.cs
@@ -15,16 +15,7 @@ public sealed class SmithyHttpRequest(HttpMethod method, string requestUri)
     public IDictionary<string, IReadOnlyList<string>> Headers { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Performance",
-        "CA1819:Properties should not return arrays",
-        Justification = "SmithyHttpRequest is a mutable low-level transport DTO for buffered wire bytes."
-    )]
-    public byte[]? Content { get; set; }
-
-    public Stream? StreamingContent { get; set; }
-
-    public long? StreamingContentLength { get; set; }
+    public SmithyHttpBody Body { get; set; } = SmithyHttpBody.Empty;
 
     public bool ExpectStreamingResponse { get; set; }
 

--- a/packages/NSmithy.Http/SmithyHttpResponse.cs
+++ b/packages/NSmithy.Http/SmithyHttpResponse.cs
@@ -6,12 +6,32 @@ namespace NSmithy.Http;
 public sealed record SmithyHttpResponse(
     HttpStatusCode StatusCode,
     string? ReasonPhrase,
-    byte[] Content,
+    SmithyHttpBody Body,
     IReadOnlyDictionary<string, IReadOnlyList<string>> Headers,
     IReadOnlyDictionary<string, IReadOnlyList<string>> ContentHeaders
 )
 {
-    public string ContentText => Encoding.UTF8.GetString(Content);
+    public SmithyHttpResponse(
+        HttpStatusCode statusCode,
+        string? reasonPhrase,
+        byte[] content,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> headers,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> contentHeaders
+    )
+        : this(
+            statusCode,
+            reasonPhrase,
+            content.Length == 0 ? SmithyHttpBody.Empty : new SmithyHttpBody.Bytes(content),
+            headers,
+            contentHeaders
+        ) { }
 
-    public Stream? StreamingContent { get; init; }
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1819:Properties should not return arrays",
+        Justification = "SmithyHttpResponse exposes buffered wire bytes for protocol codecs."
+    )]
+    public byte[] Content => Body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
+
+    public string ContentText => Encoding.UTF8.GetString(Content);
 }

--- a/packages/NSmithy.Http/SmithyRequestModifiers.cs
+++ b/packages/NSmithy.Http/SmithyRequestModifiers.cs
@@ -16,18 +16,27 @@ public static class SmithyRequestModifiers
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(encoding);
 
-        if (request.Content is null)
+        if (ReferenceEquals(request.Body, SmithyHttpBody.Empty))
         {
             return;
         }
 
-        request.Content = encoding switch
+        if (request.Body is not SmithyHttpBody.Bytes bytes)
         {
-            "gzip" => CompressGzip(request.Content),
-            _ => throw new NotSupportedException(
-                $"Request compression encoding '{encoding}' is not supported."
-            ),
-        };
+            throw new InvalidOperationException(
+                "Request compression for streaming bodies is not supported."
+            );
+        }
+
+        request.Body = new SmithyHttpBody.Bytes(
+            encoding switch
+            {
+                "gzip" => CompressGzip(bytes.Content),
+                _ => throw new NotSupportedException(
+                    $"Request compression encoding '{encoding}' is not supported."
+                ),
+            }
+        );
 
         if (
             request.ContentHeaders.TryGetValue("Content-Encoding", out var values)
@@ -49,14 +58,21 @@ public static class SmithyRequestModifiers
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (request.Content is null)
+        if (ReferenceEquals(request.Body, SmithyHttpBody.Empty))
         {
             return;
         }
 
+        if (request.Body is not SmithyHttpBody.Bytes bytes)
+        {
+            throw new InvalidOperationException(
+                "Content-MD5 for streaming bodies is not supported."
+            );
+        }
+
         request.ContentHeaders["Content-MD5"] =
         [
-            Convert.ToBase64String(MD5.HashData(request.Content)),
+            Convert.ToBase64String(MD5.HashData(bytes.Content)),
         ];
     }
 #pragma warning restore CA5351

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -82,10 +82,11 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
         {
             var request = new SmithyHttpRequest(HttpMethod.Post, "/")
             {
-                Content =
+                Body = new SmithyHttpBody.Bytes(
                     typeof(TInput) == typeof(SmithyUnit)
                         ? EmptyJsonObject
-                        : requestCodec.Serialize(input),
+                        : requestCodec.Serialize(input)
+                ),
                 ContentType = contentType,
             };
             request.Headers["Accept"] = [contentType];
@@ -118,9 +119,8 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
         public TInput DeserializeRequest(SmithyHttpRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return request.Content is null || request.Content.Length == 0
-                ? default!
-                : requestCodec.Deserialize(request.Content);
+            var content = BodyBytes(request.Body);
+            return content.Length == 0 ? default! : requestCodec.Deserialize(content);
         }
 
         public SmithyHttpResponse SerializeResponse(TOutput output) =>
@@ -152,6 +152,9 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
 
             return default!;
         }
+
+        private static byte[] BodyBytes(SmithyHttpBody body) =>
+            body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
 
         private static HttpOperationError[] CompileErrors(
             IReadOnlyList<IOperationErrorSchema> errors

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -138,8 +138,8 @@ public sealed class GrpcProtocol : IProtocol
         {
             var request = new SmithyHttpRequest(HttpMethod.Post, methodPath)
             {
-                Content = GrpcMessageFraming.Frame(
-                    inputIsUnit ? [] : requestCodec!.Serialize(input)
+                Body = new SmithyHttpBody.Bytes(
+                    GrpcMessageFraming.Frame(inputIsUnit ? [] : requestCodec!.Serialize(input))
                 ),
                 ContentType = ContentType,
             };
@@ -170,7 +170,7 @@ public sealed class GrpcProtocol : IProtocol
                 return default!;
             }
 
-            var payload = GrpcMessageFraming.ReadSingle(request.Content ?? []);
+            var payload = GrpcMessageFraming.ReadSingle(BodyBytes(request.Body));
             return requestCodec!.Deserialize(payload);
         }
 
@@ -305,7 +305,7 @@ public sealed class GrpcProtocol : IProtocol
                 return default!;
             }
 
-            var payload = GrpcMessageFraming.ReadSingle(request.Content ?? []);
+            var payload = GrpcMessageFraming.ReadSingle(BodyBytes(request.Body));
             return requestCodec!.Deserialize(payload);
         }
 
@@ -570,6 +570,9 @@ public sealed class GrpcProtocol : IProtocol
         && contentType.Any(value =>
             value.StartsWith("application/grpc", StringComparison.OrdinalIgnoreCase)
         );
+
+    private static byte[] BodyBytes(SmithyHttpBody body) =>
+        body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
 
     private static void EnsureGrpcResponse(SmithyHttpResponse response)
     {

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -77,9 +77,7 @@ public static class RestProtocol
             var body = writePayload(input!);
             if (body.HasContent)
             {
-                request.Content = body.StreamingContent is null ? body.Content : null;
-                request.StreamingContent = body.StreamingContent;
-                request.StreamingContentLength = body.StreamingContentLength;
+                request.Body = ToHttpBody(body);
                 if (body.ContentType is not null)
                     SetContentTypeIfMissing(request, body.ContentType);
             }
@@ -87,7 +85,7 @@ public static class RestProtocol
         }
         if (binding.InputBodyCodec is { } codec)
         {
-            request.Content = codec.Serialize(input!);
+            request.Body = ToHttpBody(codec.Serialize(input!));
             SetContentTypeIfMissing(request, binding.BodyContentType);
         }
 
@@ -135,8 +133,11 @@ public static class RestProtocol
         if (binding.QueryParamsMember is { } qpMember)
             qpMember.SetObject(builder, ReadQueryParams(qpMember, query, binding.BoundQueryNames));
         if (binding.InputPayloadReader is { } readPayload)
-            readPayload(request.Content, request.StreamingContent, builder);
-        else if (binding.InputBodyCodec is { } codec && request.Content is { Length: > 0 } content)
+            readPayload(BodyBytesOrNull(request.Body), BodyStreamOrNull(request.Body), builder);
+        else if (
+            binding.InputBodyCodec is { } codec
+            && BodyBytesOrNull(request.Body) is { Length: > 0 } content
+        )
             codec.ReadInto(content, builder);
 
         return (TInput)binding.InputSchema.BuildObject(builder);
@@ -169,26 +170,21 @@ public static class RestProtocol
         if (binding.ResponsePrefixHeadersMember is { } respPhMember)
             AddPrefixedHeaders(headers, respPhMember.Prefix, respPhMember.Member, output!);
 
-        byte[] content = [];
-        Stream? streamingContent = null;
+        SmithyHttpBody responseBody = SmithyHttpBody.Empty;
         if (binding.OutputPayloadWriter is { } writePayload)
         {
             var body = writePayload(output!);
-            content = body.StreamingContent is null ? body.Content : [];
-            streamingContent = body.StreamingContent;
+            responseBody = ToHttpBody(body);
             if (body.ContentType is not null)
                 contentHeaders["Content-Type"] = [body.ContentType];
         }
         else if (binding.OutputBodyCodec is { } codec)
         {
-            content = codec.Serialize(output!);
+            responseBody = ToHttpBody(codec.Serialize(output!));
             contentHeaders["Content-Type"] = [binding.BodyContentType];
         }
 
-        return new SmithyHttpResponse(statusCode, null, content, headers, contentHeaders)
-        {
-            StreamingContent = streamingContent,
-        };
+        return new SmithyHttpResponse(statusCode, null, responseBody, headers, contentHeaders);
     }
 
     public static TOutput DeserializeResponse<TInput, TOutput>(
@@ -228,7 +224,7 @@ public static class RestProtocol
                 ReadPrefixedHeaders(respPhMember.Member, response.Headers, respPhMember.Prefix)
             );
         if (binding.OutputPayloadReader is { } readPayload)
-            readPayload(response.Content, response.StreamingContent, builder);
+            readPayload(BodyBytesOrNull(response.Body), BodyStreamOrNull(response.Body), builder);
         else if (binding.OutputBodyCodec is { } codec && response.Content.Length > 0)
             codec.ReadInto(response.Content, builder);
 
@@ -347,7 +343,11 @@ public static class RestProtocol
                     );
                 }
 
-                payloadReader?.Invoke(response.Content, response.StreamingContent, builder);
+                payloadReader?.Invoke(
+                    BodyBytesOrNull(response.Body),
+                    BodyStreamOrNull(response.Body),
+                    builder
+                );
                 if (bodyCodec is not null && response.Content.Length > 0)
                 {
                     bodyCodec.ReadInto(response.Content, builder);
@@ -445,11 +445,25 @@ public static class RestProtocol
         return new SmithyHttpResponse(
             (HttpStatusCode)statusCode,
             null,
-            content,
+            ToHttpBody(content),
             headers,
             contentHeaders
         );
     }
+
+    private static SmithyHttpBody ToHttpBody(RestBody body) =>
+        body.StreamingContent is not null
+            ? new SmithyHttpBody.Streaming(body.StreamingContent, body.StreamingContentLength)
+            : ToHttpBody(body.Content);
+
+    private static SmithyHttpBody ToHttpBody(byte[] content) =>
+        content.Length == 0 ? SmithyHttpBody.Empty : new SmithyHttpBody.Bytes(content);
+
+    private static byte[]? BodyBytesOrNull(SmithyHttpBody body) =>
+        body is SmithyHttpBody.Bytes bytes ? bytes.Content : null;
+
+    private static Stream? BodyStreamOrNull(SmithyHttpBody body) =>
+        body is SmithyHttpBody.Streaming stream ? stream.Content : null;
 
     private static string LocalName(string shapeId)
     {

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -82,7 +82,7 @@ public sealed class RpcV2CborProtocol : IProtocol
             request.Headers["Accept"] = [ContentType];
             if (!inputIsUnit)
             {
-                request.Content = requestCodec.Serialize(input);
+                request.Body = new SmithyHttpBody.Bytes(requestCodec.Serialize(input));
                 request.ContentType = ContentType;
             }
 
@@ -111,7 +111,7 @@ public sealed class RpcV2CborProtocol : IProtocol
                 return default!;
             }
 
-            var content = request.Content ?? [];
+            var content = BodyBytes(request.Body);
             return content.Length == 0 ? default! : requestCodec.Deserialize(content);
         }
 
@@ -181,6 +181,9 @@ public sealed class RpcV2CborProtocol : IProtocol
                 response => DeserializeRequiredBody(codec, response.Content)
             );
         }
+
+        private static byte[] BodyBytes(SmithyHttpBody body) =>
+            body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
     }
 
     /// <summary>

--- a/packages/NSmithy.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
+++ b/packages/NSmithy.Server.AspNetCore/SmithyAspNetCoreProtocol.cs
@@ -40,13 +40,17 @@ public static class SmithyAspNetCoreProtocol
         request.ContentType = httpContext.Request.ContentType;
         if (streamBody)
         {
-            request.StreamingContent = httpContext.Request.Body;
-            request.StreamingContentLength = httpContext.Request.ContentLength;
+            request.Body = new SmithyHttpBody.Streaming(
+                httpContext.Request.Body,
+                httpContext.Request.ContentLength
+            );
         }
         else
         {
-            request.Content = await ReadRequestBodyContentAsync(httpContext, cancellationToken)
-                .ConfigureAwait(false);
+            request.Body = ToHttpBody(
+                await ReadRequestBodyContentAsync(httpContext, cancellationToken)
+                    .ConfigureAwait(false)
+            );
         }
         return request;
     }
@@ -76,16 +80,21 @@ public static class SmithyAspNetCoreProtocol
             httpContext.Response.Headers[header.Key] = header.Value.ToArray();
         }
 
-        if (response.StreamingContent is not null)
+        if (response.Body is SmithyHttpBody.Streaming streamBody)
         {
-            await response
-                .StreamingContent.CopyToAsync(httpContext.Response.Body, cancellationToken)
+            if (streamBody.ContentLength is { } contentLength)
+            {
+                httpContext.Response.ContentLength = contentLength;
+            }
+
+            await streamBody
+                .Content.CopyToAsync(httpContext.Response.Body, cancellationToken)
                 .ConfigureAwait(false);
         }
-        else if (response.Content.Length > 0)
+        else if (response.Body is SmithyHttpBody.Bytes bytesBody && bytesBody.Content.Length > 0)
         {
             await httpContext
-                .Response.Body.WriteAsync(response.Content, cancellationToken)
+                .Response.Body.WriteAsync(bytesBody.Content, cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -323,4 +332,7 @@ public static class SmithyAspNetCoreProtocol
         await Task.CompletedTask.ConfigureAwait(false);
         yield return eventFrame;
     }
+
+    private static SmithyHttpBody ToHttpBody(byte[] content) =>
+        content.Length == 0 ? SmithyHttpBody.Empty : new SmithyHttpBody.Bytes(content);
 }

--- a/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
@@ -11,7 +11,7 @@ public sealed class AwsSigV4InterceptorTests
     public async Task SignAddsSigV4Headers()
     {
         var request = new SmithyHttpRequest(HttpMethod.Post, "/");
-        request.Content = "{}"u8.ToArray();
+        request.Body = new SmithyHttpBody.Bytes("{}"u8.ToArray());
         request.ContentType = "application/x-amz-json-1.0";
         request.Headers["X-Amz-Target"] = ["DynamoDB_20120810.ListTables"];
 

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -416,7 +416,7 @@ public sealed class SmithyClientRuntimeTests
         );
         var request = new SmithyHttpRequest(HttpMethod.Post, "/upload")
         {
-            StreamingContent = new MemoryStream("hello"u8.ToArray()),
+            Body = new SmithyHttpBody.Streaming(new MemoryStream("hello"u8.ToArray())),
         };
 
         await Assert.ThrowsAsync<SmithyClientException>(() =>

--- a/tests/NSmithy.Tests/Protocols/Grpc/GrpcProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/Grpc/GrpcProtocolTests.cs
@@ -127,7 +127,8 @@ public sealed class GrpcProtocolTests
         string[] trailers = ["trailers"];
         Assert.Equal(trailers, request.Headers["te"]);
         // 5-byte frame header + proto body (0A 02 'h' 'i')
-        Assert.Equal(GrpcMessageFraming.HeaderLength + 4, request.Content!.Length);
+        var body = Assert.IsType<SmithyHttpBody.Bytes>(request.Body);
+        Assert.Equal(GrpcMessageFraming.HeaderLength + 4, body.Content.Length);
     }
 
     [Fact]

--- a/tests/NSmithy.Tests/Protocols/RestJson/RestJson1ProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/RestJson/RestJson1ProtocolTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using Microsoft.AspNetCore.Http;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
 using NSmithy.Http;
@@ -89,7 +90,8 @@ public sealed class RestJson1ProtocolTests
         Assert.Equal("/users/ada%20lovelace", request.RequestUri);
         Assert.Equal("token-123", request.Headers["X-Request-Token"].Single());
         Assert.Equal("application/json", request.ContentType);
-        Assert.Equal("{\"displayName\":\"Ada\"}", Encoding.UTF8.GetString(request.Content!));
+        var body = Assert.IsType<SmithyHttpBody.Bytes>(request.Body);
+        Assert.Equal("{\"displayName\":\"Ada\"}", Encoding.UTF8.GetString(body.Content));
     }
 
     [Fact]
@@ -140,7 +142,7 @@ public sealed class RestJson1ProtocolTests
         );
         var request = new SmithyHttpRequest(HttpMethod.Put, "/users/ada%20lovelace")
         {
-            Content = Encoding.UTF8.GetBytes("{\"displayName\":\"Ada\"}"),
+            Body = new SmithyHttpBody.Bytes(Encoding.UTF8.GetBytes("{\"displayName\":\"Ada\"}")),
             ContentType = "application/json",
         };
         request.Headers["X-Request-Token"] = ["token-123"];
@@ -252,7 +254,7 @@ public sealed class RestJson1ProtocolTests
             request.RequestUri
         );
         Assert.Equal("abc", request.Headers["X-Extra-Trace"].Single());
-        Assert.Null(request.Content);
+        Assert.Same(SmithyHttpBody.Empty, request.Body);
         Assert.Null(request.ContentType);
     }
 
@@ -671,6 +673,30 @@ public sealed class RestJson1ProtocolTests
 
     public sealed class UploadUserAvatarOutputBuilder { }
 
+    public sealed record UploadUserAvatarStreamInput(
+        string UserId,
+        string Checksum,
+        Stream Payload
+    );
+
+    public sealed class UploadUserAvatarStreamInputBuilder
+    {
+        public string? UserId { get; set; }
+
+        public string? Checksum { get; set; }
+
+        public Stream? Payload { get; set; }
+    }
+
+    public sealed record GetUserAvatarStreamOutput(string ETag, Stream Payload);
+
+    public sealed class GetUserAvatarStreamOutputBuilder
+    {
+        public string? ETag { get; set; }
+
+        public Stream? Payload { get; set; }
+    }
+
     [Fact]
     public void RestJson1ProtocolSerializesHttpPayload()
     {
@@ -730,8 +756,240 @@ public sealed class RestJson1ProtocolTests
         Assert.Equal("/users/ada/avatar", request.RequestUri);
         Assert.Equal("abc123", request.Headers["X-Checksum"].Single());
         Assert.Equal("application/octet-stream", request.ContentType);
-        Assert.Equal(payload, request.Content);
+        var body = Assert.IsType<SmithyHttpBody.Bytes>(request.Body);
+        Assert.Equal(payload, body.Content);
     }
+
+    [Fact]
+    public void RestJson1ProtocolSerializesStreamingBlobPayloadWithoutBuffering()
+    {
+        var inputSchema = StreamingUploadInputSchema();
+        var outputSchema = Schemas
+            .Structure<UploadUserAvatarOutput, UploadUserAvatarOutputBuilder>(
+                new ShapeId("example", "UploadUserAvatarOutput")
+            )
+            .Build(
+                static () => new UploadUserAvatarOutputBuilder(),
+                static _ => new UploadUserAvatarOutput()
+            );
+        var operation = Schemas.Operation(
+            new ShapeId("example", "UploadUserAvatar"),
+            inputSchema,
+            outputSchema,
+            traits: [RestTraits.HttpTrait("PUT", "/users/{userId}/avatar")]
+        );
+        var payload = new MemoryStream("avatar bytes"u8.ToArray());
+        payload.Position = 2;
+        var input = new UploadUserAvatarStreamInput("ada", "abc123", payload);
+
+        var request = Protocol(operation).SerializeRequest(input);
+
+        Assert.Equal(HttpMethod.Put, request.Method);
+        Assert.Equal("/users/ada/avatar", request.RequestUri);
+        Assert.Equal("abc123", request.Headers["X-Checksum"].Single());
+        Assert.Equal("application/octet-stream", request.ContentType);
+        var body = Assert.IsType<SmithyHttpBody.Streaming>(request.Body);
+        Assert.Same(payload, body.Content);
+        Assert.Equal(payload.Length - 2, body.ContentLength);
+        Assert.False(request.ExpectStreamingResponse);
+    }
+
+    [Fact]
+    public void RestJson1ProtocolDeserializesStreamingBlobPayloadWithoutBuffering()
+    {
+        var inputSchema = StreamingUploadInputSchema();
+        var outputSchema = Schemas
+            .Structure<UploadUserAvatarOutput, UploadUserAvatarOutputBuilder>(
+                new ShapeId("example", "UploadUserAvatarOutput")
+            )
+            .Build(
+                static () => new UploadUserAvatarOutputBuilder(),
+                static _ => new UploadUserAvatarOutput()
+            );
+        var operation = Schemas.Operation(
+            new ShapeId("example", "UploadUserAvatar"),
+            inputSchema,
+            outputSchema,
+            traits: [RestTraits.HttpTrait("PUT", "/users/{userId}/avatar")]
+        );
+        var payload = new MemoryStream("avatar bytes"u8.ToArray());
+        var request = new SmithyHttpRequest(HttpMethod.Put, "/users/ada/avatar")
+        {
+            Body = new SmithyHttpBody.Streaming(payload, payload.Length),
+            ContentType = "application/octet-stream",
+        };
+        request.Headers["X-Checksum"] = ["abc123"];
+
+        var input = Protocol(operation).DeserializeRequest(request);
+
+        Assert.Equal("ada", input.UserId);
+        Assert.Equal("abc123", input.Checksum);
+        Assert.Same(payload, input.Payload);
+    }
+
+    [Fact]
+    public void RestJson1ProtocolDeserializesStreamingBlobResponseWithoutBuffering()
+    {
+        var inputSchema = Schemas
+            .Structure<GetUserOutput, GetUserOutputBuilder>(new ShapeId("example", "GetUserInput"))
+            .Build(static () => new GetUserOutputBuilder(), static _ => new GetUserOutput());
+        var outputSchema = StreamingAvatarOutputSchema();
+        var operation = Schemas.Operation(
+            new ShapeId("example", "GetUserAvatar"),
+            inputSchema,
+            outputSchema,
+            traits: [RestTraits.HttpTrait("GET", "/users/{userId}/avatar")]
+        );
+        var payload = new MemoryStream("avatar bytes"u8.ToArray());
+        var response = new SmithyHttpResponse(
+            HttpStatusCode.OK,
+            null,
+            new SmithyHttpBody.Streaming(payload),
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ETag"] = ["etag-1"],
+            },
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = ["application/octet-stream"],
+            }
+        );
+
+        var output = Protocol(operation).DeserializeResponse(response);
+
+        Assert.Equal("etag-1", output.ETag);
+        Assert.Same(payload, output.Payload);
+    }
+
+    [Fact]
+    public void RestJson1ProtocolSerializesStreamingBlobResponseWithoutBuffering()
+    {
+        var inputSchema = Schemas
+            .Structure<GetUserOutput, GetUserOutputBuilder>(new ShapeId("example", "GetUserInput"))
+            .Build(static () => new GetUserOutputBuilder(), static _ => new GetUserOutput());
+        var outputSchema = StreamingAvatarOutputSchema();
+        var operation = Schemas.Operation(
+            new ShapeId("example", "GetUserAvatar"),
+            inputSchema,
+            outputSchema,
+            traits: [RestTraits.HttpTrait("GET", "/users/{userId}/avatar")]
+        );
+        var payload = new MemoryStream("avatar bytes"u8.ToArray());
+        var output = new GetUserAvatarStreamOutput("etag-1", payload);
+
+        var response = Protocol(operation).SerializeResponse(output);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("etag-1", response.Headers["ETag"].Single());
+        Assert.Equal("application/octet-stream", response.ContentHeaders["Content-Type"].Single());
+        Assert.Empty(response.Content);
+        var body = Assert.IsType<SmithyHttpBody.Streaming>(response.Body);
+        Assert.Same(payload, body.Content);
+        Assert.Equal(payload.Length, body.ContentLength);
+    }
+
+    [Fact]
+    public async Task AspNetCoreProtocolWritesStreamingBlobResponseLength()
+    {
+        var payload = new MemoryStream("avatar bytes"u8.ToArray());
+        var response = new SmithyHttpResponse(
+            HttpStatusCode.OK,
+            null,
+            new SmithyHttpBody.Streaming(payload, payload.Length),
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase),
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = ["application/octet-stream"],
+            }
+        );
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+
+        await NSmithy.Server.AspNetCore.SmithyAspNetCoreProtocol.WriteSmithyHttpResponseAsync(
+            httpContext,
+            response
+        );
+
+        Assert.Equal(payload.Length, httpContext.Response.ContentLength);
+        httpContext.Response.Body.Position = 0;
+        using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
+        Assert.Equal("avatar bytes", await reader.ReadToEndAsync());
+    }
+
+    private static StructSchema<
+        UploadUserAvatarStreamInput,
+        UploadUserAvatarStreamInputBuilder
+    > StreamingUploadInputSchema() =>
+        Schemas
+            .Structure<UploadUserAvatarStreamInput, UploadUserAvatarStreamInputBuilder>(
+                new ShapeId("example", "UploadUserAvatarInput")
+            )
+            .Required(
+                "userId",
+                static input => input.UserId,
+                static (builder, value) => builder.UserId = value,
+                Schemas.String,
+                traits: [RestTraits.HttpLabelTrait]
+            )
+            .Required(
+                "checksum",
+                static input => input.Checksum,
+                static (builder, value) => builder.Checksum = value,
+                Schemas.String,
+                traits: [RestTraits.HttpHeaderTrait("X-Checksum")]
+            )
+            .Required(
+                "payload",
+                static input => input.Payload,
+                static (builder, value) => builder.Payload = value,
+                Schemas.StreamingBlob,
+                traits:
+                [
+                    RestTraits.HttpPayloadTrait,
+                    new Trait(RestTraits.Streaming),
+                    new Trait(RestTraits.RequiresLength),
+                ]
+            )
+            .Build(
+                static () => new UploadUserAvatarStreamInputBuilder(),
+                static builder => new UploadUserAvatarStreamInput(
+                    builder.UserId!,
+                    builder.Checksum!,
+                    builder.Payload!
+                )
+            );
+
+    private static StructSchema<
+        GetUserAvatarStreamOutput,
+        GetUserAvatarStreamOutputBuilder
+    > StreamingAvatarOutputSchema() =>
+        Schemas
+            .Structure<GetUserAvatarStreamOutput, GetUserAvatarStreamOutputBuilder>(
+                new ShapeId("example", "GetUserAvatarOutput")
+            )
+            .Required(
+                "eTag",
+                static output => output.ETag,
+                static (builder, value) => builder.ETag = value,
+                Schemas.String,
+                traits: [RestTraits.HttpHeaderTrait("ETag")]
+            )
+            .Required(
+                "payload",
+                static output => output.Payload,
+                static (builder, value) => builder.Payload = value,
+                Schemas.StreamingBlob,
+                traits:
+                [
+                    RestTraits.HttpPayloadTrait,
+                    new Trait(RestTraits.Streaming),
+                    new Trait(RestTraits.RequiresLength),
+                ]
+            )
+            .Build(
+                static () => new GetUserAvatarStreamOutputBuilder(),
+                static builder => new GetUserAvatarStreamOutput(builder.ETag!, builder.Payload!)
+            );
 
     public sealed record GetUserProfileOutput(
         int StatusCode,


### PR DESCRIPTION
## Summary
- replace parallel buffered/streaming request and response fields with a single `SmithyHttpBody` union (`Empty`, `Bytes`, `Streaming`)
- route HttpClient, ASP.NET Core, REST, AWS JSON, rpcv2Cbor, gRPC unary, auth, retry, and request modifiers through the explicit body model
- preserve streaming response content length via `SmithyHttpBody.Streaming.ContentLength`
- add restJson1 streaming blob regression coverage for request/response streaming without buffering

## Validation
- `just fmt`
- `dotnet build NSmithy.slnx --configuration Release --no-restore --disable-build-servers`
- `dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj --configuration Release --no-build`
- `dotnet test tests/Conformance/RestJson1/RestJson1.Conformance.csproj --configuration Release --no-build`