### PR TITLE
docs: overhaul design + protocol docs for 0.4.0 accuracy

### DIFF
--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -115,14 +115,29 @@ lifecycle stages:
 ```csharp
 public interface IClientInterceptor
 {
-    void ReadBeforeExecution(SmithyContext context);
-    object? ModifyBeforeSerialization(SmithyContext context, object? input);
-    SmithyHttpRequest ModifyBeforeSigning(SmithyContext context, SmithyHttpRequest request);
-    SmithyHttpRequest ModifyBeforeTransmit(SmithyContext context, SmithyHttpRequest request);
-    void ReadAfterTransmit(SmithyContext context, SmithyHttpResponse response);
-    object? ModifyBeforeCompletion(SmithyContext context, object? output);
+    void OnBeforeExecution(SmithyContext context) { }
+    void OnBeforeSerialization(SmithyContext context, object? input) { }
+
+    ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default);
+
+    void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response) { }
+    void OnAfterDeserialization(SmithyContext context, object? output) { }
+    void OnAfterExecution(SmithyContext context) { }
 }
 ```
+
+Every hook has a default implementation, so an interceptor overrides only the
+stages it cares about. The signing and transmit hooks are async so they can do
+I/O — fetching credentials or tokens — before the request goes out. Auth signing
+is itself modeled as an interceptor.
 
 Interceptors run in configured order before transmit and reverse order after
 transmit/completion. They are scoped to the client and must be safe for

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -162,38 +162,46 @@ var request = getForecastProtocol.SerializeRequest(
 // GET /forecast/Berlin?units=metric
 ```
 
-Generated clients bind protocols once in static fields. Operation methods stay
-protocol-agnostic: they pass the bound operation protocol and typed input to the
-shared client runtime:
+Generated clients precompute one operation binding per operation in the
+constructor. Operation methods stay protocol-agnostic: they hand the bound
+operation and typed input to the shared client runtime:
 
 ```csharp
 public sealed class WeatherServiceClient
 {
     private readonly SmithyClientRuntime runtime;
 
-    private static readonly IServiceProtocol ServiceProtocol =
-        RestJsonProtocol.ForService(WeatherServiceSchema.Schema);
+    private readonly SmithyOperationBinding<GetForecastInput, GetForecastOutput>
+        GetForecastBinding;
 
-    private static readonly IOperationProtocol<GetForecastInput, GetForecastOutput>
-        GetForecastProtocol = ServiceProtocol.ForOperation(GetForecastSchema.Schema);
+    public WeatherServiceClient(/* endpoint / config / runtime */)
+    {
+        IServiceProtocol serviceProtocol =
+            RestJsonProtocol.ForService(WeatherServiceSchema.Schema);
+
+        GetForecastBinding = new SmithyOperationBinding<GetForecastInput, GetForecastOutput>(
+            serviceName: "WeatherService",
+            operationName: "GetForecast",
+            protocol: serviceProtocol.ForOperation(GetForecastSchema.Schema),
+            modifyRequest: null);
+        // ... one binding per operation, plus runtime construction
+    }
 
     public async Task<GetForecastOutput> GetForecastAsync(
         GetForecastInput input,
         CancellationToken cancellationToken = default)
     {
         return await runtime
-            .InvokeAsync(
-                "WeatherService",
-                "GetForecast",
-                GetForecastProtocol,
-                input,
-                null,
-                DeserializeGetForecastErrorAsync,
-                cancellationToken)
+            .InvokeAsync(GetForecastBinding, input, cancellationToken)
             .ConfigureAwait(false);
     }
 }
 ```
+
+The binding carries the service and operation names, the bound operation
+protocol, and an optional request modifier. The runtime owns execution —
+interceptors, auth, retries — and modeled-error deserialization runs through the
+binding's protocol, so the generated method has no protocol-specific branches.
 
 For a different protocol, the model types and schemas stay the same. Only the
 service protocol factory changes, for example to
@@ -397,13 +405,29 @@ public interface IOperationProtocol<TInput, TOutput>
     TInput             DeserializeRequest(SmithyHttpRequest request);   // server
     SmithyHttpResponse SerializeResponse(TOutput output);
 
+    // errors
     bool    IsErrorResponse(SmithyHttpResponse response);
     string? GetErrorDiscriminator(SmithyHttpResponse response);
-    TError  DeserializeError<TError>(Schema<TError> errorSchema, SmithyHttpResponse response);
+    bool    RequiresErrorDiscriminator { get; }
+    bool    SupportsHttpStatusErrorFallback { get; }
+    IReadOnlyList<HttpOperationError> HttpErrors => [];
+
+    ValueTask<Exception?> DeserializeErrorAsync(
+        SmithyHttpResponse response,
+        CancellationToken cancellationToken = default);
+
     SmithyHttpResponse SerializeError<TError>(
         Schema<TError> errorSchema, TError value, string errorShapeId, int statusCode);
 }
 ```
+
+Modeled-error handling is precomputed: each protocol exposes its operation's
+modeled errors as `HttpErrors`, and the default `DeserializeErrorAsync`
+dispatches on the discriminator — falling back to the HTTP status code when
+`SupportsHttpStatusErrorFallback` is set — to build the typed exception.
+`RequiresErrorDiscriminator` and `SupportsHttpStatusErrorFallback` capture each
+protocol's error-detection rules (rpc-style protocols always carry a
+discriminator; REST can resolve an error from status alone).
 
 Each protocol provides a `ForService(ServiceSchema)` factory that returns an
 `IServiceProtocol`, which in turn hands out an `IOperationProtocol` per

--- a/designs/shapes.md
+++ b/designs/shapes.md
@@ -90,21 +90,25 @@ giving protocols and codecs full Smithy metadata.
 
 ## Errors
 
-Smithy error shapes are generated as C# `Exception` subclasses. The generated
-class extends a service-specific base error type, which in turn extends
-`SmithyException` from `NSmithy.Core`.
+Smithy error shapes are generated as `sealed partial` classes that extend
+`System.Exception` directly:
 
 ```csharp
 // Smithy: @error("client") structure NotFoundException { message: String }
-public sealed class NotFoundException : HelloServiceException
+public sealed partial class NotFoundException : System.Exception
 {
-    public string? Message { get; }
-    // ...
+    public NotFoundException(string? message = null /* , modeled members */)
+        : base(message) { /* ... */ }
+
+    // modeled members surface as read-only properties
 }
 ```
 
-The `@fault` value (`"client"` or `"server"`) and the error code (shape name)
-are accessible as properties on the exception.
+Modeled members become constructor parameters and read-only properties. The
+protocol layer maps a wire error to the right exception type using the
+operation's error discriminator (see [serialization.md](serialization.md)); the
+generated exception exposes its modeled members but no separate fault/code
+properties.
 
 ## Unions
 

--- a/designs/streaming.md
+++ b/designs/streaming.md
@@ -125,24 +125,27 @@ Streaming blob payloads belong to the unary operation path. A `GetObject`-style
 operation is still one request and one response; only the payload member is a
 stream.
 
-The HTTP model should use an explicit body abstraction instead of parallel
-nullable byte and stream properties:
+The HTTP model represents the body as an explicit abstraction rather than
+parallel nullable byte and stream properties:
 
 ```csharp
 public abstract record SmithyHttpBody
 {
+    public static SmithyHttpBody Empty { get; }
+
     public sealed record Bytes(byte[] Content) : SmithyHttpBody;
 
-    public sealed record Stream(
+    public sealed record Streaming(
         System.IO.Stream Content,
         long? ContentLength = null
     ) : SmithyHttpBody;
 }
 ```
 
-`SmithyHttpRequest` and `SmithyHttpResponse` carry `SmithyHttpBody?`. Protocols
-that buffer payloads use `SmithyHttpBody.Bytes`; protocols that bind a streaming
-blob payload use `SmithyHttpBody.Stream`.
+`SmithyHttpRequest` and `SmithyHttpResponse` carry a non-nullable
+`SmithyHttpBody` that defaults to `SmithyHttpBody.Empty`. Protocols that buffer
+payloads use `SmithyHttpBody.Bytes`; protocols that bind a streaming blob payload
+use `SmithyHttpBody.Streaming`.
 
 ### Generated API
 

--- a/designs/streaming.md
+++ b/designs/streaming.md
@@ -33,27 +33,35 @@ the protocol's normal rules.
 
 ## Event Streams
 
-Event-stream operation protocols should be named explicitly as event-stream
-protocols:
+Event-stream operations are bound through the same `IServiceProtocol` that hands
+out unary operations. Alongside `ForOperation`, it exposes three event-stream
+binding methods with default implementations that throw `NotSupportedException`,
+so a protocol opts in only to the streaming shapes it actually supports:
 
 ```csharp
-public interface IEventStreamServiceProtocol
+public interface IServiceProtocol
 {
+    IOperationProtocol<TInput, TOutput> ForOperation<TInput, TOutput>(
+        OperationSchema<TInput, TOutput> operation);
+
     IServerEventStreamOperationProtocol<TInput, TOutputEvent>
         ForServerEventStreamOperation<TInput, TOutput, TOutputEvent>(
             OperationSchema<TInput, TOutput> operation,
-            Schema<TOutputEvent> outputEvent);
+            Schema<TOutputEvent> outputEvent)
+        => throw new NotSupportedException();
 
     IClientEventStreamOperationProtocol<TInputEvent, TOutput>
         ForClientEventStreamOperation<TInput, TInputEvent, TOutput>(
             OperationSchema<TInput, TOutput> operation,
-            Schema<TInputEvent> inputEvent);
+            Schema<TInputEvent> inputEvent)
+        => throw new NotSupportedException();
 
     IBidirectionalEventStreamOperationProtocol<TInputEvent, TOutputEvent>
         ForBidirectionalEventStreamOperation<TInput, TOutput, TInputEvent, TOutputEvent>(
             OperationSchema<TInput, TOutput> operation,
             Schema<TInputEvent> inputEvent,
-            Schema<TOutputEvent> outputEvent);
+            Schema<TOutputEvent> outputEvent)
+        => throw new NotSupportedException();
 }
 ```
 

--- a/website/src/content/docs/contributing/development.md
+++ b/website/src/content/docs/contributing/development.md
@@ -29,7 +29,8 @@ All day-to-day tasks are defined as [just](https://just.systems) recipes. Run
 | Recipe | What it does |
 |---|---|
 | `just restore` | Restore NuGet packages |
-| `just build` | Build in Release configuration |
+| `just codegen` | Run Smithy code generation (Java plugin → generated C#) |
+| `just build` | Build in Release configuration (runs `codegen` and `restore` first) |
 | `just test` | Run the test suite |
 | `just fmt` | Format all sources (C#, Nix, YAML, Justfile) |
 | `just check-format` | Verify formatting (used in CI) |

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -18,6 +18,24 @@ expanding that baseline rather than revisiting it.
 - Use protocol expansion to validate and strengthen the runtime seams that are
   already in place.
 
+## Recently Shipped
+
+The 0.4.0 release delivered several items that were previously on this roadmap:
+
+- **AWS JSON client protocol** (`NSmithy.Protocols.AwsJson`).
+- **AWS SigV4 signing** driven by `@aws.auth#sigv4`, generated auth-scheme
+  wiring, and an AWS LocalStack example — early preview.
+- **Client runtime pipeline** — the generated client stack now runs on
+  `SmithyClientRuntime` with named interceptors, a typed per-call execution
+  context, auth-scheme resolution, runtime-owned retry, and precomputed
+  operation bindings.
+- **Bidirectional gRPC event streaming** for generated clients and ASP.NET Core
+  servers.
+
+See the
+[changelog](https://github.com/thomaslaich/smithy-dotnet/blob/main/CHANGELOG.md)
+for the full list. The priorities below are what remains.
+
 ## Near-Term Priorities
 
 ### 1. Expand AWS protocol coverage and AWS readiness
@@ -26,27 +44,24 @@ expanding that baseline rather than revisiting it.
   especially AWS Query and EC2 Query.
 - Continue hardening `aws.protocols#restJson1`, `aws.protocols#restXml`, and
   `smithy.protocols#rpcv2Cbor` as real preview surfaces.
-- Implement AWS authentication support, especially SigV4 signing driven by
-  `@aws.auth#sigv4`, so generated clients can call real AWS-compatible
-  endpoints.
-- Add an integration test suite against LocalStack to validate generated AWS
-  clients against realistic protocol, signing, and endpoint behavior.
+- Mature AWS authentication beyond the early-preview SigV4 signing — endpoint
+  resolution, profile/SSO/IMDS credential chains, presigning, and golden-vector
+  coverage against AWS's SigV4 test suite.
+- Grow the LocalStack integration coverage beyond the initial example into a
+  broader suite that validates generated AWS clients against realistic protocol,
+  signing, and endpoint behavior.
 - Keep the scope driven by conformance and real runtime behavior rather than by
   marketing-level protocol checklists.
 
 ### 2. Move the client runtime to the target architecture
 
-The desired client architecture is documented in
+The core client runtime pipeline landed in 0.4.0 (see Recently Shipped); the
+desired end-state is documented in
 [`designs/client-architecture.md`](https://github.com/thomaslaich/smithy-dotnet/blob/main/designs/client-architecture.md).
-The roadmap work is to close the runtime and codegen pieces needed for that
-architecture.
-
-This work includes:
+The remaining work closes the gaps:
 
 - Continuing to harden named client interceptors and the typed per-call
   execution context.
-- Moving serialization, endpoint resolution, auth resolution, signing, transmit,
-  retry, deserialization, and completion into one orchestrated client lifecycle.
 - Adding per-operation endpoint resolution, including host labels and endpoint
   auth-scheme overrides.
 - Splitting auth into scheme resolution, identity resolution, and signing;

--- a/website/src/content/docs/guides/client-configuration/authentication.md
+++ b/website/src/content/docs/guides/client-configuration/authentication.md
@@ -8,6 +8,8 @@ clients still need runtime auth configuration. Add auth schemes through
 `{Service}ClientConfig.AuthSchemes`:
 
 ```csharp
+using NSmithy.Client;
+
 var client = new WeatherClient(
     new Uri("https://api.example.com"),
     new()

--- a/website/src/content/docs/guides/client-configuration/interceptors.md
+++ b/website/src/content/docs/guides/client-configuration/interceptors.md
@@ -45,6 +45,8 @@ Available hooks:
 
 Before hooks run in configured order. After hooks run in reverse order.
 
-The per-call `SmithyContext` includes `ServiceName`, `OperationName`, `Attempt`,
-and, for generated clients constructed with an endpoint or `HttpClient`,
-`Endpoint`.
+The per-call `SmithyContext` is a typed value bag read through
+`SmithyContextKeys` — for example `context.Get(SmithyContextKeys.ServiceName)`.
+The runtime populates `ServiceName` and `OperationName` (`string`), `Attempt`
+(`int`), and — for clients constructed with an endpoint or `HttpClient` —
+`Endpoint` (`Uri`).

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -22,11 +22,14 @@ numbers.
 "software.amazon.smithy:smithy-aws-traits:1.71.0"
 ```
 
-## NuGet Package
+## NuGet Packages
 
-```xml
-<PackageReference Include="NSmithy.Protocols.AwsJson" Version="0.4.0" />
-```
+| Purpose | Packages |
+| --- | --- |
+| Client | `NSmithy.Client`, `NSmithy.Protocols.AwsJson` |
+
+`NSmithy.Protocols.AwsJson` pulls in `NSmithy.Codecs.Json` (the JSON codec)
+transitively.
 
 ## Modeling
 

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -67,6 +67,30 @@ structure NoSuchResource {
 }
 ```
 
+## On the Wire
+
+AWS JSON is RPC-style: every call is a `POST /`, the operation is selected by the
+`X-Amz-Target` header, and input/output are JSON:
+
+```http
+POST / HTTP/1.1
+Host: api.example.com
+Content-Type: application/x-amz-json-1.1
+Accept: application/x-amz-json-1.1
+X-Amz-Target: Weather.GetCity
+
+{"cityId":"123"}
+
+HTTP/1.1 200 OK
+Content-Type: application/x-amz-json-1.1
+
+{"name":"Seattle"}
+```
+
+`X-Amz-Target` is `{Service}.{Operation}` (`awsJson1_0` uses the
+`application/x-amz-json-1.0` content type). Errors are discriminated by the
+`X-Amzn-Errortype` header or a `__type` field in the body.
+
 ## Usage
 
 The generated client selects the declared protocol by default and is used

--- a/website/src/content/docs/protocols/aws-rest-json1.md
+++ b/website/src/content/docs/protocols/aws-rest-json1.md
@@ -72,6 +72,25 @@ Members without an explicit HTTP binding are serialized in the JSON body.
 `@requestCompression`, `@httpChecksumRequired`, and AWS-style error
 deserialization.
 
+## On the Wire
+
+`GetCity` binds `cityId` to the URI path label; the response comes back as a JSON
+body:
+
+```http
+GET /cities/123 HTTP/1.1
+Host: api.example.com
+Accept: application/json
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"name":"Seattle"}
+```
+
+Members without an HTTP binding are carried in the JSON body. Errors are
+discriminated by the `X-Amzn-Errortype` response header.
+
 ## Usage
 
 The generated `IWeatherServiceHandler` and `WeatherClient` are identical to every

--- a/website/src/content/docs/protocols/grpc.md
+++ b/website/src/content/docs/protocols/grpc.md
@@ -71,6 +71,39 @@ operation GetCity {
 member that appears in a proto message — omitting it is a model error.
 `@protoNumType` selects integer wire types (`sint`/`uint`/`fixed`/`sfixed`).
 
+## On the Wire
+
+NSmithy speaks standard gRPC — length-prefixed protobuf over HTTP/2,
+interoperable with any gRPC peer. Each member's `@protoIndex` is its protobuf
+field number.
+
+A unary `GetCity { cityId: "123" }` call posts to
+`/{namespace}.{Service}/{Method}`:
+
+```
+POST /example.weather.Weather/GetCity HTTP/2
+content-type: application/grpc+proto
+te: trailers
+
+<gRPC frame><protobuf message>
+```
+
+Each message is a gRPC frame — a 1-byte compression flag, a 4-byte big-endian
+length, then the protobuf payload. For `cityId: "123"`:
+
+```
+00              compression flag (0 = uncompressed)
+00 00 00 05     message length = 5 bytes (big-endian)
+0a              field 1, wire type 2 (LEN)   ← cityId, @protoIndex(1)
+03              string length = 3
+31 32 33        "123"
+```
+
+The response returns the output in the same framing and signals the result with
+the `grpc-status` trailer (`0` = OK). Modeled errors return HTTP 200 with a
+non-zero `grpc-status`; NSmithy carries the Smithy error shape id in the
+`grpc-message` / `x-smithy-grpc-error` trailer for typed dispatch.
+
 ## Server
 
 gRPC is the one protocol where the hosting and client code differs from the

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -78,6 +78,24 @@ work the same way as in `simpleRestJson` — members without an explicit binding
 into the XML body. See the [Modeling guide](/smithy-dotnet/guides/modeling/) for
 the full set.
 
+## On the Wire
+
+`GetCity` binds `cityId` to the URI path label; the response body is XML. The
+`@xmlName("Name")` on the output member sets its element name:
+
+```http
+GET /cities/123 HTTP/1.1
+Host: api.example.com
+Accept: application/xml
+
+HTTP/1.1 200 OK
+Content-Type: application/xml
+
+<GetCityOutput><Name>Seattle</Name></GetCityOutput>
+```
+
+Members without an HTTP binding are carried in the XML body.
+
 ## Usage
 
 The XML codec is wired up automatically by the generated client, which is used

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -20,11 +20,14 @@ numbers.
 "software.amazon.smithy:smithy-aws-traits:1.56.0"
 ```
 
-## NuGet Package
+## NuGet Packages
 
-```xml
-<PackageReference Include="NSmithy.Codecs.Xml" Version="0.4.0" />
-```
+| Purpose | Packages |
+| --- | --- |
+| Client | `NSmithy.Client`, `NSmithy.Protocols.RestXml` |
+
+`NSmithy.Protocols.RestXml` pulls in `NSmithy.Codecs.Xml` (the XML codec)
+transitively.
 
 ## Modeling
 

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -60,6 +60,31 @@ structure NoSuchResource {
 }
 ```
 
+## On the Wire
+
+rpcv2Cbor is RPC-style over a fixed path with a CBOR body. The bodies below are
+shown in CBOR diagnostic notation; on the wire they are binary CBOR (structures
+are encoded as indefinite-length maps):
+
+```http
+POST /service/Weather/operation/GetCity HTTP/1.1
+Host: api.example.com
+Smithy-Protocol: rpc-v2-cbor
+Content-Type: application/cbor
+Accept: application/cbor
+
+{"cityId": "123"}      # CBOR, diagnostic notation
+
+HTTP/1.1 200 OK
+Smithy-Protocol: rpc-v2-cbor
+Content-Type: application/cbor
+
+{"name": "Seattle"}    # CBOR, diagnostic notation
+```
+
+The path is always `/service/{Service}/operation/{Operation}` — operations carry
+no `@http` traits. Errors carry a `__type` discriminator in the CBOR body.
+
 ## Usage
 
 The generated handler and client are identical to every other HTTP-JSON/CBOR

--- a/website/src/content/docs/protocols/simple-rest-json.md
+++ b/website/src/content/docs/protocols/simple-rest-json.md
@@ -73,6 +73,25 @@ Members without an explicit HTTP binding are serialized in the JSON body. For
 resources, pagination, and the full set of HTTP binding traits, see the
 [Modeling guide](/smithy-dotnet/guides/modeling/).
 
+## On the Wire
+
+`GetCity` binds `cityId` to the URI path label; the response comes back as a JSON
+body:
+
+```http
+GET /cities/123 HTTP/1.1
+Host: api.example.com
+Accept: application/json
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"name":"Seattle"}
+```
+
+Members without an HTTP binding are carried in the JSON body. Errors are
+discriminated by the `X-Error-Type` response header.
+
 ## Usage
 
 NSmithy generates one `IWeatherServiceHandler` interface with a method per


### PR DESCRIPTION
Overhaul of the design docs and published docs so they match the 0.4.0 client runtime, read consistently, and demonstrate what actually distinguishes each protocol. Rebased onto `main` after #79 (explicit HTTP body model) landed.

## 1. Fix design-doc drift from the 0.4.0 client runtime (`designs/`)
The design docs lagged the 0.4.0 refactor and described APIs that no longer exist. Corrected against committed code:

- **client-architecture.md** — `IClientInterceptor` is the real 7 async hooks (`OnBeforeExecution`…`OnAfterExecution`) with default impls, not the old 6 sync Smithy-style methods.
- **serialization.md** — generated clients precompute a `SmithyOperationBinding` and call `runtime.InvokeAsync(binding, input, ct)`; dropped the removed 7-arg overload and the never-generated `DeserializeXErrorAsync`. `IOperationProtocol` error surface updated (`RequiresErrorDiscriminator`, `SupportsHttpStatusErrorFallback`, `HttpErrors`, `DeserializeErrorAsync`).
- **shapes.md** — generated errors extend `System.Exception` directly; there is no `SmithyException`/service base and no fault/code properties.
- **streaming.md** — event-stream binding lives on `IServiceProtocol` as default methods that throw `NotSupportedException`, not a separate `IEventStreamServiceProtocol`. The "Streaming Blob Payloads" section now describes the shipped `SmithyHttpBody` model from #79 (`Bytes`/`Streaming`/`Empty`, non-nullable `Body`) rather than the old proposal.

## 2. Correct published docs against 0.4.0 (`website/`)
- **roadmap.md** — added a "Recently Shipped" section (AWS JSON client, SigV4 + auth-scheme wiring, client runtime pipeline, gRPC event streaming) and trimmed near-term items 0.4.0 already delivered.
- **protocols/aws-json.md, rest-xml.md** — standard NuGet table incl. `NSmithy.Client`; rest-xml now lists the protocol package (`NSmithy.Protocols.RestXml`) rather than only the XML codec.
- **guides/interceptors.md** — `SmithyContext` is read via `SmithyContextKeys` (`Get(...)`), not direct properties.
- **guides/authentication.md** — added the missing `using NSmithy.Client;` so the first example compiles.
- **contributing/development.md** — documented `just codegen` and that `just build` runs codegen + restore first.

## 3. Add an "On the Wire" section to each protocol page
Each protocol page now shows a concrete request/response for the shared `GetCity` model — same model, different wire — so the pages demonstrate the actual protocol delta instead of only Smithy source + a shared usage link. Details verified against protocol/codec implementations and conformance fixtures (REST httpLabel + JSON/XML bodies and error-type headers; awsJson `X-Amz-Target`; rpcv2Cbor fixed path + `Smithy-Protocol` header + CBOR diagnostic notation; gRPC HTTP/2 frame + `@protoIndex` field layout + `grpc-status` trailer).
