### PR TITLE
docs: tone down landing page and docs copy

### DIFF
--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -20,7 +20,7 @@ const logo = '/smithy-dotnet/brand/nsmithy_logo_1.png';
 const features = [
   { t: 'Protocol agnostic', d: 'REST, JSON-RPC, CBOR and gRPC from one model — switch or serve several at once.' },
   { t: 'MSBuild-native', d: 'No separate codegen step. MSBuild runs <code>smithy build</code>, adds <code>.g.cs</code> files, and tracks model changes for incremental builds.' },
-  { t: 'Type-safe contracts', d: 'Generated handlers and clients are strongly typed C# records. No string URLs, no manual JSON, no runtime surprises.' },
+  { t: 'Type-safe contracts', d: 'Generated handlers and clients are strongly typed C# records, so the contract is checked at compile time.' },
   { t: 'Cross-ecosystem', d: 'The same contract powers clients in Java, Python, TypeScript, Rust, Swift and more — your .NET service stays interoperable.' },
   { t: 'Docs included', d: 'A Scalar OpenAPI explorer and Sphinx reference are generated at compile time and served as static files.' },
   { t: 'Extensible', d: 'Add protocols and generators through a plugin surface — the model stays the single source of truth.' },
@@ -94,28 +94,27 @@ const langs = [
     <div class="nsl-hero-inner">
       <div class="nsl-hero-copy">
         <a class="nsl-badge reveal" href="https://smithy.io">
-          <span class="nsl-badge-dot"></span>
-          Built on Smithy IDL&nbsp;&nbsp;·&nbsp;&nbsp;smithy.io <span aria-hidden="true">↗</span>
+          Built on the Smithy IDL&nbsp;·&nbsp;smithy.io <span aria-hidden="true">↗</span>
         </a>
-        <h1 class="nsl-h1 reveal" style="--reveal-delay: 80ms">One contract.<br />Every layer of your&nbsp;.NET&nbsp;service.</h1>
-        <p class="nsl-lead reveal" style="--reveal-delay: 160ms">
-          <span class="nsl-brandname">NSmithy</span> turns a single Smithy model into typed servers, clients, and live documentation for .NET —
-          protocol-agnostic, MSBuild-native, zero hand-written glue.
+        <h1 class="nsl-h1 reveal" style="--reveal-delay: 60ms">Smithy code generation for&nbsp;.NET</h1>
+        <p class="nsl-lead reveal" style="--reveal-delay: 120ms">
+          NSmithy generates typed servers, clients, and API documentation for .NET from a single
+          Smithy model. Code generation runs as part of <code>dotnet build</code>.
         </p>
-        <div class="nsl-hero-actions reveal" style="--reveal-delay: 240ms">
+        <div class="nsl-hero-actions reveal" style="--reveal-delay: 180ms">
           <a class="nsl-btn nsl-btn-primary" href={intro}>Get Started</a>
           <a class="nsl-btn nsl-btn-ghost" href={repo}>View on GitHub</a>
         </div>
-        <div class="nsl-chips reveal" style="--reveal-delay: 320ms">
+        <div class="nsl-chips reveal" style="--reveal-delay: 240ms">
           <span class="nsl-chip">REST</span>
           <span class="nsl-chip">JSON-RPC</span>
           <span class="nsl-chip">CBOR-RPC</span>
           <span class="nsl-chip">gRPC</span>
-          <span class="nsl-chip nsl-chip-ext">+ extensible</span>
+          <span class="nsl-chip">+extensible</span>
         </div>
       </div>
 
-      <div class="nsl-hero-art reveal" style="--reveal-delay: 220ms" aria-hidden="true">
+      <div class="nsl-hero-art reveal" style="--reveal-delay: 160ms" aria-hidden="true">
         <div class="nsl-hero-glow"></div>
         <img class="nsl-anvil" src={logo} alt="" width="340" height="340" />
       </div>
@@ -126,7 +125,7 @@ const langs = [
   <section id="workflow" class="nsl-section">
     <div class="nsl-sechead reveal">
       <div class="nsl-kicker">The workflow</div>
-      <h2 class="nsl-h2">From model to runtime in one build</h2>
+      <h2 class="nsl-h2">From model to runtime</h2>
       <p class="nsl-secp">Describe operations, shapes, and traits once. <code>dotnet&nbsp;build</code> emits the server stub, the client, and the docs.</p>
     </div>
     <div class="reveal"><Walkthrough /></div>
@@ -136,8 +135,8 @@ const langs = [
   <section id="protocols" class="nsl-section">
     <div class="nsl-sechead nsl-sechead-wide reveal">
       <div class="nsl-kicker">Protocol agnostic</div>
-      <h2 class="nsl-h2">Same code. Any protocol.</h2>
-      <p class="nsl-secp">Your handler and client never change. Annotate the service with a different protocol trait and NSmithy regenerates the wire format — REST, JSON-RPC, binary CBOR, or gRPC over HTTP/2.</p>
+      <h2 class="nsl-h2">The protocol is a trait on the model</h2>
+      <p class="nsl-secp">Handler and client code stay the same. Changing the protocol trait on the service changes the wire format — REST, JSON-RPC, binary CBOR, or gRPC over HTTP/2.</p>
     </div>
     <div class="reveal"><ProtocolSwitch /></div>
   </section>
@@ -145,9 +144,9 @@ const langs = [
   <!-- Ecosystem -->
   <section id="ecosystem" class="nsl-section nsl-eco">
     <div class="nsl-kicker reveal">Cross-ecosystem</div>
-    <h2 class="nsl-h2 reveal" style="--reveal-delay: 80ms">Same model. Any language.</h2>
-    <p class="nsl-secp nsl-eco-p reveal" style="--reveal-delay: 160ms">Smithy is the IDL behind AWS's public APIs. One model generates idiomatic clients across the ecosystem.</p>
-    <div class="nsl-langs reveal" style="--reveal-delay: 240ms">
+    <h2 class="nsl-h2 reveal" style="--reveal-delay: 60ms">Part of the Smithy ecosystem</h2>
+    <p class="nsl-secp nsl-eco-p reveal" style="--reveal-delay: 120ms">Smithy is the IDL behind AWS's public APIs. The same model works with the official Smithy code generators for other languages.</p>
+    <div class="nsl-langs reveal" style="--reveal-delay: 180ms">
       {
         langs.map((l) => (
           <a
@@ -168,7 +167,7 @@ const langs = [
     <div class="nsl-cards">
       {
         features.map((f, i) => (
-          <div class="nsl-card reveal" style={`--reveal-delay: ${(i % 3) * 80}ms`}>
+          <div class="nsl-card reveal" style={`--reveal-delay: ${(i % 3) * 60}ms`}>
             <span class="nsl-card-mark" />
             <h3 class="nsl-card-t">{f.t}</h3>
             <p class="nsl-card-d" set:html={f.d} />
@@ -183,9 +182,9 @@ const langs = [
     <div class="nsl-docs reveal">
       <div>
         <div class="nsl-kicker">Documentation</div>
-        <h2 class="nsl-h2 nsl-docs-h">Docs that build themselves</h2>
+        <h2 class="nsl-h2 nsl-docs-h">Generated API documentation</h2>
         <p class="nsl-secp nsl-docs-p">
-          No hand-authored spec. <code>app.MapSmithyOpenApi()</code> mounts an interactive Scalar explorer;
+          <code>app.MapSmithyOpenApi()</code> mounts an interactive Scalar explorer;
           <code>app.MapSmithyDocs()</code> serves the Sphinx reference — both generated straight from the model at build time.
         </p>
       </div>
@@ -213,10 +212,9 @@ const langs = [
   <!-- CTA -->
   <section class="nsl-section">
     <div class="nsl-cta reveal">
-      <div class="nsl-cta-glow" aria-hidden="true"></div>
       <div class="nsl-cta-inner">
-        <h2 class="nsl-cta-h">Forge your API.</h2>
-        <p class="nsl-cta-p">Model once. Generate the server, the clients, the docs.</p>
+        <h2 class="nsl-cta-h">Get started</h2>
+        <p class="nsl-cta-p">The quick start walks through modeling, building, and calling a small service.</p>
         <div class="nsl-hero-actions nsl-cta-actions">
           <a class="nsl-btn nsl-btn-primary" href={intro}>Get Started</a>
           <a class="nsl-btn nsl-btn-ghost" href={repo}>GitHub</a>
@@ -272,17 +270,16 @@ const langs = [
     --pill: #f1f1f5;
   }
 
-  /* ── Scroll reveal (the page's single animation language) ────────────────── */
+  /* ── Scroll reveal (deliberately subtle: short rise, gentle fade) ────────── */
   .reveal {
     transition:
-      opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+      opacity 0.5s ease-out,
+      transform 0.5s ease-out;
     transition-delay: var(--reveal-delay, 0s);
-    will-change: opacity, transform;
   }
   html.reveal-ready .reveal {
     opacity: 0;
-    transform: translateY(18px);
+    transform: translateY(10px);
   }
   html.reveal-ready .reveal.is-visible {
     opacity: 1;
@@ -423,7 +420,7 @@ const langs = [
     font-weight: 600;
     font-size: 16px;
     padding: 14px 26px;
-    transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+    transition: background 0.16s ease, border-color 0.16s ease;
   }
   .nsl-btn-sm {
     padding: 10px 18px;
@@ -433,11 +430,10 @@ const langs = [
   .nsl-btn-primary {
     background: var(--accent);
     color: #fff;
-    box-shadow: 0 12px 30px -10px rgba(109, 74, 255, 0.7);
+    box-shadow: 0 8px 22px -12px rgba(109, 74, 255, 0.55);
   }
   .nsl-btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 16px 36px -10px rgba(109, 74, 255, 0.8);
+    background: color-mix(in oklab, var(--accent) 88%, #fff);
   }
   .nsl-btn-ghost {
     background: var(--panel);
@@ -445,7 +441,6 @@ const langs = [
     border: 1px solid var(--border);
   }
   .nsl-btn-ghost:hover {
-    transform: translateY(-2px);
     border-color: var(--accent);
   }
 
@@ -483,13 +478,6 @@ const langs = [
     border-radius: 100px;
     margin-bottom: 28px;
   }
-  .nsl-badge-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--accent);
-    box-shadow: 0 0 10px var(--accent);
-  }
   .nsl-h1 {
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 600;
@@ -507,10 +495,6 @@ const langs = [
     margin: 0 0 34px;
     text-wrap: pretty;
   }
-  .nsl-brandname {
-    color: var(--accentText);
-    font-weight: 600;
-  }
   .nsl-hero-actions {
     display: flex;
     gap: 14px;
@@ -525,7 +509,7 @@ const langs = [
     flex-wrap: wrap;
   }
 
-  /* Hero art: anvil + forge glow + rising sparks */
+  /* Hero art: static logo over a soft glow */
   .nsl-hero-art {
     position: relative;
     display: flex;
@@ -536,43 +520,25 @@ const langs = [
   .nsl-hero-glow {
     position: absolute;
     inset: -8%;
-    background: radial-gradient(closest-side, rgba(109, 74, 255, 0.3), transparent 70%);
+    background: radial-gradient(closest-side, rgba(109, 74, 255, 0.16), transparent 70%);
     pointer-events: none;
     z-index: -1;
   }
   .nsl-anvil {
     width: min(330px, 92%);
     height: auto;
-    filter: drop-shadow(0 22px 50px rgba(109, 74, 255, 0.45));
-    animation: nslFloat 6s ease-in-out infinite;
+    filter: drop-shadow(0 16px 36px rgba(109, 74, 255, 0.22));
   }
-  @keyframes nslFloat {
-    0%,
-    100% {
-      transform: translateY(0);
-    }
-    50% {
-      transform: translateY(-10px);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .nsl-anvil {
-      animation: none;
-    }
-  }
+  /* Plain text labels, not pills — anything boxed next to the buttons reads as
+     clickable. */
   .nsl-chip {
     font-family: 'JetBrains Mono', monospace;
     font-size: 13px;
-    color: var(--dim);
-    padding: 8px 15px;
-    border: 1px solid var(--border);
-    border-radius: 9px;
-    background: var(--panel);
+    color: var(--faint);
   }
-  .nsl-chip-ext {
-    color: var(--accentText);
-    border: 1px dashed var(--border);
-    background: var(--accentSoft);
+  .nsl-chip + .nsl-chip::before {
+    content: '·';
+    margin-right: 10px;
   }
 
   /* ── Sections ────────────────────────────────────────────────────────────── */
@@ -673,11 +639,10 @@ const langs = [
     border: 1px solid var(--border);
     border-radius: 16px;
     background: var(--panel);
-    transition: transform 0.16s ease, border-color 0.16s ease;
+    transition: border-color 0.16s ease;
   }
   .nsl-card:hover {
-    transform: translateY(-3px);
-    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+    border-color: color-mix(in oklab, var(--accent) 35%, var(--border));
   }
   .nsl-card-mark {
     display: inline-block;
@@ -762,33 +727,16 @@ const langs = [
 
   /* CTA */
   .nsl-cta {
-    position: relative;
-    overflow: hidden;
     border-radius: 22px;
-    border: 1px solid var(--accent);
-    background: linear-gradient(180deg, var(--accentSoft), transparent);
-    padding: 72px 44px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    padding: 64px 44px;
     text-align: center;
-  }
-  .nsl-cta-glow {
-    position: absolute;
-    bottom: -180px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 720px;
-    height: 420px;
-    max-width: 100%;
-    background: radial-gradient(closest-side, rgba(109, 74, 255, 0.28), transparent 70%);
-    pointer-events: none;
-  }
-  .nsl-cta-inner {
-    position: relative;
-    z-index: 1;
   }
   .nsl-cta-h {
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 600;
-    font-size: clamp(34px, 5vw, 48px);
+    font-size: clamp(30px, 4vw, 40px);
     letter-spacing: -0.03em;
     color: var(--text);
     margin: 0 0 16px;
@@ -800,6 +748,7 @@ const langs = [
   }
   .nsl-cta-actions {
     margin-bottom: 0;
+    justify-content: center;
   }
 
   /* Footer */

--- a/website/src/components/landing/ProtocolSwitch.astro
+++ b/website/src/components/landing/ProtocolSwitch.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * ProtocolSwitch — "Same code. Any protocol." widget.
+ * ProtocolSwitch — "The protocol is a trait on the model" widget.
  * Ported from the Claude Design "ProtocolSwitch.dc.html". The same GetForecast
  * operation rendered across four protocols; auto-cycles every 4.2s, pauses on
  * hover. Always-dark code panel (does not follow the page theme).
@@ -19,8 +19,8 @@ const protocols: Proto[] = [
     name: 'awsJson1_1',
     sub: 'RPC · JSON',
     cap: 'JSON-RPC: every operation is a POST to a uniform endpoint, framed by an operation target.',
-    req: 'POST / HTTP/1.1\ncontent-type: application/x-amz-json-1.1\nx-amz-target: Weather.GetForecast\n\n{ "city": "Zurich" }',
-    res: 'HTTP/1.1 200 OK\ncontent-type: application/x-amz-json-1.1\n\n{ "tempC": 18.4,\n  "summary": "Clear skies over Zurich" }',
+    req: 'POST / HTTP/1.1\ncontent-type: application/x-amz-json-1.1\nx-amz-target: Weather.GetForecast\n\n{\n  "city": "Zurich"\n}',
+    res: 'HTTP/1.1 200 OK\ncontent-type: application/x-amz-json-1.1\n\n{\n  "tempC": 18.4,\n  "summary": "Clear skies over Zurich"\n}',
   },
   {
     name: 'rpcv2Cbor',
@@ -118,7 +118,7 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
     border: 1px solid #20202c;
     border-radius: 14px;
     overflow: hidden;
-    box-shadow: 0 30px 70px -24px rgba(0, 0, 0, 0.7);
+    box-shadow: 0 12px 32px -20px rgba(0, 0, 0, 0.6);
     width: 100%;
     color: #bcbccb;
   }
@@ -137,7 +137,6 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
     height: 9px;
     background: #6d4aff;
     transform: rotate(45deg);
-    box-shadow: 0 0 12px #6d4aff;
   }
   .psw__op {
     font-size: 12px;

--- a/website/src/components/landing/Walkthrough.astro
+++ b/website/src/components/landing/Walkthrough.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * Walkthrough — "From model to runtime in one build" widget.
+ * Walkthrough — "From model to runtime" widget.
  * Ported from the Claude Design "Walkthrough.dc.html" (forge variant). Source
  * weather.smithy on the left forges into a tabbed Server/Client/Docs output;
  * auto-cycles the 3 outputs every 3.6s, pauses on hover. Always-dark panel.
@@ -60,7 +60,7 @@ app.MapSmithyDocs();      // Sphinx docs -> /docs`,
   {
     label: 'Client',
     file: 'Program.cs',
-    cap: 'A strongly-typed async client — no string URLs, no manual JSON, no reflection.',
+    cap: 'A strongly typed async client, generated from the same model.',
     code: `using Example.Weather; // generated
 
 IWeatherClient client = new WeatherClient(endpoint);
@@ -164,7 +164,7 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     border: 1px solid #20202c;
     border-radius: 14px;
     overflow: hidden;
-    box-shadow: 0 30px 70px -24px rgba(0, 0, 0, 0.7);
+    box-shadow: 0 12px 32px -20px rgba(0, 0, 0, 0.6);
     width: 100%;
     color: #c9d1d9;
   }
@@ -183,7 +183,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     height: 9px;
     background: #6d4aff;
     transform: rotate(45deg);
-    box-shadow: 0 0 12px #6d4aff;
   }
   .wt__title {
     font-size: 11px;
@@ -205,7 +204,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     height: 6px;
     border-radius: 50%;
     background: #56c267;
-    box-shadow: 0 0 8px #56c267;
   }
 
   /* Body: source | arrow | output */
@@ -267,7 +265,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     border: 1px solid #2e2547;
     color: #b8a5ff;
     font-size: 15px;
-    box-shadow: 0 0 20px rgba(109, 74, 255, 0.4);
   }
 
   .wt__out {

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -3,17 +3,16 @@ title: Roadmap
 description: Current direction and near-term priorities for NSmithy.
 ---
 
-This roadmap describes the current direction of NSmithy as it exists today.
-The architecture is no longer the open question: NSmithy uses Smithy CLI for
-model assembly and a Smithy Java plugin for generation, integrated into the
-.NET build through `NSmithy.MSBuild`. The roadmap is about hardening and
-expanding that baseline rather than revisiting it.
+The architecture is settled: NSmithy uses the Smithy CLI for model assembly
+and a Smithy Java plugin for generation, integrated into the .NET build
+through `NSmithy.MSBuild`. This roadmap covers hardening and expanding that
+baseline rather than revisiting it.
 
 ## Direction
 
 - Keep Smithy CLI as the model front end for assembly, validation, projections,
   and Maven dependency resolution.
-- Keep the generated output and runtime story natural for .NET consumers.
+- Keep the generated output and runtime idiomatic for .NET consumers.
 - Prefer explicit preview boundaries over broad compatibility claims.
 - Use protocol expansion to validate and strengthen the runtime seams that are
   already in place.
@@ -43,15 +42,15 @@ for the full list. The priorities below are what remains.
 - Expand AWS protocol coverage beyond the initial AWS JSON client support,
   especially AWS Query and EC2 Query.
 - Continue hardening `aws.protocols#restJson1`, `aws.protocols#restXml`, and
-  `smithy.protocols#rpcv2Cbor` as real preview surfaces.
+  `smithy.protocols#rpcv2Cbor` as preview surfaces.
 - Mature AWS authentication beyond the early-preview SigV4 signing — endpoint
   resolution, profile/SSO/IMDS credential chains, presigning, and golden-vector
   coverage against AWS's SigV4 test suite.
 - Grow the LocalStack integration coverage beyond the initial example into a
   broader suite that validates generated AWS clients against realistic protocol,
   signing, and endpoint behavior.
-- Keep the scope driven by conformance and real runtime behavior rather than by
-  marketing-level protocol checklists.
+- Keep the scope driven by conformance and observed runtime behavior rather
+  than by protocol checklists.
 
 ### 2. Move the client runtime to the target architecture
 
@@ -143,10 +142,9 @@ This work includes:
 
 ### 8. Support Smithy AI traits and MCP generation
 
-Smithy's AI-oriented traits open up another important integration surface for
-NSmithy. Supporting them cleanly should make it possible to generate useful
-.NET and protocol artifacts for tool-driven and agent-driven workflows rather
-than treating them as out-of-band metadata.
+Support Smithy's AI-oriented traits so that .NET and protocol artifacts can be
+generated for tool-driven and agent-driven workflows, rather than treating the
+traits as out-of-band metadata.
 
 This work includes:
 

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -27,9 +27,9 @@ files it generates:
 - **Typed async client interfaces and implementations** per service.
 - **ASP.NET Core minimal API handler interfaces and routing adapters** per service.
 
-**No Gradle required for consumers.** Many Smithy projects use Gradle to run code
-generation. NSmithy packages the generator with the MSBuild integration, so
-application projects can stay in the .NET build system.
+Many Smithy projects use Gradle to run code generation. NSmithy packages the
+generator with the MSBuild integration instead, so application projects do not
+need Gradle and can stay in the .NET build system.
 
 NSmithy currently supports `alloy#simpleRestJson`, `aws.protocols#restJson1`,
 `aws.protocols#awsJson1_1`, `aws.protocols#awsJson1_0`,

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -8,9 +8,9 @@ is a good place to learn the IDL before continuing.
 
 ## Prerequisites
 
-You need the [.NET SDK](https://dotnet.microsoft.com/download). That's it for
-basic builds — NSmithy bundles the Smithy CLI (including a JRE) inside the
-NuGet package, so no separate Java or Smithy CLI installation is required.
+Basic builds require only the [.NET SDK](https://dotnet.microsoft.com/download).
+NSmithy bundles the Smithy CLI (including a JRE) inside the NuGet package, so no
+separate Java or Smithy CLI installation is required.
 
 If you enable `SmithyGenerateDocs` (Sphinx HTML docs), Python 3.11+ must also
 be on your PATH.
@@ -135,8 +135,8 @@ operation SayHello {
 
 `@restJson1` is the protocol; it controls serialization and HTTP binding
 behavior. `@http` binds the operation to a route. `@httpLabel` maps `name` to
-the `{name}` path segment. This is the source of truth for everything that
-follows — change the model, rebuild, and all generated code updates automatically.
+the `{name}` path segment. All generated code derives from this model; change
+the model and rebuild to regenerate it.
 
 ### Generated Types
 
@@ -170,7 +170,7 @@ builder.Services.AddHelloServiceHandler<HelloHandler>();
 app.MapHelloServiceHttp();
 ```
 
-`HelloHandler` (also generated as a starter) simply returns a greeting:
+`HelloHandler` (also generated as a starter) returns a greeting:
 
 ```csharp
 internal sealed class HelloHandler : IHelloServiceHandler
@@ -198,7 +198,7 @@ Console.WriteLine(response.Message);
 ```
 
 The client and server share the same generated input/output types from the
-contracts project. There is no hand-written glue — the model is the contract.
+contracts project.
 
 ## Template Options
 

--- a/website/src/content/docs/guides/client-configuration/dependency-injection.md
+++ b/website/src/content/docs/guides/client-configuration/dependency-injection.md
@@ -96,8 +96,7 @@ services.AddWeatherClient(
 ```
 
 The helper configures the `HttpClient` for HTTP/2 automatically when the chosen
-protocol requires it (native gRPC) — handling the one detail that is easy to get
-wrong by hand.
+protocol requires it (native gRPC).
 
 ## Manual registration
 

--- a/website/src/content/docs/guides/modeling.md
+++ b/website/src/content/docs/guides/modeling.md
@@ -5,8 +5,8 @@ description: Beyond a single operation — resources, pagination, and HTTP bindi
 
 The [protocol pages](/smithy-dotnet/protocols/overview/) each show one small
 operation to keep the focus on the wire format. Real services model more:
-resources, pagination, and richer HTTP bindings. This guide walks through those
-patterns with a fuller model.
+resources, pagination, and additional HTTP bindings. This guide walks through
+those patterns with a fuller model.
 
 The example uses `@simpleRestJson`, but the modeling patterns — resources,
 pagination, and the HTTP binding traits — apply to any HTTP protocol

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: NSmithy
-description: NSmithy turns a single Smithy model into typed servers, clients, and live documentation for .NET — protocol-agnostic, MSBuild-native, zero hand-written glue.
+description: NSmithy generates typed servers, clients, and API documentation for .NET from a single Smithy model, as part of dotnet build.
 template: splash
 pagefind: false
 head:

--- a/website/src/content/docs/protocols/aws-overview.md
+++ b/website/src/content/docs/protocols/aws-overview.md
@@ -17,22 +17,21 @@ it is documented as a top-level protocol rather than under this AWS section.)
 
 If your goal is to call AWS services in production with `restXml` or AWS JSON,
 you should use the **[AWS SDK for .NET](https://github.com/aws/aws-sdk-net)**
-instead. It is:
+instead:
 
-- **Officially supported** by AWS, with long-term maintenance guarantees.
-- **Battle-tested** across the full breadth of AWS services and edge cases.
-- **Feature-complete**, with built-in support for authentication (SigV4/SigV4a),
-  retries, endpoint resolution, pagination helpers, presigned URLs, and more.
-- **Actively developed**, tracking upstream service changes as they happen.
+- It is officially supported and maintained by AWS.
+- It covers the full breadth of AWS services.
+- It includes authentication (SigV4/SigV4a), retries, endpoint resolution,
+  pagination helpers, and presigned URLs.
 
 ## AWS restJson1 Is Different
 
 `aws.protocols#restJson1` is not AWS-specific in practice — it is a
-well-defined REST/JSON wire format that is perfectly sensible for any HTTP
-service, whether or not it runs on AWS. Many teams use it to define internal or
-public APIs that happen to follow the same protocol as AWS services.
+well-defined REST/JSON wire format usable by any HTTP service, whether or not
+it runs on AWS. Many teams use it to define internal or public APIs that follow
+the same protocol as AWS services.
 
-For AWS restJson1, NSmithy has genuine ambition beyond proof-of-concept:
+For AWS restJson1, NSmithy targets more than proof-of-concept use:
 
 - **Non-AWS services** — generated clients and servers work today and are a
   reasonable choice for services modelled with `restJson1` outside of AWS.
@@ -41,7 +40,7 @@ For AWS restJson1, NSmithy has genuine ambition beyond proof-of-concept:
   in early preview, but AWS SDK-style endpoint resolution, credential chains,
   retries, and pagination helpers are not there yet.
 
-Until those pieces mature, reach for the official SDK when targeting AWS directly.
+Until those pieces exist, use the official SDK when targeting AWS directly.
 
 ## AWS SigV4 Is Early Preview
 

--- a/website/src/content/docs/protocols/grpc.md
+++ b/website/src/content/docs/protocols/grpc.md
@@ -3,12 +3,13 @@ title: gRPC
 description: alloy.proto#grpc — generate native gRPC client and server surfaces from a Smithy model, with no protoc or Grpc.Tools.
 ---
 
-`alloy.proto#grpc` generates **native** gRPC client and server surfaces directly
-from a Smithy model. NSmithy speaks the gRPC wire contract itself — a schema-driven
-protobuf codec (`NSmithy.Codecs.Proto`) plus a gRPC transport binding
-(`NSmithy.Protocols.Grpc`) — so there is **no `protoc`, `Grpc.Tools`, or `Grpc.Net`
-dependency**. The generated surfaces match the same protocol-agnostic handler and
-client interfaces used by the HTTP protocols. Status: **Experimental**.
+`alloy.proto#grpc` generates native gRPC client and server surfaces directly
+from a Smithy model. NSmithy implements the gRPC wire contract itself — a
+schema-driven protobuf codec (`NSmithy.Codecs.Proto`) plus a gRPC transport
+binding (`NSmithy.Protocols.Grpc`) — so there is no `protoc`, `Grpc.Tools`, or
+`Grpc.Net` dependency. The generated surfaces match the same protocol-agnostic
+handler and client interfaces used by the HTTP protocols. Status:
+**Experimental**.
 
 Because the bytes on the wire are standard protobuf over gRPC/HTTP/2, an NSmithy
 peer interoperates with a `Grpc.Net` peer in either direction. A `.proto` file can
@@ -73,8 +74,8 @@ member that appears in a proto message — omitting it is a model error.
 
 ## On the Wire
 
-NSmithy speaks standard gRPC — length-prefixed protobuf over HTTP/2,
-interoperable with any gRPC peer. Each member's `@protoIndex` is its protobuf
+NSmithy uses standard gRPC framing — length-prefixed protobuf over HTTP/2 — and
+interoperates with any gRPC peer. Each member's `@protoIndex` is its protobuf
 field number.
 
 A unary `GetCity { cityId: "123" }` call posts to

--- a/website/src/content/docs/protocols/simple-rest-json.md
+++ b/website/src/content/docs/protocols/simple-rest-json.md
@@ -8,8 +8,8 @@ NSmithy generates both a typed .NET client and an ASP.NET Core minimal API
 server adapter. Status: **Preview**.
 
 Use `simpleRestJson` when your consumers are primarily .NET or Scala
-(via [Smithy4s](https://disneystreaming.github.io/smithy4s/)) and you want the
-smoothest current NSmithy end-to-end path. Use
+(via [Smithy4s](https://disneystreaming.github.io/smithy4s/)); it is the most
+complete protocol in the current NSmithy preview. Use
 [`aws.protocols#restJson1`](/smithy-dotnet/protocols/aws-rest-json1/) when you
 need broader Smithy ecosystem compatibility or OpenAPI generation.
 

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -51,9 +51,9 @@ Notes:
 
 ## Recommended Use
 
-- Prefer simpleRestJson for the smoothest end-to-end preview path, especially
-  when your consumers are primarily .NET or Scala (via
-  [Smithy4s](https://disneystreaming.github.io/smithy4s/)).
+- Prefer simpleRestJson for the most complete client and server support in the
+  current preview, especially when your consumers are primarily .NET or Scala
+  (via [Smithy4s](https://disneystreaming.github.io/smithy4s/)).
 - Use AWS restJson1 when you need generated AWS-style REST/JSON clients or
   ASP.NET Core server surfaces, broad cross-ecosystem compatibility (most
   official Smithy generators target it), or OpenAPI/Scalar generation.
@@ -61,8 +61,8 @@ Notes:
   server generation are both available.
 - Use AWS JSON or AWS restXml when you want to evaluate AWS-compatible client
   generation and are comfortable with a smaller preview slice.
-- Treat `alloy.proto#grpc` as an early adopter path for teams comfortable working
-  close to generated code and current limitations.
+- Treat `alloy.proto#grpc` as experimental: it has the smallest test surface and
+  the most explicit model requirements (see the footnote above).
 
 ## What "Early Stage" Means Here
 

--- a/website/src/content/docs/protocols/usage.md
+++ b/website/src/content/docs/protocols/usage.md
@@ -3,14 +3,13 @@ title: Client & Server Usage
 description: The generated handler and client are the same across every protocol — only the model's protocol trait and the wire format change.
 ---
 
-The point of Smithy codegen is that your **application code doesn't change when
-the protocol does**. You implement one handler and call one typed client;
-swapping the protocol trait on the service swaps the wire format underneath
-without touching either side.
+Application code does not change when the protocol does: you implement one
+handler and call one typed client, and swapping the protocol trait on the
+service swaps the wire format without touching either side.
 
-This page is the canonical unary example. Each protocol page then documents only
-what is genuinely protocol-specific: the trait to apply, any modeling
-requirements, and the bytes on the wire.
+This page is the canonical unary example. Each protocol page documents only
+what is protocol-specific: the trait to apply, any modeling requirements, and
+the bytes on the wire.
 
 ## Model
 
@@ -55,8 +54,7 @@ structure NoSuchResource {
 
 A service generates nothing until it carries exactly one protocol trait, so this
 neutral shape isn't buildable on its own — each protocol page shows the complete,
-annotated model. The point is what *doesn't* change: the shapes, and the handler
-and client below.
+annotated model.
 
 ## Server
 
@@ -111,9 +109,9 @@ The handler and client above are identical for `simpleRestJson`, `restJson1`,
 - **Server generation** exists for `simpleRestJson`, `restJson1`, and
   `rpcv2Cbor`. `awsJson1_1`/`awsJson1_0` and `restXml` are **client-only** today,
   so only the client half applies.
-- **gRPC** needs a little transport setup (HTTP/2 Kestrel, `Protocol =
-  new GrpcProtocol()`) and is the one place the code differs — see
-  [gRPC](/smithy-dotnet/protocols/grpc/). It is also where **streaming** lives.
+- **gRPC** requires transport setup (HTTP/2 Kestrel, `Protocol =
+  new GrpcProtocol()`) and is the one protocol where the code differs — see
+  [gRPC](/smithy-dotnet/protocols/grpc/). Streaming is also gRPC-specific.
 
 See [Protocol Status](/smithy-dotnet/protocols/status/) for what is generated per
 protocol.

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -12,8 +12,8 @@ Support is intentionally selective, and protocols are at different maturity
 levels. Each implemented protocol has a conformance suite run against the
 official Smithy / AWS protocol tests (`tests/Conformance`):
 
-- **simpleRestJson (`alloy#simpleRestJson`)** — the most complete path: client and ASP.NET Core
-  server, the best end-to-end coverage.
+- **simpleRestJson (`alloy#simpleRestJson`)** — the most complete: client and
+  ASP.NET Core server, with the broadest end-to-end coverage.
 - **AWS restJson1 (`aws.protocols#restJson1`)** — client and ASP.NET Core server. The main
   remaining corpus gap is the Glacier-specific fixture set, which needs broader
   projection support.
@@ -49,8 +49,7 @@ Streaming is still limited:
 
 gRPC is a **native** path — its own protobuf codec (`NSmithy.Codecs.Proto`) and
 gRPC transport binding (`NSmithy.Protocols.Grpc`) over HTTP/2, with no `protoc`,
-`Grpc.Tools`, or `Grpc.Net` dependency. It should still be treated as an
-early-adopter track:
+`Grpc.Tools`, or `Grpc.Net` dependency. It is still early-stage:
 
 - smaller test and example coverage than the HTTP/JSON paths
 - stricter model requirements, such as `alloy.proto#protoIndex` on members


### PR DESCRIPTION
## Summary

Removes sales-y wording and heavy visual flair from the docs site in favor of concise, technically precise copy and subtler design.

### Landing page
- Factual headlines: "Smithy code generation for .NET", "The protocol is a trait on the model", "Part of the Smithy ecosystem", "Generated API documentation", "Get started" (was "Forge your API.")
- Dropped hype phrasing: "zero hand-written glue", "no runtime surprises", "no string URLs, no manual JSON"
- Subtler motion: scroll-reveal kept but gentler (10px rise, shorter stagger); floating-anvil animation removed, replaced by a static logo over a soft glow
- Removed neon box-shadows (buttons, badge dot, widget diamonds/arrow, CTA gradient panel); kept a faint shadow on the primary button
- Protocol chips are now plain text labels — as pills they read as a second row of buttons
- Fixed CTA panel: buttons were left-aligned under centered text
- Pretty-printed the awsJson1_1 request/response bodies in the protocol switcher to match restJson1

### Docs pages
Copy-edited 12 of 27 pages (the rest were already neutral): getting-started, protocols (usage, status, aws-overview, simple-rest-json, grpc), guides, known-limitations, and roadmap. Marketing framing ("smoothest path", "battle-tested", "genuine ambition", "marketing-level protocol checklists") replaced with plain factual statements. No technical content, code blocks, or wire examples changed.

Site builds clean (29 pages), verified with headless screenshots.
