### PR TITLE
feat: retry overhaul

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -9,12 +9,10 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
-import io.github.thomaslaich.nsmithy.csharp.codegen.TraitIds;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport.Kind;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,7 +20,6 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -460,16 +457,16 @@ public final class ClientGenerator implements Runnable {
         }
         continue;
       }
+      String operationSchema = SchemaGenerator.operationSchemaAccessor(context, op);
       writer.write(
-          "this.$LBinding = new SmithyOperationBinding<$L, $L>($L, $L,"
-              + " serviceProtocol.ForOperation($L), $L);",
+          "this.$LBinding = new SmithyOperationBinding<$L, $L>($L.Id, $L.Id,"
+              + " serviceProtocol.ForOperation($L));",
           CSharpNaming.typeName(op.getId().getName()),
           SchemaGenerator.operationShapeType(context, op.getInputShape()),
           SchemaGenerator.operationShapeType(context, op.getOutputShape()),
-          CSharpNaming.formatString(service.getId().getName()),
-          CSharpNaming.formatString(op.getId().getName()),
-          SchemaGenerator.operationSchemaAccessor(context, op),
-          requestModifier(op));
+          SchemaGenerator.serviceSchemaAccessor(context, service),
+          operationSchema,
+          operationSchema);
     }
   }
 
@@ -671,45 +668,6 @@ public final class ClientGenerator implements Runnable {
             writer.write("$L = input.$L ?? this.idempotencyTokenProvider(),", prop, prop);
           }
         });
-  }
-
-  private String requestCompressionEncoding(OperationShape op) {
-    return op.findTrait(TraitIds.REQUEST_COMPRESSION)
-        .map(t -> (Node) t.toNode())
-        .flatMap(
-            node ->
-                node.expectObjectNode()
-                    .getArrayMember("encodings")
-                    .flatMap(array -> array.getElements().stream().findFirst())
-                    .map(Node::expectStringNode)
-                    .map(s -> s.getValue()))
-        .map(CSharpNaming::formatString)
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "@requestCompression on "
-                        + op.getId()
-                        + " has no encodings — trait requires at least one"));
-  }
-
-  private String requestModifier(OperationShape op) {
-    boolean hasCompression = op.findTrait(TraitIds.REQUEST_COMPRESSION).isPresent();
-    boolean hasMd5 = op.findTrait(TraitIds.HTTP_CHECKSUM_REQUIRED).isPresent();
-    if (!hasCompression && !hasMd5) {
-      return "null";
-    }
-
-    List<String> statements = new ArrayList<>();
-    if (hasCompression) {
-      statements.add(
-          "SmithyRequestModifiers.ApplyRequestCompression(request, "
-              + requestCompressionEncoding(op)
-              + ")");
-    }
-    if (hasMd5) {
-      statements.add("SmithyRequestModifiers.ApplyContentMd5(request)");
-    }
-    return "request => { " + String.join("; ", statements) + "; }";
   }
 
   // =====================================================================

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.RetryableTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -38,11 +39,25 @@ public final class ErrorGenerator implements Runnable {
     Optional<MemberShape> messageMember = ShapeSupport.errorMessageMember(model, shape);
     List<MemberShape> members = ShapeSupport.sortedMembers(shape);
 
-    writer.write("public sealed partial class $L : System.Exception", typeName);
+    Optional<RetryableTrait> retryable = shape.getTrait(RetryableTrait.class);
+    if (retryable.isPresent()) {
+      writer.write(
+          "public sealed partial class $L : System.Exception, NSmithy.Core.ISmithyRetryableError",
+          typeName);
+    } else {
+      writer.write("public sealed partial class $L : System.Exception", typeName);
+    }
     writer.openBlock(
         "{",
         "}",
         () -> {
+          retryable.ifPresent(
+              trait -> {
+                writer.write(
+                    "bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => $L;",
+                    trait.getThrottling() ? "true" : "false");
+                writer.write("");
+              });
           writeConstructor(typeName, messageMember.orElse(null));
           messageMember.ifPresent(
               mm -> {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
@@ -1,0 +1,115 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
+import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpDelegator;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+final class ErrorGeneratorTest {
+
+  @TempDir java.nio.file.Path tempDir;
+
+  private static final String MODEL =
+      """
+      $version: "2"
+
+      namespace example.weather
+
+      service Weather {
+          version: "1"
+          operations: [GetForecast]
+      }
+
+      operation GetForecast {
+          input := {}
+          output := {}
+          errors: [ThrottlingError, TransientError, ValidationError]
+      }
+
+      @error("client")
+      @retryable(throttling: true)
+      structure ThrottlingError {
+          message: String
+      }
+
+      @error("server")
+      @retryable
+      structure TransientError {
+          message: String
+      }
+
+      @error("client")
+      structure ValidationError {
+          message: String
+      }
+      """;
+
+  @Test
+  void retryableErrorsImplementRetryableErrorInterface() throws Exception {
+    String throttling = renderError("example.weather#ThrottlingError");
+    String transientError = renderError("example.weather#TransientError");
+
+    assertTrue(
+        throttling.contains(
+            "public sealed partial class ThrottlingError : System.Exception,"
+                + " NSmithy.Core.ISmithyRetryableError"),
+        throttling);
+    assertTrue(
+        throttling.contains("bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => true;"),
+        throttling);
+    assertTrue(
+        transientError.contains(
+            "bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => false;"),
+        transientError);
+  }
+
+  @Test
+  void nonRetryableErrorsDoNotImplementRetryableErrorInterface() throws Exception {
+    String generated = renderError("example.weather#ValidationError");
+
+    assertTrue(
+        generated.contains("public sealed partial class ValidationError : System.Exception"),
+        generated);
+    assertFalse(generated.contains("ISmithyRetryableError"), generated);
+  }
+
+  private String renderError(String shapeId) throws Exception {
+    Model model = Model.assembler().addUnparsedModel("model.smithy", MODEL).assemble().unwrap();
+    CSharpSettings settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder()
+                .withMember("service", Node.from("example.weather#Weather"))
+                .withMember("baseNamespace", Node.from("Example"))
+                .build());
+    var symbolProvider = new CSharpSymbolProvider(model, settings);
+    var manifest =
+        FileManifest.create(Files.createDirectory(tempDir.resolve(shapeId.replace('#', '-'))));
+    var context =
+        GenerationContext.builder()
+            .model(model)
+            .settings(settings)
+            .symbolProvider(symbolProvider)
+            .fileManifest(manifest)
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .build();
+    var writer = new CSharpWriter("Example.Weather");
+    var shape = model.expectShape(ShapeId.from(shapeId), StructureShape.class);
+
+    new ErrorGenerator(context, writer, shape).run();
+
+    return writer.toString();
+  }
+}

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -248,10 +248,13 @@ Protocols own wire behavior:
 
 Generated clients should not branch on protocol-specific wire rules. They bind
 operation schemas once, select the configured protocol, and precompute
-operation bindings that contain the service name, operation name,
-operation-bound protocol, and request modifier. The operation-bound protocol
-owns modeled error deserialization. The operation method hot path then passes
-the binding and typed input into the runtime.
+operation bindings that contain the service and operation shape ids and the
+operation-bound protocol. The operation-bound protocol owns modeled error
+deserialization and applies request-mutating traits (`@requestCompression`,
+`@httpChecksumRequired`) during serialization — compression is a wire concern,
+and its meaning differs by protocol (HTTP `Content-Encoding` vs gRPC
+message-level compression). The operation method hot path then passes the
+binding and typed input into the runtime.
 
 ## Observability
 

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -202,14 +202,26 @@ for a decision that carries the backoff delay:
 ```csharp
 public interface ISmithyRetryStrategy
 {
+    ISmithyRetrySession Begin();
+}
+
+public interface ISmithyRetrySession
+{
     SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
+    void RecordSuccess();
 }
 ```
 
-`SmithyRetryOutcome` is a failed attempt: the response (null on transport
-failure) plus the exception that will propagate if the attempt is not retried.
-The strategy owns the whole decision — attempt budgeting, failure
-classification, and delay.
+A strategy is long-lived and shared by every execution of its client; it owns
+client-wide state such as the retry quota and must be thread-safe. `Begin`
+runs once per operation execution and returns that execution's session, which
+owns per-execution state (for example, how much quota this execution
+acquired). `SmithyRetryOutcome` is a failed attempt: the response (null on
+transport failure) plus the exception that will propagate if the attempt is
+not retried. The session owns the whole decision — attempt budgeting, failure
+classification, and delay — and `RecordSuccess` lets quota-based strategies
+refund what the execution's retries consumed. Stateless strategies return
+themselves as the session.
 
 The standard strategy uses:
 

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -130,7 +130,7 @@ public interface IClientInterceptor
 
     void OnAfterTransmit(SmithyContext context, SmithyHttpResponse response) { }
     void OnAfterDeserialization(SmithyContext context, object? output) { }
-    void OnAfterExecution(SmithyContext context) { }
+    void OnAfterExecution(SmithyContext context, Exception? exception) { }
 }
 ```
 
@@ -138,6 +138,13 @@ Every hook has a default implementation, so an interceptor overrides only the
 stages it cares about. The signing and transmit hooks are async so they can do
 I/O — fetching credentials or tokens — before the request goes out. Auth signing
 is itself modeled as an interceptor.
+
+`OnAfterExecution` runs on both success and failure; on failure it receives the
+exception that will propagate to the caller (a modeled error, a client
+exception, or a transport failure), so logging and metrics interceptors can
+observe outcomes. The signing, transmit, and after-transmit hooks run once per
+attempt — each retry is re-signed — while the remaining hooks run once per
+execution.
 
 Interceptors run in configured order before transmit and reverse order after
 transmit/completion. They are scoped to the client and must be safe for
@@ -188,7 +195,21 @@ thread-safe services that operate on a request plus context.
 
 Retries are part of the client lifecycle, not a transport wrapper. A retry
 strategy decides whether to retry after modeled errors, response metadata, or
-transport failures.
+transport failures. The runtime classifies each failed attempt first —
+deserializing the modeled error when there is one — and then asks the strategy
+for a decision that carries the backoff delay:
+
+```csharp
+public interface ISmithyRetryStrategy
+{
+    SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
+}
+```
+
+`SmithyRetryOutcome` is a failed attempt: the response (null on transport
+failure) plus the exception that will propagate if the attempt is not retried.
+The strategy owns the whole decision — attempt budgeting, failure
+classification, and delay.
 
 The standard strategy uses:
 

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -481,8 +481,11 @@ created from its operation schema via `ForOperation`:
 private static readonly IServiceProtocol ServiceProtocol =
     RpcV2CborProtocol.ForService(RpcV2ProtocolSchema.Schema);
 
-private static readonly IOperationProtocol<GreetingWithErrorsInput, GreetingWithErrorsOutput>
-    GreetingWithErrorsProtocol = ServiceProtocol.ForOperation(GreetingWithErrorsSchema.Schema);
+private static readonly SmithyOperationBinding<GreetingWithErrorsInput, GreetingWithErrorsOutput>
+    GreetingWithErrorsBinding = new(
+        "RpcV2Protocol",
+        "GreetingWithErrors",
+        ServiceProtocol.ForOperation(GreetingWithErrorsSchema.Schema));
 ```
 
 Operation methods are protocol-agnostic. They have the same shape for restJson1,
@@ -494,14 +497,7 @@ public async Task<GreetingWithErrorsOutput> GreetingWithErrorsAsync(
     CancellationToken cancellationToken = default)
 {
     ArgumentNullException.ThrowIfNull(input);
-    return await runtime.InvokeAsync(
-            "RpcV2Protocol",
-            "GreetingWithErrors",
-            GreetingWithErrorsProtocol,
-            input,
-            null,
-            DeserializeGreetingWithErrorsErrorAsync,
-            cancellationToken)
+    return await runtime.InvokeAsync(GreetingWithErrorsBinding, input, cancellationToken)
         .ConfigureAwait(false);
 }
 ```

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -198,10 +198,10 @@ public sealed class WeatherServiceClient
 }
 ```
 
-The binding carries the service and operation names, the bound operation
-protocol, and an optional request modifier. The runtime owns execution —
-interceptors, auth, retries — and modeled-error deserialization runs through the
-binding's protocol, so the generated method has no protocol-specific branches.
+The binding carries the service and operation shape ids and the bound
+operation protocol. The runtime owns execution — interceptors, auth, retries —
+and modeled-error deserialization runs through the binding's protocol, so the
+generated method has no protocol-specific branches.
 
 For a different protocol, the model types and schemas stay the same. Only the
 service protocol factory changes, for example to
@@ -483,8 +483,8 @@ private static readonly IServiceProtocol ServiceProtocol =
 
 private static readonly SmithyOperationBinding<GreetingWithErrorsInput, GreetingWithErrorsOutput>
     GreetingWithErrorsBinding = new(
-        "RpcV2Protocol",
-        "GreetingWithErrors",
+        RpcV2ProtocolSchema.Schema.Id,
+        GreetingWithErrorsSchema.Schema.Id,
         ServiceProtocol.ForOperation(GreetingWithErrorsSchema.Schema));
 ```
 
@@ -509,11 +509,12 @@ initialized and reused for every request. The hot path serializes through those
 precomputed objects instead of reanalyzing schema metadata.
 
 The generated client also precomputes a client-runtime operation binding per
-unary operation. That binding wraps the operation-bound protocol together with
-the service/operation names, request modifiers such as compression/checksum
-hooks, and other lifecycle metadata. The operation-bound protocol owns modeled
-error deserialization; operation schemas carry the modeled error descriptors it
-uses for dispatch. Protocol implementations compile those descriptors into
+unary operation. That binding pairs the service and operation shape ids with
+the operation-bound protocol. The operation-bound protocol owns modeled error
+deserialization and applies request-mutating traits (`@requestCompression`,
+`@httpChecksumRequired`) during serialization, compiled once from the
+operation schema's traits; operation schemas carry the modeled error
+descriptors it uses for dispatch. Protocol implementations compile those descriptors into
 protocol-specific error deserializers when the operation protocol is built, so
 per-call generated code stays thin and error codec construction stays off the
 deserialization path.

--- a/packages/NSmithy.Client/IClientInterceptor.cs
+++ b/packages/NSmithy.Client/IClientInterceptor.cs
@@ -24,5 +24,10 @@ public interface IClientInterceptor
 
     void OnAfterDeserialization(SmithyContext context, object? output) { }
 
-    void OnAfterExecution(SmithyContext context) { }
+    /// <summary>
+    /// Runs once per execution, after success or failure. <paramref name="exception"/> is null
+    /// when the operation succeeded; otherwise it is the exception that will propagate to the
+    /// caller (a modeled error, a <see cref="SmithyClientException"/>, or a transport failure).
+    /// </summary>
+    void OnAfterExecution(SmithyContext context, Exception? exception) { }
 }

--- a/packages/NSmithy.Client/ISmithyRetryStrategy.cs
+++ b/packages/NSmithy.Client/ISmithyRetryStrategy.cs
@@ -11,6 +11,13 @@ namespace NSmithy.Client;
 public interface ISmithyRetryStrategy
 {
     SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
+
+    /// <summary>
+    /// Called once per execution when an attempt succeeds. Strategies that maintain a
+    /// client-shared retry quota use this to release tokens acquired by earlier retries of the
+    /// same execution.
+    /// </summary>
+    void RecordSuccess(SmithyContext context) { }
 }
 
 /// <summary>

--- a/packages/NSmithy.Client/ISmithyRetryStrategy.cs
+++ b/packages/NSmithy.Client/ISmithyRetryStrategy.cs
@@ -2,17 +2,78 @@ using NSmithy.Http;
 
 namespace NSmithy.Client;
 
+/// <summary>
+/// Decides whether the runtime retries a failed attempt. The strategy owns the whole decision:
+/// attempt budgeting, failure classification, and the backoff delay. The runtime calls
+/// <see cref="Classify"/> only for failed attempts (transport failures and error responses),
+/// never for successful ones.
+/// </summary>
 public interface ISmithyRetryStrategy
 {
-    int MaxAttempts { get; }
-
-    bool ShouldRetry(SmithyRetryContext context);
-
-    ValueTask DelayAsync(SmithyRetryContext context, CancellationToken cancellationToken = default);
+    SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
 }
 
-public sealed record SmithyRetryContext(
+/// <summary>
+/// The result of one failed attempt.
+/// </summary>
+/// <param name="Attempt">The 1-based attempt number that produced this outcome.</param>
+/// <param name="Response">
+/// The received response, or null when the attempt failed in transport before a response arrived.
+/// </param>
+/// <param name="Error">
+/// The exception the runtime will throw if the attempt is not retried: the transport exception
+/// when <paramref name="Response"/> is null, otherwise the deserialized modeled error (or a
+/// <see cref="SmithyClientException"/> when no modeled error matched).
+/// </param>
+/// <param name="ExecutionContext">The invocation's execution context.</param>
+public sealed record SmithyRetryOutcome(
     int Attempt,
-    SmithyHttpResponse Response,
+    SmithyHttpResponse? Response,
+    Exception Error,
     SmithyContext ExecutionContext
-);
+)
+{
+    /// <summary>True when the attempt failed before a response arrived.</summary>
+    public bool IsTransportFailure => Response is null;
+}
+
+/// <summary>
+/// A retry strategy's verdict on a failed attempt: give up (the runtime throws the outcome's
+/// error) or retry after a delay.
+/// </summary>
+public readonly struct SmithyRetryDecision : IEquatable<SmithyRetryDecision>
+{
+    private SmithyRetryDecision(bool shouldRetry, TimeSpan delay)
+    {
+        ShouldRetry = shouldRetry;
+        Delay = delay;
+    }
+
+    public static SmithyRetryDecision GiveUp => default;
+
+    public static SmithyRetryDecision RetryAfter(TimeSpan delay) =>
+        delay >= TimeSpan.Zero
+            ? new SmithyRetryDecision(true, delay)
+            : throw new ArgumentOutOfRangeException(
+                nameof(delay),
+                delay,
+                "Retry delay must not be negative."
+            );
+
+    public bool ShouldRetry { get; }
+
+    public TimeSpan Delay { get; }
+
+    public bool Equals(SmithyRetryDecision other) =>
+        ShouldRetry == other.ShouldRetry && Delay == other.Delay;
+
+    public override bool Equals(object? obj) => obj is SmithyRetryDecision other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(ShouldRetry, Delay);
+
+    public static bool operator ==(SmithyRetryDecision left, SmithyRetryDecision right) =>
+        left.Equals(right);
+
+    public static bool operator !=(SmithyRetryDecision left, SmithyRetryDecision right) =>
+        !left.Equals(right);
+}

--- a/packages/NSmithy.Client/ISmithyRetryStrategy.cs
+++ b/packages/NSmithy.Client/ISmithyRetryStrategy.cs
@@ -3,21 +3,32 @@ using NSmithy.Http;
 namespace NSmithy.Client;
 
 /// <summary>
-/// Decides whether the runtime retries a failed attempt. The strategy owns the whole decision:
-/// attempt budgeting, failure classification, and the backoff delay. The runtime calls
-/// <see cref="Classify"/> only for failed attempts (transport failures and error responses),
-/// never for successful ones.
+/// Decides whether the runtime retries failed attempts. A strategy is long-lived and shared by
+/// every execution of its client (it owns client-wide state such as a retry quota) and must be
+/// thread-safe. <see cref="Begin"/> is called once at the start of each operation execution and
+/// returns that execution's <see cref="ISmithyRetrySession"/>.
 /// </summary>
 public interface ISmithyRetryStrategy
+{
+    ISmithyRetrySession Begin();
+}
+
+/// <summary>
+/// One operation execution's view of a retry strategy. The runtime calls
+/// <see cref="Classify"/> after each failed attempt and <see cref="RecordSuccess"/> once if an
+/// attempt succeeds. A session is used by a single execution and does not need to be
+/// thread-safe; stateless strategies may return themselves from
+/// <see cref="ISmithyRetryStrategy.Begin"/>.
+/// </summary>
+public interface ISmithyRetrySession
 {
     SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
 
     /// <summary>
-    /// Called once per execution when an attempt succeeds. Strategies that maintain a
-    /// client-shared retry quota use this to release tokens acquired by earlier retries of the
-    /// same execution.
+    /// Called when an attempt succeeds. Quota-based sessions use this to refund tokens acquired
+    /// by this execution's earlier retries.
     /// </summary>
-    void RecordSuccess(SmithyContext context) { }
+    void RecordSuccess() { }
 }
 
 /// <summary>

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -35,7 +35,7 @@ public sealed class SmithyClientRuntime(
     )
     {
         var protocol = binding.Protocol;
-        var context = CreateContext(binding.ServiceName, binding.OperationName);
+        var context = CreateContext(binding.ServiceId.Name, binding.OperationId.Name);
         foreach (var interceptor in interceptors)
         {
             interceptor.OnBeforeExecution(context);
@@ -50,7 +50,6 @@ public sealed class SmithyClientRuntime(
             }
 
             var request = protocol.SerializeRequest(input);
-            binding.ModifyRequest?.Invoke(request);
             var response = await SendAsync(
                     context,
                     request,

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -90,8 +90,9 @@ public sealed class SmithyClientRuntime(
         CancellationToken cancellationToken
     )
     {
+        var session = retryStrategy?.Begin();
         // Streaming request bodies cannot be replayed, so they get exactly one attempt.
-        var canRetry = retryStrategy is not null && request.Body is not SmithyHttpBody.Streaming;
+        var canRetry = session is not null && request.Body is not SmithyHttpBody.Streaming;
         for (var attempt = 1; ; attempt++)
         {
             context.Set(SmithyContextKeys.Attempt, attempt);
@@ -113,7 +114,7 @@ public sealed class SmithyClientRuntime(
             catch (Exception transportError)
                 when (canRetry && !cancellationToken.IsCancellationRequested)
             {
-                var decision = retryStrategy!.Classify(
+                var decision = session!.Classify(
                     new SmithyRetryOutcome(attempt, null, transportError, context)
                 );
                 if (!decision.ShouldRetry)
@@ -132,7 +133,7 @@ public sealed class SmithyClientRuntime(
 
             if (!isErrorResponse(response))
             {
-                retryStrategy?.RecordSuccess(context);
+                session?.RecordSuccess();
                 return response;
             }
 
@@ -142,7 +143,7 @@ public sealed class SmithyClientRuntime(
 
             if (canRetry)
             {
-                var decision = retryStrategy!.Classify(
+                var decision = session!.Classify(
                     new SmithyRetryOutcome(attempt, response, error, context)
                 );
                 if (decision.ShouldRetry)

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -25,28 +25,17 @@ public sealed class SmithyClientRuntime(
     )
     {
         ArgumentNullException.ThrowIfNull(binding);
-        return InvokeTypedAsync(
-            binding.ServiceName,
-            binding.OperationName,
-            binding.Protocol,
-            input,
-            binding.ModifyRequest,
-            binding.Protocol.DeserializeErrorAsync,
-            cancellationToken
-        );
+        return InvokeCoreAsync(binding, input, cancellationToken);
     }
 
-    private async Task<TOutput> InvokeTypedAsync<TInput, TOutput>(
-        string serviceName,
-        string operationName,
-        IOperationProtocol<TInput, TOutput> protocol,
+    private async Task<TOutput> InvokeCoreAsync<TInput, TOutput>(
+        SmithyOperationBinding<TInput, TOutput> binding,
         TInput input,
-        Action<SmithyHttpRequest>? modifyRequest,
-        SmithyErrorDeserializer? errorDeserializer,
         CancellationToken cancellationToken
     )
     {
-        var context = CreateContext(serviceName, operationName);
+        var protocol = binding.Protocol;
+        var context = CreateContext(binding.ServiceName, binding.OperationName);
         foreach (var interceptor in interceptors)
         {
             interceptor.OnBeforeExecution(context);
@@ -61,11 +50,11 @@ public sealed class SmithyClientRuntime(
             }
 
             var request = protocol.SerializeRequest(input);
-            modifyRequest?.Invoke(request);
+            binding.ModifyRequest?.Invoke(request);
             var response = await SendAsync(
                     context,
                     request,
-                    errorDeserializer,
+                    protocol.DeserializeErrorAsync,
                     protocol.IsErrorResponse,
                     cancellationToken
                 )
@@ -93,86 +82,11 @@ public sealed class SmithyClientRuntime(
         }
     }
 
-    public Task<TOutput> InvokeAsync<TInput, TOutput>(
-        string serviceName,
-        string operationName,
-        IOperationProtocol<TInput, TOutput> protocol,
-        TInput input,
-        Action<SmithyHttpRequest>? modifyRequest = null,
-        SmithyErrorDeserializer? errorDeserializer = null,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
-        ArgumentNullException.ThrowIfNull(protocol);
-
-        return InvokeTypedAsync(
-            serviceName,
-            operationName,
-            protocol,
-            input,
-            modifyRequest,
-            errorDeserializer ?? protocol.DeserializeErrorAsync,
-            cancellationToken
-        );
-    }
-
-    public Task<SmithyHttpResponse> InvokeAsync(
-        string serviceName,
-        string operationName,
-        SmithyHttpRequest request,
-        SmithyErrorDeserializer? errorDeserializer = null,
-        Func<SmithyHttpResponse, bool>? isErrorResponse = null,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
-        ArgumentNullException.ThrowIfNull(request);
-
-        var context = CreateContext(serviceName, operationName);
-        foreach (var interceptor in interceptors)
-        {
-            interceptor.OnBeforeExecution(context);
-        }
-
-        return InvokeWithCompletionAsync();
-
-        async Task<SmithyHttpResponse> InvokeWithCompletionAsync()
-        {
-            Exception? executionError = null;
-            try
-            {
-                return await SendAsync(
-                        context,
-                        request,
-                        errorDeserializer,
-                        isErrorResponse,
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-            }
-            catch (Exception error)
-            {
-                executionError = error;
-                throw;
-            }
-            finally
-            {
-                for (var i = interceptors.Count - 1; i >= 0; i--)
-                {
-                    interceptors[i].OnAfterExecution(context, executionError);
-                }
-            }
-        }
-    }
-
     private async Task<SmithyHttpResponse> SendAsync(
         SmithyContext context,
         SmithyHttpRequest request,
-        SmithyErrorDeserializer? errorDeserializer,
-        Func<SmithyHttpResponse, bool>? isErrorResponse,
+        Func<SmithyHttpResponse, CancellationToken, ValueTask<Exception?>> deserializeError,
+        Func<SmithyHttpResponse, bool> isErrorResponse,
         CancellationToken cancellationToken
     )
     {
@@ -216,20 +130,15 @@ public sealed class SmithyClientRuntime(
                 interceptors[i].OnAfterTransmit(context, response);
             }
 
-            var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
-            if (!isError)
+            if (!isErrorResponse(response))
             {
                 retryStrategy?.RecordSuccess(context);
                 return response;
             }
 
-            Exception? error = null;
-            if (errorDeserializer is not null)
-            {
-                error = await errorDeserializer(response, cancellationToken).ConfigureAwait(false);
-            }
-
-            error ??= new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+            var error =
+                await deserializeError(response, cancellationToken).ConfigureAwait(false)
+                ?? new SmithyClientException(response.StatusCode, response.ReasonPhrase);
 
             if (canRetry)
             {

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -219,6 +219,7 @@ public sealed class SmithyClientRuntime(
             var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
             if (!isError)
             {
+                retryStrategy?.RecordSuccess(context);
                 return response;
             }
 

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -52,6 +52,7 @@ public sealed class SmithyClientRuntime(
             interceptor.OnBeforeExecution(context);
         }
 
+        Exception? executionError = null;
         try
         {
             foreach (var interceptor in interceptors)
@@ -78,11 +79,16 @@ public sealed class SmithyClientRuntime(
 
             return output;
         }
+        catch (Exception error)
+        {
+            executionError = error;
+            throw;
+        }
         finally
         {
             for (var i = interceptors.Count - 1; i >= 0; i--)
             {
-                interceptors[i].OnAfterExecution(context);
+                interceptors[i].OnAfterExecution(context, executionError);
             }
         }
     }
@@ -135,6 +141,7 @@ public sealed class SmithyClientRuntime(
 
         async Task<SmithyHttpResponse> InvokeWithCompletionAsync()
         {
+            Exception? executionError = null;
             try
             {
                 return await SendAsync(
@@ -146,11 +153,16 @@ public sealed class SmithyClientRuntime(
                     )
                     .ConfigureAwait(false);
             }
+            catch (Exception error)
+            {
+                executionError = error;
+                throw;
+            }
             finally
             {
                 for (var i = interceptors.Count - 1; i >= 0; i--)
                 {
-                    interceptors[i].OnAfterExecution(context);
+                    interceptors[i].OnAfterExecution(context, executionError);
                 }
             }
         }
@@ -164,6 +176,8 @@ public sealed class SmithyClientRuntime(
         CancellationToken cancellationToken
     )
     {
+        // Streaming request bodies cannot be replayed, so they get exactly one attempt.
+        var canRetry = retryStrategy is not null && request.Body is not SmithyHttpBody.Streaming;
         for (var attempt = 1; ; attempt++)
         {
             context.Set(SmithyContextKeys.Attempt, attempt);
@@ -175,27 +189,31 @@ public sealed class SmithyClientRuntime(
                 )
                 .ConfigureAwait(false);
 
-            var response = await transport
-                .SendAsync(attemptRequest, cancellationToken)
-                .ConfigureAwait(false);
+            SmithyHttpResponse response;
+            try
+            {
+                response = await transport
+                    .SendAsync(attemptRequest, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception transportError)
+                when (canRetry && !cancellationToken.IsCancellationRequested)
+            {
+                var decision = retryStrategy!.Classify(
+                    new SmithyRetryOutcome(attempt, null, transportError, context)
+                );
+                if (!decision.ShouldRetry)
+                {
+                    throw;
+                }
+
+                await DelayAsync(decision.Delay, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
 
             for (var i = interceptors.Count - 1; i >= 0; i--)
             {
                 interceptors[i].OnAfterTransmit(context, response);
-            }
-
-            var retryContext = new SmithyRetryContext(attempt, response, context);
-            if (
-                retryStrategy is not null
-                && attempt < retryStrategy.MaxAttempts
-                && request.Body is not SmithyHttpBody.Streaming
-                && retryStrategy.ShouldRetry(retryContext)
-            )
-            {
-                await retryStrategy
-                    .DelayAsync(retryContext, cancellationToken)
-                    .ConfigureAwait(false);
-                continue;
             }
 
             var isError = isErrorResponse?.Invoke(response) ?? (int)response.StatusCode >= 400;
@@ -204,19 +222,32 @@ public sealed class SmithyClientRuntime(
                 return response;
             }
 
+            Exception? error = null;
             if (errorDeserializer is not null)
             {
-                var error = await errorDeserializer(response, cancellationToken)
-                    .ConfigureAwait(false);
-                if (error is not null)
+                error = await errorDeserializer(response, cancellationToken).ConfigureAwait(false);
+            }
+
+            error ??= new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+
+            if (canRetry)
+            {
+                var decision = retryStrategy!.Classify(
+                    new SmithyRetryOutcome(attempt, response, error, context)
+                );
+                if (decision.ShouldRetry)
                 {
-                    throw error;
+                    await DelayAsync(decision.Delay, cancellationToken).ConfigureAwait(false);
+                    continue;
                 }
             }
 
-            throw new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+            throw error;
         }
     }
+
+    private static Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken) =>
+        delay > TimeSpan.Zero ? Task.Delay(delay, cancellationToken) : Task.CompletedTask;
 
     private async Task<SmithyHttpRequest> ApplyRequestInterceptorsAsync(
         SmithyContext context,

--- a/packages/NSmithy.Client/SmithyErrorDeserializer.cs
+++ b/packages/NSmithy.Client/SmithyErrorDeserializer.cs
@@ -1,8 +1,0 @@
-using NSmithy.Http;
-
-namespace NSmithy.Client;
-
-public delegate ValueTask<Exception?> SmithyErrorDeserializer(
-    SmithyHttpResponse response,
-    CancellationToken cancellationToken = default
-);

--- a/packages/NSmithy.Client/SmithyOperationBinding.cs
+++ b/packages/NSmithy.Client/SmithyOperationBinding.cs
@@ -1,31 +1,35 @@
+using NSmithy.Core;
 using NSmithy.Http;
 
 namespace NSmithy.Client;
 
+/// <summary>
+/// A precomputed operation handle: the Smithy identifiers plus the operation-bound protocol.
+/// Generated clients build one binding per unary operation at construction and pass it to
+/// <see cref="SmithyClientRuntime.InvokeAsync{TInput, TOutput}"/> on every call. Pure data —
+/// request-mutating traits (<c>@requestCompression</c>, <c>@httpChecksumRequired</c>) are applied
+/// by the protocol during serialization.
+/// </summary>
 public sealed class SmithyOperationBinding<TInput, TOutput>
 {
     public SmithyOperationBinding(
-        string serviceName,
-        string operationName,
-        IOperationProtocol<TInput, TOutput> protocol,
-        Action<SmithyHttpRequest>? modifyRequest = null
+        ShapeId serviceId,
+        ShapeId operationId,
+        IOperationProtocol<TInput, TOutput> protocol
     )
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId.Name, nameof(serviceId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationId.Name, nameof(operationId));
         ArgumentNullException.ThrowIfNull(protocol);
 
-        ServiceName = serviceName;
-        OperationName = operationName;
+        ServiceId = serviceId;
+        OperationId = operationId;
         Protocol = protocol;
-        ModifyRequest = modifyRequest;
     }
 
-    public string ServiceName { get; }
+    public ShapeId ServiceId { get; }
 
-    public string OperationName { get; }
+    public ShapeId OperationId { get; }
 
     public IOperationProtocol<TInput, TOutput> Protocol { get; }
-
-    public Action<SmithyHttpRequest>? ModifyRequest { get; }
 }

--- a/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
@@ -7,7 +7,7 @@ namespace NSmithy.Client;
 /// pluggable retry predicate. By default it retries transport failures, HTTP 429, and 5xx
 /// responses. For production use prefer a strategy with backoff and jitter.
 /// </summary>
-public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy
+public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy, ISmithyRetrySession
 {
     private readonly Func<SmithyRetryOutcome, bool> shouldRetry;
 
@@ -34,6 +34,9 @@ public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy
     public int MaxAttempts { get; }
 
     public TimeSpan Delay { get; }
+
+    // Stateless: every execution shares this instance as its session.
+    public ISmithyRetrySession Begin() => this;
 
     public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
     {

--- a/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithySimpleRetryStrategy.cs
@@ -1,16 +1,20 @@
 using System.Net;
-using NSmithy.Http;
 
 namespace NSmithy.Client;
 
+/// <summary>
+/// A minimal retry strategy: a fixed attempt budget, an optional fixed delay, and a
+/// pluggable retry predicate. By default it retries transport failures, HTTP 429, and 5xx
+/// responses. For production use prefer a strategy with backoff and jitter.
+/// </summary>
 public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy
 {
-    private readonly Func<SmithyRetryContext, bool> shouldRetry;
+    private readonly Func<SmithyRetryOutcome, bool> shouldRetry;
 
     public SmithySimpleRetryStrategy(
         int maxAttempts = 3,
         TimeSpan? delay = null,
-        Func<SmithyRetryContext, bool>? shouldRetry = null
+        Func<SmithyRetryOutcome, bool>? shouldRetry = null
     )
     {
         if (maxAttempts < 1)
@@ -31,17 +35,16 @@ public sealed class SmithySimpleRetryStrategy : ISmithyRetryStrategy
 
     public TimeSpan Delay { get; }
 
-    public bool ShouldRetry(SmithyRetryContext context) => shouldRetry(context);
+    public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return outcome.Attempt < MaxAttempts && shouldRetry(outcome)
+            ? SmithyRetryDecision.RetryAfter(Delay)
+            : SmithyRetryDecision.GiveUp;
+    }
 
-    public ValueTask DelayAsync(
-        SmithyRetryContext context,
-        CancellationToken cancellationToken = default
-    ) =>
-        Delay > TimeSpan.Zero
-            ? new ValueTask(Task.Delay(Delay, cancellationToken))
-            : ValueTask.CompletedTask;
-
-    private static bool DefaultShouldRetry(SmithyRetryContext context) =>
-        context.Response.StatusCode == HttpStatusCode.TooManyRequests
-        || (int)context.Response.StatusCode is >= 500 and <= 599;
+    private static bool DefaultShouldRetry(SmithyRetryOutcome outcome) =>
+        outcome.Response is null
+        || outcome.Response.StatusCode == HttpStatusCode.TooManyRequests
+        || (int)outcome.Response.StatusCode is >= 500 and <= 599;
 }

--- a/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
@@ -24,7 +24,7 @@ public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
     private const int TransportFailureRetryCost = 10;
     private const int SuccessRefund = 1;
 
-    private readonly object quotaLock = new();
+    private readonly Lock quotaLock = new();
     private int quota = QuotaCapacity;
 
     private readonly Func<SmithyRetryOutcome, SmithyRetryVerdict>? classifyOutcome;

--- a/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
@@ -13,8 +13,6 @@ namespace NSmithy.Client;
 /// </summary>
 public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
 {
-    private static readonly ContextKey<int> AcquiredQuota = new("smithy.retry.acquiredQuota");
-
     private static readonly TimeSpan DefaultBaseDelay = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan DefaultThrottlingBaseDelay = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan DefaultMaxDelay = TimeSpan.FromSeconds(20);
@@ -87,43 +85,48 @@ public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
 
     public TimeSpan MaxDelay { get; }
 
-    public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
+    public ISmithyRetrySession Begin() => new Session(this);
+
+    /// <summary>
+    /// One execution's session: tracks how much quota this execution acquired so an eventual
+    /// success refunds exactly that amount.
+    /// </summary>
+    private sealed class Session(SmithyStandardRetryStrategy strategy) : ISmithyRetrySession
     {
-        ArgumentNullException.ThrowIfNull(outcome);
+        private int acquired;
 
-        if (outcome.Attempt >= MaxAttempts)
+        public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
         {
-            return SmithyRetryDecision.GiveUp;
+            ArgumentNullException.ThrowIfNull(outcome);
+
+            if (outcome.Attempt >= strategy.MaxAttempts)
+            {
+                return SmithyRetryDecision.GiveUp;
+            }
+
+            var verdict = strategy.classifyOutcome?.Invoke(outcome) ?? DefaultClassify(outcome);
+            if (verdict == SmithyRetryVerdict.NotRetryable)
+            {
+                return SmithyRetryDecision.GiveUp;
+            }
+
+            var cost = outcome.IsTransportFailure ? TransportFailureRetryCost : RetryCost;
+            if (!strategy.TryAcquireQuota(cost))
+            {
+                return SmithyRetryDecision.GiveUp;
+            }
+
+            acquired += cost;
+            return SmithyRetryDecision.RetryAfter(
+                strategy.RetryAfterDelay(outcome.Response)
+                    ?? strategy.BackoffDelay(outcome.Attempt, verdict)
+            );
         }
-
-        var verdict = classifyOutcome?.Invoke(outcome) ?? DefaultClassify(outcome);
-        if (verdict == SmithyRetryVerdict.NotRetryable)
-        {
-            return SmithyRetryDecision.GiveUp;
-        }
-
-        var cost = outcome.IsTransportFailure ? TransportFailureRetryCost : RetryCost;
-        if (!TryAcquireQuota(outcome.ExecutionContext, cost))
-        {
-            return SmithyRetryDecision.GiveUp;
-        }
-
-        return SmithyRetryDecision.RetryAfter(
-            RetryAfterDelay(outcome.Response) ?? BackoffDelay(outcome.Attempt, verdict)
-        );
-    }
-
-    public void RecordSuccess(SmithyContext context)
-    {
-        ArgumentNullException.ThrowIfNull(context);
 
         // Refund what this execution's retries consumed; a first-attempt success slowly
         // replenishes quota spent by other executions.
-        var refund = context.TryGet(AcquiredQuota, out var acquired) ? acquired : SuccessRefund;
-        lock (quotaLock)
-        {
-            quota = Math.Min(QuotaCapacity, quota + refund);
-        }
+        public void RecordSuccess() =>
+            strategy.ReleaseQuota(acquired == 0 ? SuccessRefund : acquired);
     }
 
     private static SmithyRetryVerdict DefaultClassify(SmithyRetryOutcome outcome)
@@ -152,7 +155,7 @@ public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
         };
     }
 
-    private bool TryAcquireQuota(SmithyContext context, int cost)
+    private bool TryAcquireQuota(int cost)
     {
         lock (quotaLock)
         {
@@ -162,11 +165,16 @@ public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
             }
 
             quota -= cost;
+            return true;
         }
+    }
 
-        var acquired = context.TryGet(AcquiredQuota, out var existing) ? existing : 0;
-        context.Set(AcquiredQuota, acquired + cost);
-        return true;
+    private void ReleaseQuota(int refund)
+    {
+        lock (quotaLock)
+        {
+            quota = Math.Min(QuotaCapacity, quota + refund);
+        }
     }
 
     private TimeSpan BackoffDelay(int attempt, SmithyRetryVerdict verdict)

--- a/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
+++ b/packages/NSmithy.Client/SmithyStandardRetryStrategy.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Net;
+using NSmithy.Core;
+using NSmithy.Http;
+
+namespace NSmithy.Client;
+
+/// <summary>
+/// The recommended retry strategy: exponential backoff with full jitter and a backoff cap, a
+/// client-shared retry quota, and <c>Retry-After</c> support. Retryability comes from transport
+/// failures, modeled <c>@retryable</c> errors (<see cref="ISmithyRetryableError"/>), and
+/// transient HTTP status codes. Throttling outcomes back off from a larger base delay.
+/// </summary>
+public sealed class SmithyStandardRetryStrategy : ISmithyRetryStrategy
+{
+    private static readonly ContextKey<int> AcquiredQuota = new("smithy.retry.acquiredQuota");
+
+    private static readonly TimeSpan DefaultBaseDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan DefaultThrottlingBaseDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan DefaultMaxDelay = TimeSpan.FromSeconds(20);
+
+    private const int QuotaCapacity = 500;
+    private const int RetryCost = 5;
+    private const int TransportFailureRetryCost = 10;
+    private const int SuccessRefund = 1;
+
+    private readonly object quotaLock = new();
+    private int quota = QuotaCapacity;
+
+    private readonly Func<SmithyRetryOutcome, SmithyRetryVerdict>? classifyOutcome;
+    private readonly TimeProvider timeProvider;
+    private readonly Random random;
+
+    public SmithyStandardRetryStrategy(
+        int maxAttempts = 3,
+        TimeSpan? baseDelay = null,
+        TimeSpan? maxDelay = null,
+        Func<SmithyRetryOutcome, SmithyRetryVerdict>? classifyOutcome = null,
+        TimeProvider? timeProvider = null,
+        Random? random = null
+    )
+    {
+        if (maxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxAttempts),
+                maxAttempts,
+                "Retry attempts must be greater than zero."
+            );
+        }
+
+        if (baseDelay is { } configuredBase && configuredBase <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(baseDelay),
+                configuredBase,
+                "Base delay must be positive."
+            );
+        }
+
+        if (maxDelay is { } configuredMax && configuredMax <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDelay),
+                configuredMax,
+                "Max delay must be positive."
+            );
+        }
+
+        MaxAttempts = maxAttempts;
+        BaseDelay = baseDelay ?? DefaultBaseDelay;
+        ThrottlingBaseDelay =
+            baseDelay is { } custom && custom > DefaultThrottlingBaseDelay
+                ? custom
+                : DefaultThrottlingBaseDelay;
+        MaxDelay = maxDelay ?? DefaultMaxDelay;
+        this.classifyOutcome = classifyOutcome;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+        this.random = random ?? Random.Shared;
+    }
+
+    public int MaxAttempts { get; }
+
+    public TimeSpan BaseDelay { get; }
+
+    public TimeSpan ThrottlingBaseDelay { get; }
+
+    public TimeSpan MaxDelay { get; }
+
+    public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        if (outcome.Attempt >= MaxAttempts)
+        {
+            return SmithyRetryDecision.GiveUp;
+        }
+
+        var verdict = classifyOutcome?.Invoke(outcome) ?? DefaultClassify(outcome);
+        if (verdict == SmithyRetryVerdict.NotRetryable)
+        {
+            return SmithyRetryDecision.GiveUp;
+        }
+
+        var cost = outcome.IsTransportFailure ? TransportFailureRetryCost : RetryCost;
+        if (!TryAcquireQuota(outcome.ExecutionContext, cost))
+        {
+            return SmithyRetryDecision.GiveUp;
+        }
+
+        return SmithyRetryDecision.RetryAfter(
+            RetryAfterDelay(outcome.Response) ?? BackoffDelay(outcome.Attempt, verdict)
+        );
+    }
+
+    public void RecordSuccess(SmithyContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Refund what this execution's retries consumed; a first-attempt success slowly
+        // replenishes quota spent by other executions.
+        var refund = context.TryGet(AcquiredQuota, out var acquired) ? acquired : SuccessRefund;
+        lock (quotaLock)
+        {
+            quota = Math.Min(QuotaCapacity, quota + refund);
+        }
+    }
+
+    private static SmithyRetryVerdict DefaultClassify(SmithyRetryOutcome outcome)
+    {
+        if (outcome.IsTransportFailure)
+        {
+            return SmithyRetryVerdict.Retryable;
+        }
+
+        if (outcome.Error is ISmithyRetryableError retryableError)
+        {
+            return retryableError.IsThrottlingError
+                ? SmithyRetryVerdict.Throttling
+                : SmithyRetryVerdict.Retryable;
+        }
+
+        return outcome.Response!.StatusCode switch
+        {
+            HttpStatusCode.TooManyRequests => SmithyRetryVerdict.Throttling,
+            HttpStatusCode.RequestTimeout => SmithyRetryVerdict.Retryable,
+            HttpStatusCode.InternalServerError => SmithyRetryVerdict.Retryable,
+            HttpStatusCode.BadGateway => SmithyRetryVerdict.Retryable,
+            HttpStatusCode.ServiceUnavailable => SmithyRetryVerdict.Retryable,
+            HttpStatusCode.GatewayTimeout => SmithyRetryVerdict.Retryable,
+            _ => SmithyRetryVerdict.NotRetryable,
+        };
+    }
+
+    private bool TryAcquireQuota(SmithyContext context, int cost)
+    {
+        lock (quotaLock)
+        {
+            if (quota < cost)
+            {
+                return false;
+            }
+
+            quota -= cost;
+        }
+
+        var acquired = context.TryGet(AcquiredQuota, out var existing) ? existing : 0;
+        context.Set(AcquiredQuota, acquired + cost);
+        return true;
+    }
+
+    private TimeSpan BackoffDelay(int attempt, SmithyRetryVerdict verdict)
+    {
+        var baseDelay = verdict == SmithyRetryVerdict.Throttling ? ThrottlingBaseDelay : BaseDelay;
+        var exponentialMs = baseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1);
+        var cappedMs = Math.Min(MaxDelay.TotalMilliseconds, exponentialMs);
+        double sample;
+        lock (quotaLock)
+        {
+            sample = random.NextDouble();
+        }
+
+        return TimeSpan.FromMilliseconds(cappedMs * sample);
+    }
+
+    private TimeSpan? RetryAfterDelay(SmithyHttpResponse? response)
+    {
+        if (
+            response is null
+            || !response.Headers.TryGetValue("Retry-After", out var values)
+            || values.Count == 0
+        )
+        {
+            return null;
+        }
+
+        var value = values[0];
+        if (
+            int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds)
+            && seconds >= 0
+        )
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        if (
+            DateTimeOffset.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal,
+                out var date
+            )
+        )
+        {
+            var delay = date - timeProvider.GetUtcNow();
+            return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
+        }
+
+        return null;
+    }
+}
+
+/// <summary>How a retry strategy classified one failed attempt.</summary>
+public enum SmithyRetryVerdict
+{
+    NotRetryable,
+    Retryable,
+
+    /// <summary>Retryable, but the service is shedding load; back off from a larger base delay.</summary>
+    Throttling,
+}

--- a/packages/NSmithy.Core/ISmithyRetryableError.cs
+++ b/packages/NSmithy.Core/ISmithyRetryableError.cs
@@ -1,0 +1,11 @@
+namespace NSmithy.Core;
+
+/// <summary>
+/// Implemented by generated error types that carry the <c>smithy.api#retryable</c> trait.
+/// Retry strategies use this to honor modeled retryability regardless of protocol or status code.
+/// </summary>
+public interface ISmithyRetryableError
+{
+    /// <summary>True when the error models throttling (<c>@retryable(throttling: true)</c>).</summary>
+    bool IsThrottlingError { get; }
+}

--- a/packages/NSmithy.Http/SmithyRequestModifiers.cs
+++ b/packages/NSmithy.Http/SmithyRequestModifiers.cs
@@ -1,16 +1,84 @@
 using System.IO.Compression;
 using System.Security.Cryptography;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
 
 namespace NSmithy.Http;
 
 /// <summary>
-/// Protocol-agnostic request mutations applied by the generated client based on operation traits
-/// (<c>@requestCompression</c>, <c>@httpChecksumRequired</c>). They operate purely on the request
-/// bytes, so they are identical across wire protocols and live here rather than being duplicated
-/// per protocol.
+/// Request mutations driven by operation traits (<c>@requestCompression</c>,
+/// <c>@httpChecksumRequired</c>). HTTP-body protocols compile them once per operation via
+/// <see cref="Compile{TInput, TOutput}"/> and apply the result at the end of request
+/// serialization; protocols with their own framing (gRPC) must handle these traits in their own
+/// wire terms instead.
 /// </summary>
 public static class SmithyRequestModifiers
 {
+    private static readonly ShapeId RequestCompressionTraitId = ShapeId.Parse(
+        "smithy.api#requestCompression"
+    );
+    private static readonly ShapeId HttpChecksumRequiredTraitId = ShapeId.Parse(
+        "smithy.api#httpChecksumRequired"
+    );
+
+    /// <summary>
+    /// Compiles the operation's request-mutating HTTP traits into a single transform, or null
+    /// when the operation has none.
+    /// </summary>
+    public static Action<SmithyHttpRequest>? Compile<TInput, TOutput>(
+        OperationSchema<TInput, TOutput> operation
+    )
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var encoding = RequestCompressionEncoding(operation.GetTrait(RequestCompressionTraitId));
+        var checksumRequired = operation.HasTrait(HttpChecksumRequiredTraitId);
+        if (encoding is null && !checksumRequired)
+        {
+            return null;
+        }
+
+        return request =>
+        {
+            if (encoding is not null)
+            {
+                ApplyRequestCompression(request, encoding);
+            }
+
+            if (checksumRequired)
+            {
+                ApplyContentMd5(request);
+            }
+        };
+    }
+
+    public static bool HasRequestCompression<TInput, TOutput>(
+        OperationSchema<TInput, TOutput> operation
+    )
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        return operation.HasTrait(RequestCompressionTraitId);
+    }
+
+    private static string? RequestCompressionEncoding(Trait? trait)
+    {
+        if (trait is not { } compression || compression.Value.Kind != DocumentKind.Object)
+        {
+            return null;
+        }
+
+        if (
+            !compression.Value.AsObject().TryGetValue("encodings", out var encodings)
+            || encodings.Kind != DocumentKind.Array
+        )
+        {
+            return null;
+        }
+
+        var values = encodings.AsArray();
+        return values.Count > 0 ? values[0].AsString() : null;
+    }
+
     public static void ApplyRequestCompression(SmithyHttpRequest request, string encoding)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -59,6 +59,7 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
         private readonly Schema<TOutput> outputSchema;
         private readonly IJsonCodec<TInput> requestCodec;
         private readonly IJsonCodec<TOutput> responseCodec;
+        private readonly Action<SmithyHttpRequest>? requestTransform;
 
         public OperationProtocol(
             ServiceSchema service,
@@ -73,6 +74,7 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             outputSchema = operation.Output;
             requestCodec = JsonCodec.FromSchema(operation.Input);
             responseCodec = JsonCodec.FromSchema(operation.Output);
+            requestTransform = SmithyRequestModifiers.Compile(operation);
             HttpErrors = CompileErrors(operation.Errors);
         }
 
@@ -91,6 +93,7 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             };
             request.Headers["Accept"] = [contentType];
             request.Headers["X-Amz-Target"] = [target];
+            requestTransform?.Invoke(request);
             return request;
         }
 

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -53,6 +53,18 @@ public sealed class GrpcProtocol : IProtocol
         )
         {
             ArgumentNullException.ThrowIfNull(operation);
+            if (SmithyRequestModifiers.HasRequestCompression(operation))
+            {
+                // gRPC compresses per message inside the length-prefixed framing
+                // (grpc-encoding), not via Content-Encoding on the HTTP body; applying the
+                // HTTP-style transform would produce broken requests. Fail at bind time until
+                // message-level compression is implemented.
+                throw new NotSupportedException(
+                    $"@requestCompression on '{operation.Id}' is not supported by the gRPC "
+                        + "protocol yet."
+                );
+            }
+
             return new OperationProtocol<TInput, TOutput>(service, operation);
         }
 

--- a/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
@@ -30,7 +30,8 @@ public sealed class RestServiceProtocol(
             codecFactory,
             errorDiscriminator,
             rawStringPayloads,
-            errorTypeHeader
+            errorTypeHeader,
+            SmithyRequestModifiers.Compile(operation)
         );
     }
 }
@@ -46,14 +47,19 @@ public sealed class RestOperationProtocol<TInput, TOutput>(
     IRestBodyCodecFactory codecFactory,
     Func<SmithyHttpResponse, string?> errorDiscriminator,
     bool rawStringPayloads,
-    string? errorTypeHeader
+    string? errorTypeHeader,
+    Action<SmithyHttpRequest>? requestTransform = null
 ) : IOperationProtocol<TInput, TOutput>
 {
     public IReadOnlyList<HttpOperationError> HttpErrors { get; } =
         RestProtocol.CompileErrorDeserializers(modeledErrors, codecFactory, rawStringPayloads);
 
-    public SmithyHttpRequest SerializeRequest(TInput input) =>
-        RestProtocol.SerializeRequest(binding, input);
+    public SmithyHttpRequest SerializeRequest(TInput input)
+    {
+        var request = RestProtocol.SerializeRequest(binding, input);
+        requestTransform?.Invoke(request);
+        return request;
+    }
 
     public TOutput DeserializeResponse(SmithyHttpResponse response) =>
         RestProtocol.DeserializeResponse(binding, response);

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -52,9 +52,11 @@ public sealed class RpcV2CborProtocol : IProtocol
         private readonly bool outputIsUnit;
         private readonly ICborCodec<TInput> requestCodec;
         private readonly ICborCodec<TOutput> responseCodec;
+        private readonly Action<SmithyHttpRequest>? requestTransform;
 
         public OperationProtocol(ServiceSchema service, OperationSchema<TInput, TOutput> operation)
         {
+            requestTransform = SmithyRequestModifiers.Compile(operation);
             // The rpcv2Cbor path is service-derived; the protocol owns this wire detail.
             requestUri = $"/service/{service.Id.Name}/operation/{operation.Id.Name}";
             inputIsUnit = typeof(TInput) == typeof(SmithyUnit) || IsUnitSchema(operation.Input);
@@ -86,6 +88,7 @@ public sealed class RpcV2CborProtocol : IProtocol
                 request.ContentType = ContentType;
             }
 
+            requestTransform?.Invoke(request);
             return request;
         }
 

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -23,15 +23,7 @@ public sealed class SmithyClientRuntimeTests
         var runtime = new SmithyClientRuntime(transport);
 
         var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            runtime.InvokeAsync(
-                "Weather",
-                "GetForecast",
-                new SmithyHttpRequest(HttpMethod.Get, "/forecast"),
-                static (response, _) =>
-                    ValueTask.FromResult<Exception?>(
-                        new InvalidOperationException(response.ContentText)
-                    )
-            )
+            runtime.InvokeAsync(Binding(new ContentTextErrorProtocol()), "input")
         );
 
         Assert.Equal("""{"message":"bad city"}""", error.Message);
@@ -52,11 +44,7 @@ public sealed class SmithyClientRuntimeTests
         var runtime = new SmithyClientRuntime(transport);
 
         var error = await Assert.ThrowsAsync<SmithyClientException>(() =>
-            runtime.InvokeAsync(
-                "Weather",
-                "GetForecast",
-                new SmithyHttpRequest(HttpMethod.Get, "/forecast")
-            )
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
         );
 
         Assert.Equal(HttpStatusCode.InternalServerError, error.StatusCode);
@@ -78,13 +66,7 @@ public sealed class SmithyClientRuntimeTests
         );
         var runtime = new SmithyClientRuntime(transport, [interceptor]);
 
-        var output = await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        var output = await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal("output", output);
         Assert.Equal(
@@ -150,13 +132,7 @@ public sealed class SmithyClientRuntimeTests
             endpoint: endpoint
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal([endpoint], endpoints);
     }
@@ -178,13 +154,7 @@ public sealed class SmithyClientRuntimeTests
             endpoint: new Uri("https://api.example.com/base")
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal("https://api.example.com/base/input", transport.Request.RequestUri);
     }
@@ -206,13 +176,7 @@ public sealed class SmithyClientRuntimeTests
             endpoint: new Uri("https://api.example.com")
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new AbsoluteUriProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new AbsoluteUriProtocol()), "input");
 
         Assert.Equal("https://override.example/input", transport.Request.RequestUri);
     }
@@ -250,13 +214,7 @@ public sealed class SmithyClientRuntimeTests
             [new RecordingInterceptor("one", calls), new RecordingInterceptor("two", calls)]
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal(
             [
@@ -303,13 +261,7 @@ public sealed class SmithyClientRuntimeTests
             retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
-        var output = await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        var output = await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal("output", output);
         Assert.Equal(2, transport.Attempts);
@@ -341,13 +293,7 @@ public sealed class SmithyClientRuntimeTests
             retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal([1, 2], attempts);
     }
@@ -377,13 +323,7 @@ public sealed class SmithyClientRuntimeTests
             retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
-        await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal(
             ["/input?attempt=1", "/input?attempt=2"],
@@ -414,13 +354,8 @@ public sealed class SmithyClientRuntimeTests
             transport,
             retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
-        var request = new SmithyHttpRequest(HttpMethod.Post, "/upload")
-        {
-            Body = new SmithyHttpBody.Streaming(new MemoryStream("hello"u8.ToArray())),
-        };
-
         await Assert.ThrowsAsync<SmithyClientException>(() =>
-            runtime.InvokeAsync("Weather", "Upload", request)
+            runtime.InvokeAsync(Binding(new StreamingRequestProtocol()), "input")
         );
 
         Assert.Equal(1, transport.Attempts);
@@ -444,13 +379,7 @@ public sealed class SmithyClientRuntimeTests
             retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
         );
 
-        var output = await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            cancellationToken: CancellationToken.None
-        );
+        var output = await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal("output", output);
         Assert.Equal(2, transport.Attempts);
@@ -466,13 +395,7 @@ public sealed class SmithyClientRuntimeTests
         var runtime = new SmithyClientRuntime(transport);
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
-            runtime.InvokeAsync(
-                "Weather",
-                "GetForecast",
-                new TextProtocol(),
-                "input",
-                cancellationToken: CancellationToken.None
-            )
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
         );
 
         Assert.Equal(1, transport.Attempts);
@@ -491,13 +414,7 @@ public sealed class SmithyClientRuntimeTests
         );
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
-            runtime.InvokeAsync(
-                "Weather",
-                "GetForecast",
-                new TextProtocol(),
-                "input",
-                cancellationToken: CancellationToken.None
-            )
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
         );
 
         Assert.Equal(2, transport.Attempts);
@@ -535,17 +452,7 @@ public sealed class SmithyClientRuntimeTests
             )
         );
 
-        var output = await runtime.InvokeAsync(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            "input",
-            errorDeserializer: static (response, _) =>
-                ValueTask.FromResult<Exception?>(
-                    new InvalidOperationException(response.ContentText)
-                ),
-            cancellationToken: CancellationToken.None
-        );
+        var output = await runtime.InvokeAsync(Binding(new ContentTextErrorProtocol()), "input");
 
         Assert.Equal("output", output);
         var outcome = Assert.Single(outcomes);
@@ -570,13 +477,7 @@ public sealed class SmithyClientRuntimeTests
         var runtime = new SmithyClientRuntime(transport, [new RecordingInterceptor("one", calls)]);
 
         await Assert.ThrowsAsync<SmithyClientException>(() =>
-            runtime.InvokeAsync(
-                "Weather",
-                "GetForecast",
-                new TextProtocol(),
-                "input",
-                cancellationToken: CancellationToken.None
-            )
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
         );
 
         Assert.Equal("one:after-execution:SmithyClientException", calls[^1]);
@@ -584,6 +485,10 @@ public sealed class SmithyClientRuntimeTests
 
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+    private static SmithyOperationBinding<string, string> Binding(
+        IOperationProtocol<string, string> protocol
+    ) => new("Weather", "GetForecast", protocol);
 
     private sealed class RecordingTransport(SmithyHttpResponse response) : IHttpTransport
     {
@@ -767,5 +672,22 @@ public sealed class SmithyClientRuntimeTests
     {
         public override SmithyHttpRequest SerializeRequest(string input) =>
             new(HttpMethod.Post, $"https://override.example/{input}");
+    }
+
+    private sealed class ContentTextErrorProtocol : TextProtocol, IOperationProtocol<string, string>
+    {
+        public ValueTask<Exception?> DeserializeErrorAsync(
+            SmithyHttpResponse response,
+            CancellationToken cancellationToken = default
+        ) => ValueTask.FromResult<Exception?>(new InvalidOperationException(response.ContentText));
+    }
+
+    private sealed class StreamingRequestProtocol : TextProtocol
+    {
+        public override SmithyHttpRequest SerializeRequest(string input) =>
+            new(HttpMethod.Post, "/upload")
+            {
+                Body = new SmithyHttpBody.Streaming(new MemoryStream("hello"u8.ToArray())),
+            };
     }
 }

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -95,7 +95,7 @@ public sealed class SmithyClientRuntimeTests
                 "one:before-transmit:/input",
                 "one:after-transmit:OK",
                 "one:after-deserialization:output",
-                "one:after-execution",
+                "one:after-execution:ok",
             ],
             calls
         );
@@ -272,8 +272,8 @@ public sealed class SmithyClientRuntimeTests
                 "one:after-transmit:OK",
                 "two:after-deserialization:output",
                 "one:after-deserialization:output",
-                "two:after-execution",
-                "one:after-execution",
+                "two:after-execution:ok",
+                "one:after-execution:ok",
             ],
             calls
         );
@@ -426,6 +426,162 @@ public sealed class SmithyClientRuntimeTests
         Assert.Equal(1, transport.Attempts);
     }
 
+    [Fact]
+    public async Task RuntimeRetriesTransportFailures()
+    {
+        var transport = new FlakyTransport(
+            failures: 1,
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
+        );
+
+        var output = await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("output", output);
+        Assert.Equal(2, transport.Attempts);
+    }
+
+    [Fact]
+    public async Task RuntimeThrowsTransportFailureWhenNoRetryStrategyIsConfigured()
+    {
+        var transport = new FlakyTransport(
+            failures: 1,
+            new SmithyHttpResponse(HttpStatusCode.OK, "OK", [], EmptyHeaders, EmptyHeaders)
+        );
+        var runtime = new SmithyClientRuntime(transport);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            runtime.InvokeAsync(
+                "Weather",
+                "GetForecast",
+                new TextProtocol(),
+                "input",
+                cancellationToken: CancellationToken.None
+            )
+        );
+
+        Assert.Equal(1, transport.Attempts);
+    }
+
+    [Fact]
+    public async Task RuntimeThrowsTransportFailureWhenStrategyGivesUp()
+    {
+        var transport = new FlakyTransport(
+            failures: 3,
+            new SmithyHttpResponse(HttpStatusCode.OK, "OK", [], EmptyHeaders, EmptyHeaders)
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
+        );
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            runtime.InvokeAsync(
+                "Weather",
+                "GetForecast",
+                new TextProtocol(),
+                "input",
+                cancellationToken: CancellationToken.None
+            )
+        );
+
+        Assert.Equal(2, transport.Attempts);
+    }
+
+    [Fact]
+    public async Task RetryStrategySeesDeserializedModeledError()
+    {
+        List<SmithyRetryOutcome> outcomes = [];
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.BadRequest,
+                "Bad Request",
+                Encoding.UTF8.GetBytes("""{"message":"throttled"}"""),
+                EmptyHeaders,
+                EmptyHeaders
+            ),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(
+                maxAttempts: 2,
+                shouldRetry: outcome =>
+                {
+                    outcomes.Add(outcome);
+                    return outcome.Error is InvalidOperationException;
+                }
+            )
+        );
+
+        var output = await runtime.InvokeAsync(
+            "Weather",
+            "GetForecast",
+            new TextProtocol(),
+            "input",
+            errorDeserializer: static (response, _) =>
+                ValueTask.FromResult<Exception?>(
+                    new InvalidOperationException(response.ContentText)
+                ),
+            cancellationToken: CancellationToken.None
+        );
+
+        Assert.Equal("output", output);
+        var outcome = Assert.Single(outcomes);
+        Assert.False(outcome.IsTransportFailure);
+        Assert.Equal("""{"message":"throttled"}""", outcome.Error.Message);
+        Assert.Equal(HttpStatusCode.BadRequest, outcome.Response!.StatusCode);
+    }
+
+    [Fact]
+    public async Task InterceptorsObserveExecutionFailure()
+    {
+        List<string> calls = [];
+        var transport = new RecordingTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(transport, [new RecordingInterceptor("one", calls)]);
+
+        await Assert.ThrowsAsync<SmithyClientException>(() =>
+            runtime.InvokeAsync(
+                "Weather",
+                "GetForecast",
+                new TextProtocol(),
+                "input",
+                cancellationToken: CancellationToken.None
+            )
+        );
+
+        Assert.Equal("one:after-execution:SmithyClientException", calls[^1]);
+    }
+
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -440,6 +596,24 @@ public sealed class SmithyClientRuntimeTests
         {
             Request = request;
             return Task.FromResult(response);
+        }
+    }
+
+    private sealed class FlakyTransport(int failures, SmithyHttpResponse response) : IHttpTransport
+    {
+        public int Attempts { get; private set; }
+
+        public Task<SmithyHttpResponse> SendAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Attempts++;
+            return Attempts <= failures
+                ? Task.FromException<SmithyHttpResponse>(
+                    new HttpRequestException("connection reset")
+                )
+                : Task.FromResult(response);
         }
     }
 
@@ -506,9 +680,9 @@ public sealed class SmithyClientRuntimeTests
             calls.Add($"{name}:after-deserialization:{output}");
         }
 
-        public void OnAfterExecution(SmithyContext context)
+        public void OnAfterExecution(SmithyContext context, Exception? error)
         {
-            calls.Add($"{name}:after-execution");
+            calls.Add($"{name}:after-execution:{(error is null ? "ok" : error.GetType().Name)}");
         }
     }
 

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using NSmithy.Client;
+using NSmithy.Core;
 using NSmithy.Core.Serde;
 using NSmithy.Http;
 
@@ -98,18 +99,11 @@ public sealed class SmithyClientRuntimeTests
             )
         );
         var runtime = new SmithyClientRuntime(transport);
-        var binding = new SmithyOperationBinding<string, string>(
-            "Weather",
-            "GetForecast",
-            new TextProtocol(),
-            request => request.Headers["x-test-binding"] = ["true"]
-        );
 
-        var output = await runtime.InvokeAsync(binding, "input");
+        var output = await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
 
         Assert.Equal("output", output);
         Assert.Equal("/input", transport.Request.RequestUri);
-        Assert.Equal(["true"], transport.Request.Headers["x-test-binding"]);
     }
 
     [Fact]
@@ -488,7 +482,12 @@ public sealed class SmithyClientRuntimeTests
 
     private static SmithyOperationBinding<string, string> Binding(
         IOperationProtocol<string, string> protocol
-    ) => new("Weather", "GetForecast", protocol);
+    ) =>
+        new(
+            ShapeId.Parse("example.weather#Weather"),
+            ShapeId.Parse("example.weather#GetForecast"),
+            protocol
+        );
 
     private sealed class RecordingTransport(SmithyHttpResponse response) : IHttpTransport
     {

--- a/tests/NSmithy.Tests/Client/SmithyStandardRetryStrategyTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyStandardRetryStrategyTests.cs
@@ -1,0 +1,293 @@
+using System.Net;
+using NSmithy.Client;
+using NSmithy.Core;
+using NSmithy.Http;
+
+namespace NSmithy.Tests.Client;
+
+public sealed class SmithyStandardRetryStrategyTests
+{
+    [Fact]
+    public void BackoffGrowsExponentiallyWithFullJitter()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 4, random: new MaxRandom());
+
+        var first = strategy.Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway));
+        var second = strategy.Classify(Outcome(attempt: 2, StatusCode: HttpStatusCode.BadGateway));
+        var third = strategy.Classify(Outcome(attempt: 3, StatusCode: HttpStatusCode.BadGateway));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(100), first.Delay);
+        Assert.Equal(TimeSpan.FromMilliseconds(200), second.Delay);
+        Assert.Equal(TimeSpan.FromMilliseconds(400), third.Delay);
+    }
+
+    [Fact]
+    public void JitterSamplesBelowTheExponentialCeiling()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new HalfRandom());
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway)
+        );
+
+        Assert.Equal(TimeSpan.FromMilliseconds(50), decision.Delay);
+    }
+
+    [Fact]
+    public void BackoffIsCappedAtMaxDelay()
+    {
+        var strategy = new SmithyStandardRetryStrategy(
+            maxAttempts: 30,
+            maxDelay: TimeSpan.FromSeconds(1),
+            random: new MaxRandom()
+        );
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 20, StatusCode: HttpStatusCode.BadGateway)
+        );
+
+        Assert.Equal(TimeSpan.FromSeconds(1), decision.Delay);
+    }
+
+    [Fact]
+    public void ThrottlingBacksOffFromLargerBaseDelay()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new MaxRandom());
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 1, StatusCode: HttpStatusCode.TooManyRequests)
+        );
+
+        Assert.Equal(TimeSpan.FromMilliseconds(500), decision.Delay);
+    }
+
+    [Fact]
+    public void RetryAfterSecondsOverridesBackoff()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new MaxRandom());
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable, retryAfter: "7")
+        );
+
+        Assert.True(decision.ShouldRetry);
+        Assert.Equal(TimeSpan.FromSeconds(7), decision.Delay);
+    }
+
+    [Fact]
+    public void RetryAfterHttpDateUsesTimeProvider()
+    {
+        var now = new DateTimeOffset(2026, 7, 2, 12, 0, 0, TimeSpan.Zero);
+        var strategy = new SmithyStandardRetryStrategy(
+            maxAttempts: 2,
+            timeProvider: new FixedTimeProvider(now)
+        );
+
+        var decision = strategy.Classify(
+            Outcome(
+                attempt: 1,
+                StatusCode: HttpStatusCode.ServiceUnavailable,
+                retryAfter: now.AddSeconds(30).ToString("R")
+            )
+        );
+
+        Assert.True(decision.ShouldRetry);
+        Assert.Equal(TimeSpan.FromSeconds(30), decision.Delay);
+    }
+
+    [Fact]
+    public void GivesUpAfterMaxAttempts()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 3, StatusCode: HttpStatusCode.ServiceUnavailable)
+        );
+
+        Assert.False(decision.ShouldRetry);
+    }
+
+    [Fact]
+    public void DoesNotRetryNonTransientErrors()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 1, StatusCode: HttpStatusCode.BadRequest)
+        );
+
+        Assert.False(decision.ShouldRetry);
+    }
+
+    [Fact]
+    public void RetriesTransportFailures()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
+
+        var decision = strategy.Classify(
+            new SmithyRetryOutcome(
+                1,
+                null,
+                new HttpRequestException("connection reset"),
+                new SmithyContext()
+            )
+        );
+
+        Assert.True(decision.ShouldRetry);
+    }
+
+    [Fact]
+    public void RetriesModeledRetryableErrorsRegardlessOfStatusCode()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
+
+        var decision = strategy.Classify(
+            Outcome(
+                attempt: 1,
+                StatusCode: HttpStatusCode.BadRequest,
+                error: new RetryableTestError(throttling: false)
+            )
+        );
+
+        Assert.True(decision.ShouldRetry);
+    }
+
+    [Fact]
+    public void ModeledThrottlingErrorsUseThrottlingBackoff()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
+
+        var decision = strategy.Classify(
+            Outcome(
+                attempt: 1,
+                StatusCode: HttpStatusCode.BadRequest,
+                error: new RetryableTestError(throttling: true)
+            )
+        );
+
+        Assert.Equal(TimeSpan.FromMilliseconds(500), decision.Delay);
+    }
+
+    [Fact]
+    public void QuotaExhaustionStopsRetries()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
+
+        // Capacity 500, 5 tokens per response retry: 100 retries drain the bucket.
+        for (var i = 0; i < 100; i++)
+        {
+            var decision = strategy.Classify(
+                Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable)
+            );
+            Assert.True(decision.ShouldRetry);
+        }
+
+        Assert.False(
+            strategy
+                .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable))
+                .ShouldRetry
+        );
+    }
+
+    [Fact]
+    public void RecordSuccessRefundsQuotaAcquiredByTheExecution()
+    {
+        var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
+
+        // Drain the bucket, remembering each execution's context.
+        List<SmithyContext> contexts = [];
+        for (var i = 0; i < 100; i++)
+        {
+            var context = new SmithyContext();
+            var decision = strategy.Classify(
+                new SmithyRetryOutcome(
+                    1,
+                    Response(HttpStatusCode.ServiceUnavailable),
+                    new SmithyClientException(HttpStatusCode.ServiceUnavailable, null),
+                    context
+                )
+            );
+            Assert.True(decision.ShouldRetry);
+            contexts.Add(context);
+        }
+
+        // A retried execution eventually succeeding refunds its tokens.
+        strategy.RecordSuccess(contexts[0]);
+
+        Assert.True(
+            strategy
+                .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable))
+                .ShouldRetry
+        );
+    }
+
+    [Fact]
+    public void CustomClassifierOverridesDefault()
+    {
+        var strategy = new SmithyStandardRetryStrategy(
+            maxAttempts: 3,
+            classifyOutcome: static _ => SmithyRetryVerdict.NotRetryable
+        );
+
+        var decision = strategy.Classify(
+            Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable)
+        );
+
+        Assert.False(decision.ShouldRetry);
+    }
+
+    private static SmithyRetryOutcome Outcome(
+        int attempt,
+        HttpStatusCode StatusCode,
+        string? retryAfter = null,
+        Exception? error = null
+    )
+    {
+        var response = Response(StatusCode, retryAfter);
+        return new SmithyRetryOutcome(
+            attempt,
+            response,
+            error ?? new SmithyClientException(StatusCode, null),
+            new SmithyContext()
+        );
+    }
+
+    private static SmithyHttpResponse Response(HttpStatusCode statusCode, string? retryAfter = null)
+    {
+        var headers = new Dictionary<string, IReadOnlyList<string>>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        if (retryAfter is not null)
+        {
+            headers["Retry-After"] = [retryAfter];
+        }
+
+        return new SmithyHttpResponse(
+            statusCode,
+            statusCode.ToString(),
+            [],
+            headers,
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        );
+    }
+
+    private sealed class MaxRandom : Random
+    {
+        public override double NextDouble() => 1.0;
+    }
+
+    private sealed class HalfRandom : Random
+    {
+        public override double NextDouble() => 0.5;
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class RetryableTestError(bool throttling) : Exception, ISmithyRetryableError
+    {
+        public bool IsThrottlingError { get; } = throttling;
+    }
+}

--- a/tests/NSmithy.Tests/Client/SmithyStandardRetryStrategyTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyStandardRetryStrategyTests.cs
@@ -12,9 +12,15 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 4, random: new MaxRandom());
 
-        var first = strategy.Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway));
-        var second = strategy.Classify(Outcome(attempt: 2, StatusCode: HttpStatusCode.BadGateway));
-        var third = strategy.Classify(Outcome(attempt: 3, StatusCode: HttpStatusCode.BadGateway));
+        var first = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway));
+        var second = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 2, StatusCode: HttpStatusCode.BadGateway));
+        var third = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 3, StatusCode: HttpStatusCode.BadGateway));
 
         Assert.Equal(TimeSpan.FromMilliseconds(100), first.Delay);
         Assert.Equal(TimeSpan.FromMilliseconds(200), second.Delay);
@@ -26,9 +32,9 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new HalfRandom());
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.BadGateway));
 
         Assert.Equal(TimeSpan.FromMilliseconds(50), decision.Delay);
     }
@@ -42,9 +48,9 @@ public sealed class SmithyStandardRetryStrategyTests
             random: new MaxRandom()
         );
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 20, StatusCode: HttpStatusCode.BadGateway)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 20, StatusCode: HttpStatusCode.BadGateway));
 
         Assert.Equal(TimeSpan.FromSeconds(1), decision.Delay);
     }
@@ -54,9 +60,9 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new MaxRandom());
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 1, StatusCode: HttpStatusCode.TooManyRequests)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.TooManyRequests));
 
         Assert.Equal(TimeSpan.FromMilliseconds(500), decision.Delay);
     }
@@ -66,9 +72,11 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 2, random: new MaxRandom());
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable, retryAfter: "7")
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(
+                Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable, retryAfter: "7")
+            );
 
         Assert.True(decision.ShouldRetry);
         Assert.Equal(TimeSpan.FromSeconds(7), decision.Delay);
@@ -83,13 +91,15 @@ public sealed class SmithyStandardRetryStrategyTests
             timeProvider: new FixedTimeProvider(now)
         );
 
-        var decision = strategy.Classify(
-            Outcome(
-                attempt: 1,
-                StatusCode: HttpStatusCode.ServiceUnavailable,
-                retryAfter: now.AddSeconds(30).ToString("R")
-            )
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(
+                Outcome(
+                    attempt: 1,
+                    StatusCode: HttpStatusCode.ServiceUnavailable,
+                    retryAfter: now.AddSeconds(30).ToString("R")
+                )
+            );
 
         Assert.True(decision.ShouldRetry);
         Assert.Equal(TimeSpan.FromSeconds(30), decision.Delay);
@@ -100,9 +110,9 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 3, StatusCode: HttpStatusCode.ServiceUnavailable)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 3, StatusCode: HttpStatusCode.ServiceUnavailable));
 
         Assert.False(decision.ShouldRetry);
     }
@@ -112,9 +122,9 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 1, StatusCode: HttpStatusCode.BadRequest)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.BadRequest));
 
         Assert.False(decision.ShouldRetry);
     }
@@ -124,14 +134,16 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
 
-        var decision = strategy.Classify(
-            new SmithyRetryOutcome(
-                1,
-                null,
-                new HttpRequestException("connection reset"),
-                new SmithyContext()
-            )
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(
+                new SmithyRetryOutcome(
+                    1,
+                    null,
+                    new HttpRequestException("connection reset"),
+                    new SmithyContext()
+                )
+            );
 
         Assert.True(decision.ShouldRetry);
     }
@@ -141,13 +153,15 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
 
-        var decision = strategy.Classify(
-            Outcome(
-                attempt: 1,
-                StatusCode: HttpStatusCode.BadRequest,
-                error: new RetryableTestError(throttling: false)
-            )
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(
+                Outcome(
+                    attempt: 1,
+                    StatusCode: HttpStatusCode.BadRequest,
+                    error: new RetryableTestError(throttling: false)
+                )
+            );
 
         Assert.True(decision.ShouldRetry);
     }
@@ -157,13 +171,15 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3, random: new MaxRandom());
 
-        var decision = strategy.Classify(
-            Outcome(
-                attempt: 1,
-                StatusCode: HttpStatusCode.BadRequest,
-                error: new RetryableTestError(throttling: true)
-            )
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(
+                Outcome(
+                    attempt: 1,
+                    StatusCode: HttpStatusCode.BadRequest,
+                    error: new RetryableTestError(throttling: true)
+                )
+            );
 
         Assert.Equal(TimeSpan.FromMilliseconds(500), decision.Delay);
     }
@@ -176,14 +192,15 @@ public sealed class SmithyStandardRetryStrategyTests
         // Capacity 500, 5 tokens per response retry: 100 retries drain the bucket.
         for (var i = 0; i < 100; i++)
         {
-            var decision = strategy.Classify(
-                Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable)
-            );
+            var decision = strategy
+                .Begin()
+                .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable));
             Assert.True(decision.ShouldRetry);
         }
 
         Assert.False(
             strategy
+                .Begin()
                 .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable))
                 .ShouldRetry
         );
@@ -194,28 +211,24 @@ public sealed class SmithyStandardRetryStrategyTests
     {
         var strategy = new SmithyStandardRetryStrategy(maxAttempts: 3);
 
-        // Drain the bucket, remembering each execution's context.
-        List<SmithyContext> contexts = [];
+        // Drain the bucket, remembering each execution's session.
+        List<ISmithyRetrySession> sessions = [];
         for (var i = 0; i < 100; i++)
         {
-            var context = new SmithyContext();
-            var decision = strategy.Classify(
-                new SmithyRetryOutcome(
-                    1,
-                    Response(HttpStatusCode.ServiceUnavailable),
-                    new SmithyClientException(HttpStatusCode.ServiceUnavailable, null),
-                    context
-                )
+            var session = strategy.Begin();
+            var decision = session.Classify(
+                Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable)
             );
             Assert.True(decision.ShouldRetry);
-            contexts.Add(context);
+            sessions.Add(session);
         }
 
         // A retried execution eventually succeeding refunds its tokens.
-        strategy.RecordSuccess(contexts[0]);
+        sessions[0].RecordSuccess();
 
         Assert.True(
             strategy
+                .Begin()
                 .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable))
                 .ShouldRetry
         );
@@ -229,9 +242,9 @@ public sealed class SmithyStandardRetryStrategyTests
             classifyOutcome: static _ => SmithyRetryVerdict.NotRetryable
         );
 
-        var decision = strategy.Classify(
-            Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable)
-        );
+        var decision = strategy
+            .Begin()
+            .Classify(Outcome(attempt: 1, StatusCode: HttpStatusCode.ServiceUnavailable));
 
         Assert.False(decision.ShouldRetry);
     }

--- a/tests/NSmithy.Tests/Http/SmithyRequestModifiersTests.cs
+++ b/tests/NSmithy.Tests/Http/SmithyRequestModifiersTests.cs
@@ -1,0 +1,112 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Http;
+
+namespace NSmithy.Tests.Http;
+
+public sealed class SmithyRequestModifiersTests
+{
+    [Fact]
+    public void CompileReturnsNullForOperationsWithoutRequestTraits()
+    {
+        Assert.Null(SmithyRequestModifiers.Compile(Operation()));
+    }
+
+    [Fact]
+    public void CompiledTransformGzipsBodyAndSetsContentEncoding()
+    {
+        var transform = SmithyRequestModifiers.Compile(Operation(compressionEncoding: "gzip"));
+        var request = Request("hello world"u8.ToArray());
+
+        transform!(request);
+
+        Assert.Equal(["gzip"], request.ContentHeaders["Content-Encoding"]);
+        Assert.Equal(
+            "hello world"u8.ToArray(),
+            Gunzip(((SmithyHttpBody.Bytes)request.Body).Content)
+        );
+    }
+
+    [Fact]
+    public void CompiledTransformAppliesContentMd5()
+    {
+        var transform = SmithyRequestModifiers.Compile(Operation(checksumRequired: true));
+        var body = "hello world"u8.ToArray();
+        var request = Request(body);
+
+        transform!(request);
+
+#pragma warning disable CA5351
+        Assert.Equal(
+            [Convert.ToBase64String(MD5.HashData(body))],
+            request.ContentHeaders["Content-MD5"]
+        );
+#pragma warning restore CA5351
+    }
+
+    [Fact]
+    public void ChecksumCoversTheCompressedBody()
+    {
+        var transform = SmithyRequestModifiers.Compile(
+            Operation(compressionEncoding: "gzip", checksumRequired: true)
+        );
+        var request = Request("hello world"u8.ToArray());
+
+        transform!(request);
+
+#pragma warning disable CA5351
+        Assert.Equal(
+            [Convert.ToBase64String(MD5.HashData(((SmithyHttpBody.Bytes)request.Body).Content))],
+            request.ContentHeaders["Content-MD5"]
+        );
+#pragma warning restore CA5351
+    }
+
+    private static OperationSchema<string, string> Operation(
+        string? compressionEncoding = null,
+        bool checksumRequired = false
+    )
+    {
+        List<Trait> traits = [];
+        if (compressionEncoding is not null)
+        {
+            traits.Add(
+                new Trait(
+                    ShapeId.Parse("smithy.api#requestCompression"),
+                    Document.From(
+                        new Dictionary<string, Document>
+                        {
+                            ["encodings"] = Document.From([Document.From(compressionEncoding)]),
+                        }
+                    )
+                )
+            );
+        }
+
+        if (checksumRequired)
+        {
+            traits.Add(new Trait(ShapeId.Parse("smithy.api#httpChecksumRequired")));
+        }
+
+        return Schemas.Operation(
+            ShapeId.Parse("example.weather#PutForecast"),
+            Schemas.String,
+            Schemas.String,
+            traits
+        );
+    }
+
+    private static SmithyHttpRequest Request(byte[] body) =>
+        new(HttpMethod.Post, "/forecast") { Body = new SmithyHttpBody.Bytes(body) };
+
+    private static byte[] Gunzip(byte[] compressed)
+    {
+        using var input = new MemoryStream(compressed);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gzip.CopyTo(output);
+        return output.ToArray();
+    }
+}

--- a/website/src/content/docs/guides/client-configuration/interceptors.md
+++ b/website/src/content/docs/guides/client-configuration/interceptors.md
@@ -41,7 +41,7 @@ Available hooks:
 | `OnBeforeTransmitAsync` | Modify the signed request before transport sends it. |
 | `OnAfterTransmit` | Observe the raw response before deserialization. |
 | `OnAfterDeserialization` | Observe the typed output after protocol deserialization. |
-| `OnAfterExecution` | Run cleanup or final observation after the call completes. |
+| `OnAfterExecution` | Run cleanup or final observation after the call completes; receives the exception on failure (`null` on success). |
 
 Before hooks run in configured order. After hooks run in reverse order.
 

--- a/website/src/content/docs/guides/client-configuration/retry.md
+++ b/website/src/content/docs/guides/client-configuration/retry.md
@@ -11,18 +11,47 @@ var client = new WeatherClient(
     new Uri("https://api.example.com"),
     new()
     {
-        RetryStrategy = new SmithySimpleRetryStrategy(maxAttempts: 3),
+        RetryStrategy = new SmithyStandardRetryStrategy(maxAttempts: 3),
     });
 ```
 
-`null` disables runtime retries. `SmithySimpleRetryStrategy` retries transport
-failures, HTTP 429, and 5xx responses, with an optional fixed delay:
+`null` disables runtime retries.
+
+## Standard strategy
+
+`SmithyStandardRetryStrategy` is the recommended strategy. It retries transport
+failures, modeled `@retryable` errors, and transient HTTP status codes (408,
+429, 500, 502, 503, 504), using:
+
+- exponential backoff with full jitter and a backoff cap (default base 100 ms,
+  cap 20 s; throttling outcomes back off from a 500 ms base)
+- a client-shared retry quota, so a downstream outage cannot amplify traffic
+  through unbounded retries
+- the server's `Retry-After` header (seconds or HTTP-date) when present
+
+```csharp
+RetryStrategy = new SmithyStandardRetryStrategy(
+    maxAttempts: 5,
+    maxDelay: TimeSpan.FromSeconds(10));
+```
+
+Errors modeled with `@retryable` implement `ISmithyRetryableError`, so modeled
+retryability works regardless of protocol or status code —
+`@retryable(throttling: true)` errors are treated as throttling.
+
+## Simple strategy
+
+`SmithySimpleRetryStrategy` retries transport failures, HTTP 429, and 5xx
+responses, with an optional fixed delay and no backoff, jitter, or quota —
+useful in tests:
 
 ```csharp
 RetryStrategy = new SmithySimpleRetryStrategy(
     maxAttempts: 3,
     delay: TimeSpan.FromMilliseconds(100));
 ```
+
+## Custom strategies
 
 For custom behavior, implement `ISmithyRetryStrategy`. The runtime classifies
 each failed attempt — deserializing the modeled error when there is one — and

--- a/website/src/content/docs/guides/client-configuration/retry.md
+++ b/website/src/content/docs/guides/client-configuration/retry.md
@@ -15,8 +15,8 @@ var client = new WeatherClient(
     });
 ```
 
-`null` disables runtime retries. `SmithySimpleRetryStrategy` retries HTTP 429
-and 5xx responses, with an optional fixed delay:
+`null` disables runtime retries. `SmithySimpleRetryStrategy` retries transport
+failures, HTTP 429, and 5xx responses, with an optional fixed delay:
 
 ```csharp
 RetryStrategy = new SmithySimpleRetryStrategy(
@@ -24,26 +24,36 @@ RetryStrategy = new SmithySimpleRetryStrategy(
     delay: TimeSpan.FromMilliseconds(100));
 ```
 
-For custom behavior, implement `ISmithyRetryStrategy`:
+For custom behavior, implement `ISmithyRetryStrategy`. The runtime classifies
+each failed attempt — deserializing the modeled error when there is one — and
+passes the outcome to the strategy. The outcome carries the attempt number, the
+response (`null` for transport failures), and the exception that will propagate
+to the caller if the attempt is not retried:
 
 ```csharp
 public sealed class BackoffRetryStrategy : ISmithyRetryStrategy
 {
-    public int MaxAttempts => 4;
-
-    public bool ShouldRetry(SmithyRetryContext context) =>
-        context.Response.StatusCode == HttpStatusCode.TooManyRequests
-        || (int)context.Response.StatusCode is >= 500 and <= 599;
-
-    public async ValueTask DelayAsync(
-        SmithyRetryContext context,
-        CancellationToken cancellationToken = default)
+    public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
     {
-        var delay = TimeSpan.FromMilliseconds(100 * Math.Pow(2, context.Attempt - 1));
-        await Task.Delay(delay, cancellationToken);
+        if (outcome.Attempt >= 4 || !IsTransient(outcome))
+        {
+            return SmithyRetryDecision.GiveUp;
+        }
+
+        var delay = TimeSpan.FromMilliseconds(100 * Math.Pow(2, outcome.Attempt - 1));
+        return SmithyRetryDecision.RetryAfter(delay);
     }
+
+    private static bool IsTransient(SmithyRetryOutcome outcome) =>
+        outcome.IsTransportFailure
+        || outcome.Response!.StatusCode == HttpStatusCode.TooManyRequests
+        || (int)outcome.Response.StatusCode is >= 500 and <= 599;
 }
 ```
+
+Because the modeled error is deserialized before the retry decision,
+`outcome.Error` lets a strategy retry on specific modeled error types (for
+example, a service's throttling error).
 
 Retries run inside the NSmithy client runtime. Request interceptors run again for
 each retry attempt, and each attempt starts from the serialized request rather

--- a/website/src/content/docs/guides/client-configuration/retry.md
+++ b/website/src/content/docs/guides/client-configuration/retry.md
@@ -53,15 +53,21 @@ RetryStrategy = new SmithySimpleRetryStrategy(
 
 ## Custom strategies
 
-For custom behavior, implement `ISmithyRetryStrategy`. The runtime classifies
-each failed attempt — deserializing the modeled error when there is one — and
-passes the outcome to the strategy. The outcome carries the attempt number, the
-response (`null` for transport failures), and the exception that will propagate
-to the caller if the attempt is not retried:
+For custom behavior, implement `ISmithyRetryStrategy`. A strategy is long-lived
+and shared by every call on the client; `Begin()` runs once per operation
+execution and returns that execution's `ISmithyRetrySession`. The runtime
+classifies each failed attempt — deserializing the modeled error when there is
+one — and passes the outcome to the session. The outcome carries the attempt
+number, the response (`null` for transport failures), and the exception that
+will propagate to the caller if the attempt is not retried.
+
+A stateless strategy can be its own session:
 
 ```csharp
-public sealed class BackoffRetryStrategy : ISmithyRetryStrategy
+public sealed class BackoffRetryStrategy : ISmithyRetryStrategy, ISmithyRetrySession
 {
+    public ISmithyRetrySession Begin() => this;
+
     public SmithyRetryDecision Classify(SmithyRetryOutcome outcome)
     {
         if (outcome.Attempt >= 4 || !IsTransient(outcome))
@@ -79,6 +85,11 @@ public sealed class BackoffRetryStrategy : ISmithyRetryStrategy
         || (int)outcome.Response.StatusCode is >= 500 and <= 599;
 }
 ```
+
+A stateful strategy keeps client-wide state (like a retry quota) on the
+strategy and per-execution state on the session; the session's
+`RecordSuccess` hook fires when an attempt succeeds, which is how the standard
+strategy refunds quota.
 
 Because the modeled error is deserialized before the retry decision,
 `outcome.Error` lets a strategy retry on specific modeled error types (for


### PR DESCRIPTION
Part 1 of the series aligning the client runtime with `designs/client-architecture.md`. This PR reshapes the retry/interceptor seams **and** ships the standard strategy that motivates them, so the design change and its payoff review together.

## Why

Three gaps vs. the design, all coupled:

1. **Transport failures were never retried** — `transport.SendAsync` exceptions escaped the retry loop entirely.
2. **The retry decision ran before error classification**, so strategies could never see modeled errors, and protocols that signal errors without an error status (gRPC trailers on HTTP 200) couldn't classify.
3. **Interceptors were blind to failures** — the error path skipped every after-hook signal, so logging/metrics interceptors couldn't distinguish success from failure.

## Interface changes (breaking, pre-1.0)

- `IClientInterceptor.OnAfterExecution(SmithyContext)` → `OnAfterExecution(SmithyContext, Exception?)` — receives the exception that will propagate to the caller; `null` on success.
- `ISmithyRetryStrategy` is reshaped around per-execution **sessions** (mirroring smithy-java's `acquireInitialToken`/`refreshRetryToken`/`recordSuccess` token protocol, with the token as an object):

  ```csharp
  interface ISmithyRetryStrategy  { ISmithyRetrySession Begin(); }
  interface ISmithyRetrySession
  {
      SmithyRetryDecision Classify(SmithyRetryOutcome outcome);
      void RecordSuccess() { }
  }
  ```

  Strategies are long-lived, shared, thread-safe (they own client-wide state like the retry quota); sessions are single-execution and hold that execution's state (e.g. quota acquired, refunded on eventual success). Stateless strategies return themselves as the session. The outcome is a failed attempt (response, or `null` + exception on transport failure; modeled errors are deserialized *before* the decision); the decision carries the delay so `Retry-After`/backoff flow through one type.

- `SmithyClientRuntime` now exposes a **single entry point**, `InvokeAsync(binding, input, ct)`. The loose-args typed overload and the raw request/response overload had no non-test callers and are removed; error discrimination is always the protocol's call.

## SmithyStandardRetryStrategy

The design's standard strategy:

- exponential backoff with **full jitter** and a cap (base 100 ms, throttling base 500 ms, cap 20 s)
- **client-shared retry quota** (token bucket: 500 capacity, 5/retry, 10/transport-failure retry, refunded on eventual success — retries stop during sustained outages instead of amplifying load)
- **`Retry-After`** honored (seconds and HTTP-date, via `TimeProvider`)
- default transient classification: transport failures, modeled `@retryable` errors, 408/429/500/502/503/504

## Codegen: modeled retryability

`@retryable` errors now implement `NSmithy.Core.ISmithyRetryableError` (with `IsThrottlingError` from `@retryable(throttling: true)`), so retryability from Smithy traits works regardless of protocol or status code.

## Tests

- runtime: transport-failure retries, strategy sees deserialized modeled error, interceptors observe failures
- strategy: backoff growth/jitter/cap, throttling base, Retry-After (both forms), quota exhaustion + session refund, custom classifier
- codegen: `ErrorGeneratorTest` for the retryable interface emission

Docs updated: `designs/client-architecture.md`, `designs/serialization.md`, website retry + interceptors pages.


## Protocols own request-mutating traits; binding becomes pure data

`@requestCompression` / `@httpChecksumRequired` move from a codegen-emitted `ModifyRequest` lambda into the protocol serialization path — HTTP-body protocols compile the transform once per operation from the schema's traits. Compression is a wire concern whose meaning differs by protocol: gRPC compresses per message via `grpc-encoding`, not `Content-Encoding`, so the old protocol-blind lambda produced broken gRPC requests; `GrpcProtocol` now fails fast at bind time until message-level compression exists.

`SmithyOperationBinding` is now pure data — `(ShapeId serviceId, ShapeId operationId, protocol)` instead of bare name strings plus an opaque request mutator. Generated code passes the existing schema `.Id` values, so telemetry gets full identifiers for free.
