### PR TITLE
fix: copy caller config at client construction

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -327,6 +327,8 @@ public final class ClientGenerator implements Runnable {
             writer.write("");
           }
 
+          // Copies the caller's config before setting the endpoint, so constructing a client
+          // never mutates a config instance the caller may share with other clients.
           writer.write(
               "private static $LConfig WithEndpoint(System.Uri endpoint, $LConfig? config)",
               typeName,
@@ -336,9 +338,12 @@ public final class ClientGenerator implements Runnable {
               "}",
               () -> {
                 writer.write("System.ArgumentNullException.ThrowIfNull(endpoint);");
-                writer.write("config ??= new $LConfig();", typeName);
-                writer.write("config.Endpoint = endpoint;");
-                writer.write("return config;");
+                writer.write(
+                    "var copy = config is null ? new $LConfig() : new $LConfig(config);",
+                    typeName,
+                    typeName);
+                writer.write("copy.Endpoint = endpoint;");
+                writer.write("return copy;");
               });
           writer.write("");
 
@@ -391,11 +396,18 @@ public final class ClientGenerator implements Runnable {
    * Renders the per-service client config: a sealed subclass of the runtime's {@code
    * SmithyClientConfig}. It inherits the common knobs today; service-specific options (e.g.
    * endpoint client-context params) can be added here later without changing the client's
-   * constructor surface.
+   * constructor surface. The copy constructor backs the client's copy-at-construction semantics.
    */
   private void writeConfigClass(String typeName) {
     writer.write("public sealed class $LConfig : SmithyClientConfig", typeName);
-    writer.openBlock("{", "}", () -> {});
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("public $LConfig() { }", typeName);
+          writer.write("");
+          writer.write("public $LConfig($LConfig source) : base(source) { }", typeName, typeName);
+        });
   }
 
   /**

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -113,6 +113,23 @@ final class ClientGeneratorTest {
             "private readonly SmithyEventStreamOperationInvoker eventStreamInvoker;"));
   }
 
+  @Test
+  void endpointConstructorCopiesCallerConfig() throws Exception {
+    String generated = renderClient();
+
+    // The endpoint constructor must never mutate the caller's config instance.
+    assertTrue(
+        generated.contains(
+            "var copy = config is null ? new StreamingServiceClientConfig() : new"
+                + " StreamingServiceClientConfig(config);"),
+        generated);
+    assertTrue(
+        generated.contains(
+            "public StreamingServiceClientConfig(StreamingServiceClientConfig source) :"
+                + " base(source) { }"),
+        generated);
+  }
+
   private String renderClient() throws Exception {
     Model model =
         Model.assembler()

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -59,10 +59,12 @@ new WeatherClient(runtime, config);       // caller owns full execution pipeline
 ```
 
 `Endpoint` lives on config internally. The endpoint convenience constructor is
-the common path and copies the supplied endpoint into config before delegating to
-the internal config-based construction path. For static endpoints, the effective
-endpoint is resolved during construction and placed into each invocation's
-`SmithyContext`.
+the common path: it copies the supplied config (shallow — strategy, interceptor,
+and auth-scheme instances are shared by reference), sets the endpoint on the
+copy, and delegates to the internal config-based construction path. Construction
+never mutates a caller's config, so one config instance can safely parameterize
+several clients. For static endpoints, the effective endpoint is resolved during
+construction and placed into each invocation's `SmithyContext`.
 
 Generated clients implement `IDisposable`. Disposal releases only resources the
 client created itself.

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -9,6 +9,34 @@ namespace NSmithy.Client;
 /// </summary>
 public class SmithyClientConfig
 {
+    public SmithyClientConfig() { }
+
+    /// <summary>
+    /// Copies all common options from <paramref name="source"/>. The copy is shallow on
+    /// purpose: retry strategies, interceptors, and auth schemes are shared by reference, so a
+    /// strategy instance (and client-wide state such as its retry quota) can be deliberately
+    /// shared across clients. Generated clients copy the caller's config at construction, so
+    /// constructing a client never mutates the config the caller passed in.
+    /// </summary>
+    protected SmithyClientConfig(SmithyClientConfig source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        Endpoint = source.Endpoint;
+        Protocol = source.Protocol;
+        RetryStrategy = source.RetryStrategy;
+        IdempotencyTokenProvider = source.IdempotencyTokenProvider;
+        foreach (var interceptor in source.Interceptors)
+        {
+            Interceptors.Add(interceptor);
+        }
+
+        foreach (var authScheme in source.AuthSchemes)
+        {
+            AuthSchemes.Add(authScheme);
+        }
+    }
+
     /// <summary>
     /// The service endpoint. Set by the endpoint constructor, and optional when an
     /// <c>HttpClient</c> is supplied (it then falls back to the

--- a/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
@@ -1,0 +1,54 @@
+using NSmithy.Client;
+
+namespace NSmithy.Tests.Client;
+
+public sealed class SmithyClientConfigTests
+{
+    [Fact]
+    public void CopyConstructorCopiesAllCommonOptions()
+    {
+        var interceptor = new NoopInterceptor();
+        var strategy = new SmithySimpleRetryStrategy();
+        var authScheme = new HttpBearerAuthScheme("token");
+        Func<string> tokenProvider = static () => "token-1";
+        var source = new TestConfig
+        {
+            Endpoint = new Uri("https://api.example.com"),
+            RetryStrategy = strategy,
+            IdempotencyTokenProvider = tokenProvider,
+            Interceptors = { interceptor },
+            AuthSchemes = { authScheme },
+        };
+
+        var copy = new TestConfig(source);
+
+        Assert.Equal(source.Endpoint, copy.Endpoint);
+        // Shallow on purpose: shared strategy instances share client-wide state (retry quota).
+        Assert.Same(strategy, copy.RetryStrategy);
+        Assert.Same(tokenProvider, copy.IdempotencyTokenProvider);
+        Assert.Equal([interceptor], copy.Interceptors);
+        Assert.Equal([authScheme], copy.AuthSchemes);
+    }
+
+    [Fact]
+    public void MutatingTheCopyDoesNotAffectTheSource()
+    {
+        var source = new TestConfig { Endpoint = new Uri("https://one.example.com") };
+
+        var copy = new TestConfig(source) { Endpoint = new Uri("https://two.example.com") };
+        copy.Interceptors.Add(new NoopInterceptor());
+
+        Assert.Equal(new Uri("https://one.example.com"), source.Endpoint);
+        Assert.Empty(source.Interceptors);
+    }
+
+    private sealed class TestConfig : SmithyClientConfig
+    {
+        public TestConfig() { }
+
+        public TestConfig(TestConfig source)
+            : base(source) { }
+    }
+
+    private sealed class NoopInterceptor : IClientInterceptor;
+}


### PR DESCRIPTION
**Stacked on #82** — part 2 of the client-runtime series.

## Problem

The generated endpoint constructor's `WithEndpoint` helper set `config.Endpoint = endpoint` on the *caller's* config instance. Share one config across two clients with different endpoints and the second construction silently rewrote the shared object. It was also inconsistent: the client otherwise snapshots config at construction (later mutations are ignored), yet construction itself mutated it.

## Fix

Generated clients copy the config before touching it:

```csharp
private static WeatherClientConfig WithEndpoint(Uri endpoint, WeatherClientConfig? config)
{
    var copy = config is null ? new WeatherClientConfig() : new WeatherClientConfig(config);
    copy.Endpoint = endpoint;
    return copy;
}
```

`SmithyClientConfig` gains a protected copy constructor; generated configs expose a public one delegating to it.

**The copy is shallow on purpose**: retry strategies, interceptors, and auth schemes are shared by reference. That preserves deliberate sharing semantics — e.g. one `SmithyStandardRetryStrategy` instance shared across several clients of the same backend shares its retry quota, which is the correct scope. A deep copy would silently give every client its own quota bucket.

## Tests

- `SmithyClientConfigTests`: copy covers all common options; strategy identity preserved; mutating the copy doesn't touch the source.
- `ClientGeneratorTest.endpointConstructorCopiesCallerConfig`: pins the generated copy emission.

Docs: `designs/client-architecture.md` constructor section updated to state the copy-at-construction guarantee.
