### PR TITLE
fix: dispose abandoned streaming response bodies in the client runtime

### DIFF
--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -59,7 +59,17 @@ public sealed class SmithyClientRuntime(
                 )
                 .ConfigureAwait(false);
 
-            var output = protocol.DeserializeResponse(response);
+            TOutput output;
+            try
+            {
+                output = protocol.DeserializeResponse(response);
+            }
+            catch
+            {
+                // The protocol failed before the output took ownership of a streaming body.
+                await DisposeBodyAsync(response).ConfigureAwait(false);
+                throw;
+            }
             for (var i = interceptors.Count - 1; i >= 0; i--)
             {
                 interceptors[i].OnAfterDeserialization(context, output);
@@ -140,6 +150,10 @@ public sealed class SmithyClientRuntime(
                 await deserializeError(response, cancellationToken).ConfigureAwait(false)
                 ?? new SmithyClientException(response.StatusCode, response.ReasonPhrase);
 
+            // The error path abandons the response, so a streaming body (which holds the live
+            // HTTP connection) must be released here — whether we retry or throw.
+            await DisposeBodyAsync(response).ConfigureAwait(false);
+
             if (canRetry)
             {
                 var decision = session!.Classify(
@@ -155,6 +169,11 @@ public sealed class SmithyClientRuntime(
             throw error;
         }
     }
+
+    private static ValueTask DisposeBodyAsync(SmithyHttpResponse response) =>
+        response.Body is SmithyHttpBody.Streaming streaming
+            ? streaming.Content.DisposeAsync()
+            : ValueTask.CompletedTask;
 
     private static Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken) =>
         delay > TimeSpan.Zero ? Task.Delay(delay, cancellationToken) : Task.CompletedTask;

--- a/packages/NSmithy.Http/IOperationProtocol.cs
+++ b/packages/NSmithy.Http/IOperationProtocol.cs
@@ -69,6 +69,8 @@ public interface IOperationProtocol<TInput, TOutput>
     /// <summary>
     /// Attempts to deserialize the response into one of the operation's modeled exceptions.
     /// Returns null when the protocol cannot resolve a modeled error from the response.
+    /// The client runtime disposes a streaming response body after this returns (the error path
+    /// abandons the response), so the returned exception must not retain the live stream.
     /// </summary>
     ValueTask<Exception?> DeserializeErrorAsync(
         SmithyHttpResponse response,

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -477,6 +477,81 @@ public sealed class SmithyClientRuntimeTests
         Assert.Equal("one:after-execution:SmithyClientException", calls[^1]);
     }
 
+    [Fact]
+    public async Task RuntimeDisposesStreamingResponseBodyWhenRetrying()
+    {
+        var abandoned = new TrackingStream();
+        var transport = new SequenceTransport(
+            StreamingResponse(HttpStatusCode.InternalServerError, abandoned),
+            new SmithyHttpResponse(
+                HttpStatusCode.OK,
+                "OK",
+                Encoding.UTF8.GetBytes("serialized output"),
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
+        );
+
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
+
+        Assert.True(abandoned.Disposed);
+    }
+
+    [Fact]
+    public async Task RuntimeDisposesStreamingResponseBodyWhenThrowing()
+    {
+        var abandoned = new TrackingStream();
+        var transport = new RecordingTransport(
+            StreamingResponse(HttpStatusCode.InternalServerError, abandoned)
+        );
+        var runtime = new SmithyClientRuntime(transport);
+
+        await Assert.ThrowsAsync<SmithyClientException>(() =>
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
+        );
+
+        Assert.True(abandoned.Disposed);
+    }
+
+    [Fact]
+    public async Task RuntimeDisposesStreamingResponseBodyWhenDeserializationFails()
+    {
+        var abandoned = new TrackingStream();
+        var transport = new RecordingTransport(StreamingResponse(HttpStatusCode.OK, abandoned));
+        var runtime = new SmithyClientRuntime(transport);
+
+        await Assert.ThrowsAsync<FormatException>(() =>
+            runtime.InvokeAsync(Binding(new ThrowingDeserializationProtocol()), "input")
+        );
+
+        Assert.True(abandoned.Disposed);
+    }
+
+    [Fact]
+    public async Task RuntimeLeavesSuccessfulStreamingResponseBodyToTheCaller()
+    {
+        var stream = new TrackingStream();
+        var transport = new RecordingTransport(StreamingResponse(HttpStatusCode.OK, stream));
+        var runtime = new SmithyClientRuntime(transport);
+
+        await runtime.InvokeAsync(Binding(new TextProtocol()), "input");
+
+        Assert.False(stream.Disposed);
+    }
+
+    private static SmithyHttpResponse StreamingResponse(HttpStatusCode statusCode, Stream body) =>
+        new(
+            statusCode,
+            statusCode.ToString(),
+            new SmithyHttpBody.Streaming(body),
+            EmptyHeaders,
+            EmptyHeaders
+        );
+
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -688,5 +763,24 @@ public sealed class SmithyClientRuntimeTests
             {
                 Body = new SmithyHttpBody.Streaming(new MemoryStream("hello"u8.ToArray())),
             };
+    }
+
+    private sealed class ThrowingDeserializationProtocol
+        : TextProtocol,
+            IOperationProtocol<string, string>
+    {
+        public new string DeserializeResponse(SmithyHttpResponse response) =>
+            throw new FormatException("malformed body");
+    }
+
+    private sealed class TrackingStream : MemoryStream
+    {
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
**Stacked on #83** (← #82) — part 3 of the client-runtime series.

## Problem

`HttpClientTransport` wraps streaming responses in a `ResponseContentStream` that owns the live `HttpResponseMessage`. Whenever the runtime abandoned such a response, the HTTP connection stayed pinned until the finalizer ran. Three abandonment paths existed:

1. **Retry**: an error response with a streaming body (e.g. a 503 on a blob download — the transport wraps the body whenever `ExpectStreamingResponse`, regardless of status) is classified, retried, and dropped.
2. **Error throw**: the modeled error is deserialized from the response, the exception propagates, and nobody owns the stream.
3. **Deserialization failure**: `protocol.DeserializeResponse` throws before the typed output takes ownership of the stream.

## Fix

One dispose point on the error path (covers retry-and-throw uniformly, after error deserialization), plus a catch around `DeserializeResponse`. Successful streaming responses are untouched — ownership passes to the caller as before, pinned by a test.

`IOperationProtocol.DeserializeErrorAsync` gains a documented contract: the runtime disposes streaming bodies after error deserialization, so returned exceptions must not retain the live stream (modeled errors are deserialized from buffered bytes in all shipped protocols, so this only constrains exotic custom protocols).

## Tests

Four new runtime tests with a `TrackingStream`: disposed on retry, disposed on throw, disposed on deserialization failure, **not** disposed on success.
