### PR TITLE
feat: OperationTimeout — a deadline over the whole operation execution

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -190,7 +190,8 @@ public final class ClientGenerator implements Runnable {
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
                           + " config.RetryStrategy,"
-                          + " endpoint);",
+                          + " endpoint,"
+                          + " config.OperationTimeout);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -237,7 +238,8 @@ public final class ClientGenerator implements Runnable {
                           + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
                           + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
                           + " config.RetryStrategy,"
-                          + " endpoint);",
+                          + " endpoint,"
+                          + " config.OperationTimeout);",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -25,6 +25,7 @@ public class SmithyClientConfig
         Endpoint = source.Endpoint;
         Protocol = source.Protocol;
         RetryStrategy = source.RetryStrategy;
+        OperationTimeout = source.OperationTimeout;
         IdempotencyTokenProvider = source.IdempotencyTokenProvider;
         foreach (var interceptor in source.Interceptors)
         {
@@ -52,6 +53,13 @@ public class SmithyClientConfig
 
     /// <summary>Runtime-owned retry policy. Null disables runtime retries.</summary>
     public ISmithyRetryStrategy? RetryStrategy { get; set; }
+
+    /// <summary>
+    /// Deadline for one operation execution, spanning all retry attempts and backoff delays.
+    /// When exceeded the call throws <see cref="TimeoutException"/>. Null (the default) means no
+    /// runtime-imposed deadline; the caller's <see cref="CancellationToken"/> always applies.
+    /// </summary>
+    public TimeSpan? OperationTimeout { get; set; }
 
     /// <summary>
     /// Configured auth schemes. The resolver installs the first scheme the service models for which

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -6,7 +6,8 @@ public sealed class SmithyClientRuntime(
     IHttpTransport transport,
     IEnumerable<IClientInterceptor>? interceptors = null,
     ISmithyRetryStrategy? retryStrategy = null,
-    Uri? endpoint = null
+    Uri? endpoint = null,
+    TimeSpan? operationTimeout = null
 )
 {
     private readonly IHttpTransport transport =
@@ -17,6 +18,14 @@ public sealed class SmithyClientRuntime(
         endpoint is null || endpoint.IsAbsoluteUri
             ? endpoint
             : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
+    private readonly TimeSpan? operationTimeout =
+        operationTimeout is null || operationTimeout > TimeSpan.Zero
+            ? operationTimeout
+            : throw new ArgumentOutOfRangeException(
+                nameof(operationTimeout),
+                operationTimeout,
+                "Operation timeout must be positive."
+            );
 
     public Task<TOutput> InvokeAsync<TInput, TOutput>(
         SmithyOperationBinding<TInput, TOutput> binding,
@@ -31,9 +40,18 @@ public sealed class SmithyClientRuntime(
     private async Task<TOutput> InvokeCoreAsync<TInput, TOutput>(
         SmithyOperationBinding<TInput, TOutput> binding,
         TInput input,
-        CancellationToken cancellationToken
+        CancellationToken callerToken
     )
     {
+        // The operation timeout is a deadline over the whole execution — serialization, every
+        // retry attempt, and backoff delays — enforced through a linked token so in-flight
+        // transport work is cancelled promptly.
+        using var timeoutSource = operationTimeout is null
+            ? null
+            : CancellationTokenSource.CreateLinkedTokenSource(callerToken);
+        timeoutSource?.CancelAfter(operationTimeout!.Value);
+        var cancellationToken = timeoutSource?.Token ?? callerToken;
+
         var protocol = binding.Protocol;
         var context = CreateContext(binding.ServiceId.Name, binding.OperationId.Name);
         foreach (var interceptor in interceptors)
@@ -76,6 +94,19 @@ public sealed class SmithyClientRuntime(
             }
 
             return output;
+        }
+        catch (OperationCanceledException)
+            when (timeoutSource?.IsCancellationRequested == true
+                && !callerToken.IsCancellationRequested
+            )
+        {
+            // The deadline fired, not the caller: surface a TimeoutException so the two are
+            // distinguishable. Interceptors observe the translated exception.
+            var timeoutError = new TimeoutException(
+                $"The operation did not complete within {operationTimeout!.Value}."
+            );
+            executionError = timeoutError;
+            throw timeoutError;
         }
         catch (Exception error)
         {

--- a/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
@@ -15,6 +15,7 @@ public sealed class SmithyClientConfigTests
         {
             Endpoint = new Uri("https://api.example.com"),
             RetryStrategy = strategy,
+            OperationTimeout = TimeSpan.FromSeconds(10),
             IdempotencyTokenProvider = tokenProvider,
             Interceptors = { interceptor },
             AuthSchemes = { authScheme },
@@ -23,6 +24,7 @@ public sealed class SmithyClientConfigTests
         var copy = new TestConfig(source);
 
         Assert.Equal(source.Endpoint, copy.Endpoint);
+        Assert.Equal(TimeSpan.FromSeconds(10), copy.OperationTimeout);
         // Shallow on purpose: shared strategy instances share client-wide state (retry quota).
         Assert.Same(strategy, copy.RetryStrategy);
         Assert.Same(tokenProvider, copy.IdempotencyTokenProvider);

--- a/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientRuntimeTests.cs
@@ -543,6 +543,78 @@ public sealed class SmithyClientRuntimeTests
         Assert.False(stream.Disposed);
     }
 
+    [Fact]
+    public async Task OperationTimeoutThrowsTimeoutException()
+    {
+        List<string> calls = [];
+        var runtime = new SmithyClientRuntime(
+            new HangingTransport(),
+            [new RecordingInterceptor("one", calls)],
+            operationTimeout: TimeSpan.FromMilliseconds(50)
+        );
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
+        );
+
+        Assert.Equal("one:after-execution:TimeoutException", calls[^1]);
+    }
+
+    [Fact]
+    public async Task CallerCancellationIsNotTranslatedToTimeout()
+    {
+        using var cts = new CancellationTokenSource();
+        var runtime = new SmithyClientRuntime(
+            new HangingTransport(),
+            operationTimeout: TimeSpan.FromSeconds(30)
+        );
+
+        var invocation = runtime.InvokeAsync(Binding(new TextProtocol()), "input", cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invocation);
+    }
+
+    [Fact]
+    public async Task OperationTimeoutSpansRetryBackoff()
+    {
+        var transport = new SequenceTransport(
+            new SmithyHttpResponse(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                [],
+                EmptyHeaders,
+                EmptyHeaders
+            )
+        );
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(
+                maxAttempts: 2,
+                delay: TimeSpan.FromSeconds(30)
+            ),
+            operationTimeout: TimeSpan.FromMilliseconds(50)
+        );
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            runtime.InvokeAsync(Binding(new TextProtocol()), "input")
+        );
+
+        Assert.Equal(1, transport.Attempts);
+    }
+
+    private sealed class HangingTransport : IHttpTransport
+    {
+        public async Task<SmithyHttpResponse> SendAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("unreachable");
+        }
+    }
+
     private static SmithyHttpResponse StreamingResponse(HttpStatusCode statusCode, Stream body) =>
         new(
             statusCode,

--- a/website/src/content/docs/guides/client-configuration/index.md
+++ b/website/src/content/docs/guides/client-configuration/index.md
@@ -44,6 +44,7 @@ when you want to set client options.
 | `Protocol` | The wire protocol. Defaults to the service's primary declared [protocol](/smithy-dotnet/protocols/overview/). |
 | `AuthSchemes` | Configured auth schemes; the resolver installs the first scheme the service models. An empty list means anonymous. |
 | `RetryStrategy` | Runtime-owned retry policy. `null` disables runtime retries. |
+| `OperationTimeout` | Deadline for one operation execution, spanning all retry attempts and backoff delays. Throws `TimeoutException` when exceeded; `null` (default) means no deadline. |
 | `Interceptors` | Protocol-agnostic hooks for observing and modifying client execution. |
 | `IdempotencyTokenProvider` | Overrides the idempotency-token generator (default: a random GUID). |
 


### PR DESCRIPTION
**Stacked on #84** (← #83 ← #82) — part 4 of the client-runtime series.

Implements the `OperationTimeout` knob the design doc promises on `SmithyClientConfig`.

## Semantics

- **One deadline over the whole execution**: serialization, every retry attempt, *and backoff delays*. A retry strategy that would sleep 30 s cannot blow past a 5 s deadline — the linked token cancels the backoff sleep and in-flight transport work promptly.
- **`TimeoutException` vs. `OperationCanceledException`**: the deadline firing throws `TimeoutException`; caller cancellation still surfaces `OperationCanceledException`. The two are distinguishable, and interceptors observe the translated exception in `OnAfterExecution`.
- `null` (default) = no runtime-imposed deadline; the caller's token always applies either way.
- No per-attempt timeout in this PR — `HttpClient.Timeout` remains available for that layer; an `AttemptTimeout` can be added to the config later without breaking.

## Wiring

`SmithyClientRuntime` gains an optional `operationTimeout` constructor parameter (validated positive); generated clients pass `config.OperationTimeout`; the config copy constructor copies it. The runtime-supplied constructor keeps its existing rule: the runtime's own configuration wins, `config.OperationTimeout` is not read there.

## Tests

- deadline fires → `TimeoutException`, interceptor sees it
- caller cancellation → `OperationCanceledException`, never translated
- deadline spans retry backoff (30 s retry delay, 50 ms deadline, exactly 1 attempt)
- config copy includes the new property
