### PR TITLE
feat: OpenTelemetry instrumentation for the client runtime

### DIFF
--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using NSmithy.Http;
 
 namespace NSmithy.Client;
@@ -54,6 +55,27 @@ public sealed class SmithyClientRuntime(
 
         var protocol = binding.Protocol;
         var context = CreateContext(binding.ServiceId.Name, binding.OperationId.Name);
+
+        var tags = new TagList
+        {
+            { "rpc.system", "smithy" },
+            { "rpc.service", binding.ServiceId.ToString() },
+            { "rpc.method", binding.OperationId.Name },
+        };
+        using var activity = SmithyClientTelemetry.ActivitySource.StartActivity(
+            $"{binding.ServiceId.Name}.{binding.OperationId.Name}",
+            ActivityKind.Client
+        );
+        if (activity is not null)
+        {
+            foreach (var tag in tags)
+            {
+                activity.SetTag(tag.Key, tag.Value);
+            }
+        }
+
+        var startTimestamp = Stopwatch.GetTimestamp();
+
         foreach (var interceptor in interceptors)
         {
             interceptor.OnBeforeExecution(context);
@@ -73,6 +95,7 @@ public sealed class SmithyClientRuntime(
                     request,
                     protocol.DeserializeErrorAsync,
                     protocol.IsErrorResponse,
+                    tags,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -119,6 +142,20 @@ public sealed class SmithyClientRuntime(
             {
                 interceptors[i].OnAfterExecution(context, executionError);
             }
+
+            if (executionError is not null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, executionError.Message);
+                activity?.SetTag("error.type", executionError.GetType().FullName);
+                var errorTags = tags;
+                errorTags.Add("error.type", executionError.GetType().FullName);
+                SmithyClientTelemetry.Errors.Add(1, errorTags);
+            }
+
+            SmithyClientTelemetry.OperationDuration.Record(
+                Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds,
+                tags
+            );
         }
     }
 
@@ -127,6 +164,7 @@ public sealed class SmithyClientRuntime(
         SmithyHttpRequest request,
         Func<SmithyHttpResponse, CancellationToken, ValueTask<Exception?>> deserializeError,
         Func<SmithyHttpResponse, bool> isErrorResponse,
+        TagList tags,
         CancellationToken cancellationToken
     )
     {
@@ -136,6 +174,13 @@ public sealed class SmithyClientRuntime(
         for (var attempt = 1; ; attempt++)
         {
             context.Set(SmithyContextKeys.Attempt, attempt);
+            using var attemptActivity = SmithyClientTelemetry.ActivitySource.StartActivity(
+                "attempt",
+                ActivityKind.Internal
+            );
+            attemptActivity?.SetTag("smithy.attempt", attempt);
+            SmithyClientTelemetry.Attempts.Add(1, tags);
+
             var resolvedRequest = ApplyEndpoint(CloneRequest(request));
             var attemptRequest = await ApplyRequestInterceptorsAsync(
                     context,
@@ -154,6 +199,8 @@ public sealed class SmithyClientRuntime(
             catch (Exception transportError)
                 when (canRetry && !cancellationToken.IsCancellationRequested)
             {
+                attemptActivity?.SetStatus(ActivityStatusCode.Error, transportError.Message);
+                attemptActivity?.SetTag("error.type", transportError.GetType().FullName);
                 var decision = session!.Classify(
                     new SmithyRetryOutcome(attempt, null, transportError, context)
                 );
@@ -180,6 +227,9 @@ public sealed class SmithyClientRuntime(
             var error =
                 await deserializeError(response, cancellationToken).ConfigureAwait(false)
                 ?? new SmithyClientException(response.StatusCode, response.ReasonPhrase);
+
+            attemptActivity?.SetStatus(ActivityStatusCode.Error, error.Message);
+            attemptActivity?.SetTag("error.type", error.GetType().FullName);
 
             // The error path abandons the response, so a streaming body (which holds the live
             // HTTP connection) must be released here — whether we retry or throw.

--- a/packages/NSmithy.Client/SmithyClientTelemetry.cs
+++ b/packages/NSmithy.Client/SmithyClientTelemetry.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace NSmithy.Client;
+
+/// <summary>
+/// OpenTelemetry-friendly instrumentation sources for the client runtime. Subscribe with an
+/// <see cref="ActivityListener"/> / OpenTelemetry tracer provider using
+/// <see cref="ActivitySourceName"/>, and a meter provider using <see cref="MeterName"/>.
+/// Span and metric dimensions use Smithy identifiers: <c>rpc.system</c> = <c>smithy</c>,
+/// <c>rpc.service</c> = the service shape id, <c>rpc.method</c> = the operation name.
+/// </summary>
+public static class SmithyClientTelemetry
+{
+    public const string ActivitySourceName = "NSmithy.Client";
+
+    public const string MeterName = "NSmithy.Client";
+
+    private static readonly string? Version = typeof(SmithyClientTelemetry)
+        .Assembly.GetName()
+        .Version?.ToString();
+
+    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version);
+
+    internal static readonly Meter Meter = new(MeterName, Version);
+
+    /// <summary>Total transport attempts, including retries.</summary>
+    internal static readonly Counter<long> Attempts = Meter.CreateCounter<long>(
+        "smithy.client.attempts",
+        unit: "{attempt}",
+        description: "Total transport attempts, including retries."
+    );
+
+    /// <summary>Failed operation executions, dimensioned by error.type.</summary>
+    internal static readonly Counter<long> Errors = Meter.CreateCounter<long>(
+        "smithy.client.errors",
+        unit: "{error}",
+        description: "Failed operation executions."
+    );
+
+    /// <summary>End-to-end operation duration, spanning all attempts and backoff.</summary>
+    internal static readonly Histogram<double> OperationDuration = Meter.CreateHistogram<double>(
+        "smithy.client.operation.duration",
+        unit: "s",
+        description: "End-to-end operation duration, spanning all attempts and backoff."
+    );
+}

--- a/tests/NSmithy.Tests/Client/SmithyClientTelemetryTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientTelemetryTests.cs
@@ -1,0 +1,255 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Text;
+using NSmithy.Client;
+using NSmithy.Core;
+using NSmithy.Http;
+
+namespace NSmithy.Tests.Client;
+
+/// <summary>
+/// ActivitySource/Meter are process-global and other test classes run in parallel, so every
+/// test here uses a unique service shape id and filters captured telemetry by it.
+/// </summary>
+public sealed class SmithyClientTelemetryTests : IDisposable
+{
+    private readonly object sync = new();
+    private readonly List<Activity> activities = [];
+    private readonly List<(
+        string Instrument,
+        double Value,
+        KeyValuePair<string, object?>[] Tags
+    )> measurements = [];
+    private readonly ActivityListener activityListener;
+    private readonly MeterListener meterListener;
+
+    public SmithyClientTelemetryTests()
+    {
+        activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SmithyClientTelemetry.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                lock (sync)
+                {
+                    activities.Add(activity);
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == SmithyClientTelemetry.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<long>(
+            (instrument, measurement, tags, _) => Record(instrument.Name, measurement, tags)
+        );
+        meterListener.SetMeasurementEventCallback<double>(
+            (instrument, measurement, tags, _) => Record(instrument.Name, measurement, tags)
+        );
+        meterListener.Start();
+    }
+
+    private void Record(
+        string instrument,
+        double value,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags
+    )
+    {
+        var copied = tags.ToArray();
+        lock (sync)
+        {
+            measurements.Add((instrument, value, copied));
+        }
+    }
+
+    public void Dispose()
+    {
+        activityListener.Dispose();
+        meterListener.Dispose();
+    }
+
+    [Fact]
+    public async Task SuccessfulOperationEmitsSpanAttemptAndDuration()
+    {
+        var serviceId = "example.telemetry#WeatherSuccess";
+        var runtime = new SmithyClientRuntime(new StaticTransport(Ok()));
+
+        await runtime.InvokeAsync(Binding(serviceId), "input");
+
+        var operation = Assert.Single(
+            Activities(a => a.OperationName == "WeatherSuccess.GetForecast")
+        );
+        Assert.Equal(ActivityKind.Client, operation.Kind);
+        Assert.Equal("smithy", operation.GetTagItem("rpc.system"));
+        Assert.Equal(serviceId, operation.GetTagItem("rpc.service"));
+        Assert.Equal("GetForecast", operation.GetTagItem("rpc.method"));
+        Assert.NotEqual(ActivityStatusCode.Error, operation.Status);
+
+        var attempt = Assert.Single(Activities(a => a.ParentSpanId == operation.SpanId));
+        Assert.Equal("attempt", attempt.OperationName);
+        Assert.Equal(1, attempt.GetTagItem("smithy.attempt"));
+
+        Assert.Equal(1, Total("smithy.client.attempts", serviceId));
+        Assert.Equal(0, Total("smithy.client.errors", serviceId));
+        Assert.Single(Values("smithy.client.operation.duration", serviceId));
+    }
+
+    [Fact]
+    public async Task FailedOperationMarksSpanAndCountsError()
+    {
+        var serviceId = "example.telemetry#WeatherFailure";
+        var runtime = new SmithyClientRuntime(
+            new StaticTransport(Response(HttpStatusCode.InternalServerError))
+        );
+
+        await Assert.ThrowsAsync<SmithyClientException>(() =>
+            runtime.InvokeAsync(Binding(serviceId), "input")
+        );
+
+        var operation = Assert.Single(
+            Activities(a => a.OperationName == "WeatherFailure.GetForecast")
+        );
+        Assert.Equal(ActivityStatusCode.Error, operation.Status);
+        Assert.Equal(typeof(SmithyClientException).FullName, operation.GetTagItem("error.type"));
+
+        var error = Assert.Single(Measurements("smithy.client.errors", serviceId));
+        Assert.Contains(
+            new KeyValuePair<string, object?>("error.type", typeof(SmithyClientException).FullName),
+            error.Tags
+        );
+    }
+
+    [Fact]
+    public async Task RetriesEmitOneAttemptSpanPerAttempt()
+    {
+        var serviceId = "example.telemetry#WeatherRetry";
+        var transport = new SequenceTransport(Response(HttpStatusCode.InternalServerError), Ok());
+        var runtime = new SmithyClientRuntime(
+            transport,
+            retryStrategy: new SmithySimpleRetryStrategy(maxAttempts: 2)
+        );
+
+        await runtime.InvokeAsync(Binding(serviceId), "input");
+
+        var operation = Assert.Single(
+            Activities(a => a.OperationName == "WeatherRetry.GetForecast")
+        );
+        Assert.Equal(2, Activities(a => a.ParentSpanId == operation.SpanId).Count);
+        Assert.Equal(2, Total("smithy.client.attempts", serviceId));
+        // The execution eventually succeeded, so no error is counted.
+        Assert.Equal(0, Total("smithy.client.errors", serviceId));
+    }
+
+    private List<Activity> Activities(Func<Activity, bool> predicate)
+    {
+        lock (sync)
+        {
+            return activities.Where(predicate).ToList();
+        }
+    }
+
+    private List<(
+        string Instrument,
+        double Value,
+        KeyValuePair<string, object?>[] Tags
+    )> Measurements(string instrument, string serviceId)
+    {
+        lock (sync)
+        {
+            return measurements
+                .Where(m =>
+                    m.Instrument == instrument
+                    && m.Tags.Contains(new KeyValuePair<string, object?>("rpc.service", serviceId))
+                )
+                .ToList();
+        }
+    }
+
+    private double Total(string instrument, string serviceId) =>
+        Measurements(instrument, serviceId).Sum(m => m.Value);
+
+    private List<double> Values(string instrument, string serviceId) =>
+        Measurements(instrument, serviceId).Select(m => m.Value).ToList();
+
+    private static SmithyOperationBinding<string, string> Binding(string serviceId) =>
+        new(
+            ShapeId.Parse(serviceId),
+            ShapeId.Parse($"{serviceId.Split('#')[0]}#GetForecast"),
+            new TextProtocol()
+        );
+
+    private static SmithyHttpResponse Ok() => Response(HttpStatusCode.OK);
+
+    private static SmithyHttpResponse Response(HttpStatusCode statusCode) =>
+        new(
+            statusCode,
+            statusCode.ToString(),
+            Encoding.UTF8.GetBytes("serialized output"),
+            EmptyHeaders,
+            EmptyHeaders
+        );
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+    private sealed class StaticTransport(SmithyHttpResponse response) : IHttpTransport
+    {
+        public Task<SmithyHttpResponse> SendAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(response);
+    }
+
+    private sealed class SequenceTransport(params SmithyHttpResponse[] responses) : IHttpTransport
+    {
+        private int attempts;
+
+        public Task<SmithyHttpResponse> SendAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var index = Math.Min(attempts, responses.Length - 1);
+            attempts++;
+            return Task.FromResult(responses[index]);
+        }
+    }
+
+    private sealed class TextProtocol : IOperationProtocol<string, string>
+    {
+        public SmithyHttpRequest SerializeRequest(string input) =>
+            new(HttpMethod.Post, $"/{input}");
+
+        public string DeserializeResponse(SmithyHttpResponse response) => "output";
+
+        public string DeserializeRequest(SmithyHttpRequest request) => request.RequestUri;
+
+        public SmithyHttpResponse SerializeResponse(string output) => Ok();
+
+        public bool IsErrorResponse(SmithyHttpResponse response) => (int)response.StatusCode >= 400;
+
+        public string? GetErrorDiscriminator(SmithyHttpResponse response) => null;
+
+        public bool RequiresErrorDiscriminator => false;
+
+        public bool SupportsHttpStatusErrorFallback => true;
+
+        public SmithyHttpResponse SerializeError<TError>(
+            NSmithy.Core.Serde.Schema<TError> errorSchema,
+            TError value,
+            string errorShapeId,
+            int statusCode
+        ) => throw new NotSupportedException();
+    }
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -79,6 +79,7 @@ export default defineConfig({
 								{ label: 'Authentication', slug: 'guides/client-configuration/authentication' },
 								{ label: 'Retry', slug: 'guides/client-configuration/retry' },
 								{ label: 'Interceptors', slug: 'guides/client-configuration/interceptors' },
+								{ label: 'Observability', slug: 'guides/client-configuration/observability' },
 								{ label: 'Transport', slug: 'guides/client-configuration/transport' },
 								{ label: 'Dependency Injection', slug: 'guides/client-configuration/dependency-injection' },
 							],

--- a/website/src/content/docs/guides/client-configuration/index.md
+++ b/website/src/content/docs/guides/client-configuration/index.md
@@ -93,6 +93,8 @@ For a long-lived application, prefer registering the client once with
   runtime-owned retry configuration.
 - [Interceptors](/smithy-dotnet/guides/client-configuration/interceptors/)
   covers client execution hooks.
+- [Observability](/smithy-dotnet/guides/client-configuration/observability/)
+  covers OpenTelemetry tracing and metrics.
 - [Transport](/smithy-dotnet/guides/client-configuration/transport/) covers
   endpoint, `HttpClient`, and low-level runtime ownership.
 - [Dependency Injection](/smithy-dotnet/guides/client-configuration/dependency-injection/)

--- a/website/src/content/docs/guides/client-configuration/observability.md
+++ b/website/src/content/docs/guides/client-configuration/observability.md
@@ -1,0 +1,55 @@
+---
+title: Observability
+description: OpenTelemetry tracing and metrics for generated clients.
+---
+
+The client runtime emits OpenTelemetry-friendly telemetry through the standard
+.NET primitives — no NSmithy-specific setup, no extra packages. Subscribe with
+your tracer/meter provider:
+
+```csharp
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource("NSmithy.Client"))
+    .WithMetrics(metrics => metrics.AddMeter("NSmithy.Client"));
+```
+
+The source and meter names are also available as constants:
+`SmithyClientTelemetry.ActivitySourceName` and
+`SmithyClientTelemetry.MeterName`.
+
+## Traces
+
+Each operation execution produces a client span named
+`{Service}.{Operation}` (e.g. `Weather.GetForecast`), with one child span per
+transport attempt, so retries are visible in the trace:
+
+| Attribute | Value |
+| --- | --- |
+| `rpc.system` | `smithy` |
+| `rpc.service` | The service shape id (e.g. `example.weather#Weather`). |
+| `rpc.method` | The operation name. |
+| `error.type` | The exception type on failure (execution span). |
+| `smithy.attempt` | The 1-based attempt number (attempt spans). |
+
+Failed executions set the span status to `Error` with the exception message;
+failed attempts mark their attempt span the same way, so a retried-then-
+successful call shows a failed first attempt under a successful operation span.
+
+## Metrics
+
+| Instrument | Type | Unit | Meaning |
+| --- | --- | --- | --- |
+| `smithy.client.operation.duration` | Histogram | `s` | End-to-end operation duration, spanning all attempts and backoff. |
+| `smithy.client.attempts` | Counter | `{attempt}` | Total transport attempts, including retries. |
+| `smithy.client.errors` | Counter | `{error}` | Failed operation executions, dimensioned by `error.type`. |
+
+All instruments carry `rpc.system`, `rpc.service`, and `rpc.method` dimensions.
+The ratio of `smithy.client.attempts` to operation count is a direct
+retry-amplification signal.
+
+For custom logging or per-request diagnostics beyond spans and metrics, use
+[interceptors](/smithy-dotnet/guides/client-configuration/interceptors/) —
+`OnAfterExecution` receives the outcome (the exception, or `null` on success).


### PR DESCRIPTION
**Stacked on #85** (← #84 ← #83 ← #82) — part 5 of the client-runtime series. Implements the design doc's Observability section.

## Traces

- One `ActivityKind.Client` span per operation execution, named `{Service}.{Operation}`, tagged `rpc.system=smithy`, `rpc.service=<service shape id>`, `rpc.method=<operation>` — the ShapeIds now carried by the operation binding pay off here.
- One child span per transport attempt (`smithy.attempt` tag), so a retried call shows a failed first attempt under the operation span.
- Failures set `Error` status + `error.type` on both levels; the `TimeoutException` from `OperationTimeout` and modeled errors are all visible.

## Metrics

| Instrument | Type | Meaning |
|---|---|---|
| `smithy.client.operation.duration` | histogram (s) | end-to-end, spanning all attempts and backoff |
| `smithy.client.attempts` | counter | total transport attempts incl. retries |
| `smithy.client.errors` | counter | failed executions, dimensioned by `error.type` |

All instruments carry the `rpc.*` dimensions; `attempts / operations` is a direct retry-amplification signal (pairs with the retry quota from #82).

## Notes

- **No new dependencies** — `System.Diagnostics.ActivitySource` + `System.Diagnostics.Metrics.Meter` from the BCL; consumers subscribe via `AddSource("NSmithy.Client")` / `AddMeter("NSmithy.Client")` (names exposed as constants on `SmithyClientTelemetry`).
- **Zero overhead when unobserved**: `StartActivity` returns null and counters no-op without listeners.
- Event-stream operations don't flow through the runtime and are not instrumented here (they'll get theirs when streaming moves onto the lifecycle).

Tests subscribe an `ActivityListener`/`MeterListener` and assert span shape, parenting, attempt counts, and error dimensions — scoped by unique service ids since the sources are process-global and tests run in parallel. Website gains an Observability page documenting names and dimensions.
