### PR TITLE
feat: per-operation endpoint resolution and auth scheme selection

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -187,11 +187,13 @@ public final class ClientGenerator implements Runnable {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient),"
-                          + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
-                          + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
+                          + " config.Interceptors,"
                           + " config.RetryStrategy,"
                           + " endpoint,"
-                          + " config.OperationTimeout);",
+                          + " config.OperationTimeout,"
+                          + " config.EndpointResolver,"
+                          + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
+                          + " ModeledAuthSchemes, config.AuthSchemes));",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -235,11 +237,13 @@ public final class ClientGenerator implements Runnable {
                   writer.write(
                       "this.runtime = new SmithyClientRuntime(new"
                           + " HttpClientTransport(httpClient),"
-                          + " SmithyAuthSchemeResolver.Resolve(endpoint, $L,"
-                          + " ModeledAuthSchemes, config.AuthSchemes, config.Interceptors),"
+                          + " config.Interceptors,"
                           + " config.RetryStrategy,"
                           + " endpoint,"
-                          + " config.OperationTimeout);",
+                          + " config.OperationTimeout,"
+                          + " config.EndpointResolver,"
+                          + " SmithyAuthSchemeResolver.ResolveInterceptors(endpoint, $L,"
+                          + " ModeledAuthSchemes, config.AuthSchemes));",
                       serviceSchema);
                 }
                 if (wiresEventStreamOperations) {
@@ -474,14 +478,34 @@ public final class ClientGenerator implements Runnable {
       String operationSchema = SchemaGenerator.operationSchemaAccessor(context, op);
       writer.write(
           "this.$LBinding = new SmithyOperationBinding<$L, $L>($L.Id, $L.Id,"
-              + " serviceProtocol.ForOperation($L));",
+              + " serviceProtocol.ForOperation($L), $L);",
           CSharpNaming.typeName(op.getId().getName()),
           SchemaGenerator.operationShapeType(context, op.getInputShape()),
           SchemaGenerator.operationShapeType(context, op.getOutputShape()),
           SchemaGenerator.serviceSchemaAccessor(context, service),
           operationSchema,
-          operationSchema);
+          operationSchema,
+          operationAuthSchemesLiteral(op));
     }
+  }
+
+  /**
+   * The operation's effective auth schemes in Smithy priority order: the service's effective
+   * schemes, overridden by a per-operation {@code @auth} trait. Rendered as a C# array literal of
+   * shape-id strings for the operation binding; the runtime selects the configured interceptor per
+   * invocation from this list.
+   */
+  private String operationAuthSchemesLiteral(OperationShape op) {
+    List<String> ids =
+        ServiceIndex.of(context.model()).getEffectiveAuthSchemes(service, op).keySet().stream()
+            .map(ShapeId::toString)
+            .collect(Collectors.toList());
+    if (ids.isEmpty()) {
+      return "System.Array.Empty<string>()";
+    }
+    return "new string[] { "
+        + ids.stream().map(CSharpNaming::formatString).collect(Collectors.joining(", "))
+        + " }";
   }
 
   private void writeEventStreamProtocolField(SymbolProvider sp, Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -113,6 +113,69 @@ final class ClientGeneratorTest {
             "private readonly SmithyEventStreamOperationInvoker eventStreamInvoker;"));
   }
 
+  private static final String REST_PROTOCOL_TRAITS =
+      """
+      $version: "2"
+
+      namespace aws.protocols
+
+      use smithy.api#protocolDefinition
+      use smithy.api#trait
+
+      @trait(selector: "service")
+      @protocolDefinition
+      structure restJson1 {}
+      """;
+
+  private static final String AUTH_MODEL =
+      """
+      $version: "2"
+
+      namespace example.auth
+
+      use aws.protocols#restJson1
+
+      @restJson1
+      @httpBearerAuth
+      @httpApiKeyAuth(name: "x-api-key", in: "header")
+      service Secured {
+          version: "1"
+          operations: [ReadThing, AdminThing]
+      }
+
+      @http(method: "GET", uri: "/thing")
+      operation ReadThing {
+          input := {}
+          output := {}
+      }
+
+      @auth([httpApiKeyAuth])
+      @http(method: "GET", uri: "/admin")
+      operation AdminThing {
+          input := {}
+          output := {}
+      }
+      """;
+
+  @Test
+  void operationBindingsCarryEffectiveAuthSchemes() throws Exception {
+    String generated =
+        renderClient(REST_PROTOCOL_TRAITS, AUTH_MODEL, "example.auth#Secured", "Example.Auth");
+
+    // ReadThing inherits the service's effective schemes (alphabetical by shape id).
+    assertTrue(
+        generated.contains(
+            "serviceProtocol.ForOperation(Example.Example.Auth.ReadThingSchema.Schema), new"
+                + " string[] { \"smithy.api#httpApiKeyAuth\", \"smithy.api#httpBearerAuth\" });"),
+        generated);
+    // AdminThing's @auth trait overrides the service default.
+    assertTrue(
+        generated.contains(
+            "serviceProtocol.ForOperation(Example.Example.Auth.AdminThingSchema.Schema), new"
+                + " string[] { \"smithy.api#httpApiKeyAuth\" });"),
+        generated);
+  }
+
   @Test
   void endpointConstructorCopiesCallerConfig() throws Exception {
     String generated = renderClient();
@@ -131,20 +194,29 @@ final class ClientGeneratorTest {
   }
 
   private String renderClient() throws Exception {
+    return renderClient(
+        PROTOCOL_TRAITS, MODEL, "example.streaming#StreamingService", "Example.Streaming");
+  }
+
+  private String renderClient(
+      String protocolTraits, String serviceModel, String serviceId, String writerNamespace)
+      throws Exception {
     Model model =
         Model.assembler()
-            .addUnparsedModel("protocol-traits.smithy", PROTOCOL_TRAITS)
-            .addUnparsedModel("model.smithy", MODEL)
+            .addUnparsedModel("protocol-traits.smithy", protocolTraits)
+            .addUnparsedModel("model.smithy", serviceModel)
             .assemble()
             .unwrap();
     CSharpSettings settings =
         CSharpSettings.fromNode(
             ObjectNode.builder()
-                .withMember("service", Node.from("example.streaming#StreamingService"))
+                .withMember("service", Node.from(serviceId))
                 .withMember("baseNamespace", Node.from("Example"))
                 .build());
     var symbolProvider = new CSharpSymbolProvider(model, settings);
-    var manifest = FileManifest.create(Files.createDirectory(tempDir.resolve("manifest")));
+    var manifest =
+        FileManifest.create(
+            Files.createDirectory(tempDir.resolve("manifest-" + serviceId.replace('#', '-'))));
     var context =
         GenerationContext.builder()
             .model(model)
@@ -153,9 +225,8 @@ final class ClientGeneratorTest {
             .fileManifest(manifest)
             .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
             .build();
-    var writer = new CSharpWriter("Example.Streaming");
-    var service =
-        model.expectShape(ShapeId.from("example.streaming#StreamingService"), ServiceShape.class);
+    var writer = new CSharpWriter(writerNamespace);
+    var service = model.expectShape(ShapeId.from(serviceId), ServiceShape.class);
 
     new ClientGenerator(context, writer, service).run();
 

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -14,9 +14,9 @@ The desired shape is:
 ```text
 start execution
   -> create execution context
+  -> resolve endpoint and select auth scheme
   -> run before-execution interceptors
   -> prepare typed input
-  -> resolve endpoint
   -> serialize request
   -> resolve auth identity and signer
   -> sign request
@@ -25,6 +25,9 @@ start execution
   -> run completion interceptors
   -> return typed output
 ```
+
+Endpoint resolution and auth scheme selection run before the before-execution
+interceptors so every hook observes the effective endpoint in the context.
 
 Retries wrap the attempt portion of the lifecycle. Telemetry observes both the
 overall execution and individual attempts.
@@ -154,28 +157,42 @@ concurrent calls unless explicitly documented otherwise.
 
 ## Endpoint Resolution
 
-Endpoint resolution can be per operation. The resolver sees operation metadata,
-client config, and typed input:
+Endpoint resolution can be per operation. The resolver sees the operation's
+Smithy identifiers, the statically configured endpoint, and the typed input;
+it is async so discovery-style resolvers can do I/O:
 
 ```csharp
 public interface IEndpointResolver
 {
-    Endpoint ResolveEndpoint(EndpointParameters parameters);
+    ValueTask<SmithyEndpoint> ResolveEndpointAsync(
+        SmithyEndpointParameters parameters,
+        CancellationToken cancellationToken = default);
 }
 
-public sealed record Endpoint(
+public sealed record SmithyEndpoint(
     Uri Uri,
-    IReadOnlyDictionary<string, string> Headers,
+    IReadOnlyDictionary<string, string>? Headers = null,
     IReadOnlyList<string>? AuthSchemes = null);
+
+public sealed record SmithyEndpointParameters(
+    ShapeId ServiceId,
+    ShapeId OperationId,
+    Uri? ConfiguredEndpoint,
+    object? Input);
 ```
 
-A static `Config.Endpoint` is the simplest resolver and takes precedence when
-set explicitly. Static endpoints are resolved once at construction. Protocols
-and generated code apply host labels and operation endpoint traits through the
-same resolution path when an endpoint depends on operation metadata or input.
+A static `Config.Endpoint` is the simplest resolver (`StaticEndpointResolver`)
+and is used when no resolver is configured; `Config.EndpointResolver` overrides
+it for request routing. Resolution runs once per invocation, before
+serialization. Resolved endpoint headers are added to every request sent to
+that endpoint. Protocols and generated code apply host labels and operation
+endpoint traits through the same resolution path when an endpoint depends on
+operation metadata or input.
 
-Resolved endpoints may narrow auth schemes. That lets endpoint rules and auth
-selection compose without protocol-specific branches in generated clients.
+Resolved endpoints may narrow auth schemes: when `SmithyEndpoint.AuthSchemes`
+is non-null, only modeled schemes also present there are considered by auth
+selection. That lets endpoint rules and auth selection compose without
+protocol-specific branches in generated clients.
 
 ## Auth
 
@@ -188,7 +205,13 @@ Auth has three separable concepts:
 
 Auth schemes are keyed by Smithy auth trait shape id. Per-operation `@auth`
 overrides, endpoint-driven auth overrides, and anonymous operations all feed the
-same resolver.
+same resolver: each operation binding carries the operation's effective modeled
+scheme ids (the service default, overridden by `@auth`), the resolved endpoint
+may narrow that list, and the runtime selects the first scheme with a
+configured interceptor per invocation. Configured schemes create their
+interceptors once at client construction; selection is per call. The selected
+auth interceptor runs after user interceptors in each request phase, so signing
+sees the final request.
 
 Identity providers own caching and refresh. Signers are stateless or explicitly
 thread-safe services that operate on a request plus context.

--- a/packages/NSmithy.Client/IEndpointResolver.cs
+++ b/packages/NSmithy.Client/IEndpointResolver.cs
@@ -1,0 +1,60 @@
+using NSmithy.Core;
+
+namespace NSmithy.Client;
+
+/// <summary>
+/// Resolves the effective endpoint for one operation execution. Resolution runs once per
+/// invocation, before serialization, and may do I/O (endpoint discovery). A static
+/// <c>Config.Endpoint</c> is the simplest resolver (<see cref="StaticEndpointResolver"/>) and is
+/// used when no resolver is configured.
+/// </summary>
+public interface IEndpointResolver
+{
+    ValueTask<SmithyEndpoint> ResolveEndpointAsync(
+        SmithyEndpointParameters parameters,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>
+/// A resolved endpoint: the base URI serialized request paths resolve against, headers to add to
+/// every request sent to it, and an optional narrowing of the auth schemes usable against it
+/// (ordered subset semantics: when non-null, only modeled schemes also present here are
+/// considered by auth selection).
+/// </summary>
+public sealed record SmithyEndpoint(
+    Uri Uri,
+    IReadOnlyDictionary<string, string>? Headers = null,
+    IReadOnlyList<string>? AuthSchemes = null
+)
+{
+    public Uri Uri { get; } =
+        Uri.IsAbsoluteUri
+            ? Uri
+            : throw new ArgumentException("Endpoint URI must be absolute.", nameof(Uri));
+}
+
+/// <summary>
+/// What an <see cref="IEndpointResolver"/> sees: the operation's Smithy identifiers, the
+/// statically configured endpoint (if any), and the typed operation input (for host-label-style
+/// resolution).
+/// </summary>
+public sealed record SmithyEndpointParameters(
+    ShapeId ServiceId,
+    ShapeId OperationId,
+    Uri? ConfiguredEndpoint,
+    object? Input
+);
+
+/// <summary>Resolves every operation to one fixed endpoint.</summary>
+public sealed class StaticEndpointResolver(Uri uri) : IEndpointResolver
+{
+    private readonly SmithyEndpoint endpoint = new(
+        uri ?? throw new ArgumentNullException(nameof(uri))
+    );
+
+    public ValueTask<SmithyEndpoint> ResolveEndpointAsync(
+        SmithyEndpointParameters parameters,
+        CancellationToken cancellationToken = default
+    ) => ValueTask.FromResult(endpoint);
+}

--- a/packages/NSmithy.Client/SmithyAuthSchemeResolver.cs
+++ b/packages/NSmithy.Client/SmithyAuthSchemeResolver.cs
@@ -3,61 +3,112 @@ using NSmithy.Core.Serde;
 namespace NSmithy.Client;
 
 /// <summary>
-/// Resolves client auth, selecting at most one auth scheme for the runtime interceptor pipeline.
-///
-/// Selection follows Smithy's effective-auth-scheme order: <paramref name="modeledAuthSchemes"/>
-/// is the priority-ordered list of auth scheme ids the service models (computed at codegen time
-/// from the <c>@auth</c> trait, defaulting to all of the service's auth traits in alphabetical
-/// order). The first modeled scheme for which the caller supplied a matching
-/// <see cref="ISmithyAuthScheme"/> wins — exactly one signer is installed, mirroring smithy-java's
-/// "first supported scheme with an available identity" rule.
+/// Resolves client auth. At construction it creates one interceptor per configured
+/// <see cref="ISmithyAuthScheme"/>, keyed by scheme id, and fails fast when none of the
+/// configured schemes are modeled by the service. Per invocation the runtime then selects the
+/// first scheme of the operation's effective modeled list (a per-operation <c>@auth</c> trait
+/// overrides the service default) that has a configured interceptor, optionally narrowed by the
+/// resolved endpoint — mirroring smithy-java's "first supported scheme with an available
+/// identity" rule.
 /// </summary>
 public static class SmithyAuthSchemeResolver
 {
-    public static IReadOnlyList<IClientInterceptor> Resolve(
+    /// <summary>
+    /// Creates the configured auth interceptors, keyed by auth scheme shape id. Returns an
+    /// empty map when no schemes are configured (anonymous access).
+    /// </summary>
+    public static IReadOnlyDictionary<string, IClientInterceptor> ResolveInterceptors(
         Uri endpoint,
         ServiceSchema service,
-        IReadOnlyList<string> modeledAuthSchemes,
-        IEnumerable<ISmithyAuthScheme>? authSchemes,
-        IEnumerable<IClientInterceptor>? interceptors = null
+        IReadOnlyList<string> serviceAuthSchemes,
+        IEnumerable<ISmithyAuthScheme>? authSchemes
     )
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentNullException.ThrowIfNull(service);
-        ArgumentNullException.ThrowIfNull(modeledAuthSchemes);
-
-        var resolved = new List<IClientInterceptor>();
-        if (interceptors is not null)
-        {
-            resolved.AddRange(interceptors);
-        }
+        ArgumentNullException.ThrowIfNull(serviceAuthSchemes);
 
         var configured = authSchemes?.ToList();
         if (configured is null || configured.Count == 0)
         {
-            // No auth configured: send anonymously. Services that require auth will reject the call.
-            return resolved;
+            // No auth configured: send anonymously. Services that require auth will reject the
+            // call.
+            return new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal);
         }
 
-        foreach (var schemeId in modeledAuthSchemes)
+        if (!configured.Any(s => serviceAuthSchemes.Contains(s.SchemeId, StringComparer.Ordinal)))
         {
-            var match = configured.FirstOrDefault(s =>
-                string.Equals(s.SchemeId, schemeId, StringComparison.Ordinal)
+            throw new InvalidOperationException(
+                $"None of the configured auth schemes [{string.Join(", ", configured.Select(s => s.SchemeId))}] "
+                    + $"match the auth schemes modeled by service '{service.Id}' "
+                    + $"[{string.Join(", ", serviceAuthSchemes)}]. Configure a scheme the service supports, "
+                    + "or omit auth schemes for anonymous access."
             );
-            if (match is not null)
+        }
+
+        var context = new SmithyAuthSchemeContext(endpoint, service);
+        var interceptors = new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal);
+        foreach (var scheme in configured)
+        {
+            interceptors[scheme.SchemeId] = scheme.CreateInterceptor(context);
+        }
+
+        return interceptors;
+    }
+
+    /// <summary>
+    /// Selects the interceptor for one invocation: the first of the operation's modeled scheme
+    /// ids — narrowed to <paramref name="endpointAuthSchemes"/> when the resolved endpoint
+    /// provided one — that has a configured interceptor. Returns null for anonymous operations
+    /// or when nothing is configured; throws when the operation models auth, schemes are
+    /// configured, but none match.
+    /// </summary>
+    public static IClientInterceptor? SelectInterceptor(
+        IReadOnlyList<string> operationAuthSchemes,
+        IReadOnlyList<string>? endpointAuthSchemes,
+        IReadOnlyDictionary<string, IClientInterceptor> interceptors
+    )
+    {
+        ArgumentNullException.ThrowIfNull(operationAuthSchemes);
+        ArgumentNullException.ThrowIfNull(interceptors);
+
+        if (operationAuthSchemes.Count == 0 || interceptors.Count == 0)
+        {
+            return null;
+        }
+
+        var sawCandidate = false;
+        foreach (var schemeId in operationAuthSchemes)
+        {
+            if (
+                endpointAuthSchemes is not null
+                && !endpointAuthSchemes.Contains(schemeId, StringComparer.Ordinal)
+            )
             {
-                resolved.Add(
-                    match.CreateInterceptor(new SmithyAuthSchemeContext(endpoint, service))
-                );
-                return resolved;
+                continue;
+            }
+
+            sawCandidate = true;
+            if (interceptors.TryGetValue(schemeId, out var interceptor))
+            {
+                return interceptor;
             }
         }
 
+        if (!sawCandidate)
+        {
+            // The endpoint narrowed away every modeled scheme; treat as anonymous.
+            return null;
+        }
+
         throw new InvalidOperationException(
-            $"None of the configured auth schemes [{string.Join(", ", configured.Select(s => s.SchemeId))}] "
-                + $"match the auth schemes modeled by service '{service.Id}' "
-                + $"[{string.Join(", ", modeledAuthSchemes)}]. Configure a scheme the service supports, "
-                + "or omit auth schemes for anonymous access."
+            $"None of the configured auth schemes [{string.Join(", ", interceptors.Keys)}] match "
+                + $"the operation's modeled auth schemes [{string.Join(", ", operationAuthSchemes)}]"
+                + (
+                    endpointAuthSchemes is null
+                        ? "."
+                        : $" narrowed by the endpoint to [{string.Join(", ", endpointAuthSchemes)}]."
+                )
         );
     }
 }

--- a/packages/NSmithy.Client/SmithyClientConfig.cs
+++ b/packages/NSmithy.Client/SmithyClientConfig.cs
@@ -24,6 +24,7 @@ public class SmithyClientConfig
 
         Endpoint = source.Endpoint;
         Protocol = source.Protocol;
+        EndpointResolver = source.EndpointResolver;
         RetryStrategy = source.RetryStrategy;
         OperationTimeout = source.OperationTimeout;
         IdempotencyTokenProvider = source.IdempotencyTokenProvider;
@@ -47,6 +48,14 @@ public class SmithyClientConfig
 
     /// <summary>The wire protocol; defaults to the service's primary declared protocol.</summary>
     public IProtocol? Protocol { get; set; }
+
+    /// <summary>
+    /// Per-operation endpoint resolution. When set it overrides the static
+    /// <see cref="Endpoint"/> for request routing (an endpoint is still required at
+    /// construction); the resolver runs once per invocation and can vary the endpoint by
+    /// operation, add endpoint headers, and narrow auth schemes.
+    /// </summary>
+    public IEndpointResolver? EndpointResolver { get; set; }
 
     /// <summary>Protocol-agnostic hooks for observing and modifying client execution.</summary>
     public IList<IClientInterceptor> Interceptors { get; } = [];

--- a/packages/NSmithy.Client/SmithyClientRuntime.cs
+++ b/packages/NSmithy.Client/SmithyClientRuntime.cs
@@ -8,9 +8,14 @@ public sealed class SmithyClientRuntime(
     IEnumerable<IClientInterceptor>? interceptors = null,
     ISmithyRetryStrategy? retryStrategy = null,
     Uri? endpoint = null,
-    TimeSpan? operationTimeout = null
+    TimeSpan? operationTimeout = null,
+    IEndpointResolver? endpointResolver = null,
+    IReadOnlyDictionary<string, IClientInterceptor>? authSchemes = null
 )
 {
+    private static readonly IReadOnlyDictionary<string, IClientInterceptor> NoAuthSchemes =
+        new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal);
+
     private readonly IHttpTransport transport =
         transport ?? throw new ArgumentNullException(nameof(transport));
     private readonly IReadOnlyList<IClientInterceptor> interceptors = [.. interceptors ?? []];
@@ -19,6 +24,11 @@ public sealed class SmithyClientRuntime(
         endpoint is null || endpoint.IsAbsoluteUri
             ? endpoint
             : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
+    private readonly IEndpointResolver? endpointResolver =
+        endpointResolver
+        ?? (endpoint is { IsAbsoluteUri: true } ? new StaticEndpointResolver(endpoint) : null);
+    private readonly IReadOnlyDictionary<string, IClientInterceptor> authSchemes =
+        authSchemes ?? NoAuthSchemes;
     private readonly TimeSpan? operationTimeout =
         operationTimeout is null || operationTimeout > TimeSpan.Zero
             ? operationTimeout
@@ -55,6 +65,32 @@ public sealed class SmithyClientRuntime(
 
         var protocol = binding.Protocol;
         var context = CreateContext(binding.ServiceId.Name, binding.OperationId.Name);
+
+        // Endpoint resolution runs once per invocation, before any lifecycle hooks, so
+        // interceptors observe the effective endpoint from OnBeforeExecution on. A static
+        // endpoint resolves via StaticEndpointResolver at effectively zero cost.
+        SmithyEndpoint? resolvedEndpoint = null;
+        if (endpointResolver is not null)
+        {
+            resolvedEndpoint = await endpointResolver
+                .ResolveEndpointAsync(
+                    new SmithyEndpointParameters(
+                        binding.ServiceId,
+                        binding.OperationId,
+                        endpoint,
+                        input
+                    ),
+                    callerToken
+                )
+                .ConfigureAwait(false);
+            context.Set(SmithyContextKeys.Endpoint, resolvedEndpoint.Uri);
+        }
+
+        var authInterceptor = SmithyAuthSchemeResolver.SelectInterceptor(
+            binding.AuthSchemeIds,
+            resolvedEndpoint?.AuthSchemes,
+            authSchemes
+        );
 
         var tags = new TagList
         {
@@ -96,6 +132,8 @@ public sealed class SmithyClientRuntime(
                     protocol.DeserializeErrorAsync,
                     protocol.IsErrorResponse,
                     tags,
+                    resolvedEndpoint,
+                    authInterceptor,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -165,6 +203,8 @@ public sealed class SmithyClientRuntime(
         Func<SmithyHttpResponse, CancellationToken, ValueTask<Exception?>> deserializeError,
         Func<SmithyHttpResponse, bool> isErrorResponse,
         TagList tags,
+        SmithyEndpoint? resolvedEndpoint,
+        IClientInterceptor? authInterceptor,
         CancellationToken cancellationToken
     )
     {
@@ -181,10 +221,11 @@ public sealed class SmithyClientRuntime(
             attemptActivity?.SetTag("smithy.attempt", attempt);
             SmithyClientTelemetry.Attempts.Add(1, tags);
 
-            var resolvedRequest = ApplyEndpoint(CloneRequest(request));
+            var resolvedRequest = ApplyEndpoint(CloneRequest(request), resolvedEndpoint);
             var attemptRequest = await ApplyRequestInterceptorsAsync(
                     context,
                     resolvedRequest,
+                    authInterceptor,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -262,12 +303,22 @@ public sealed class SmithyClientRuntime(
     private async Task<SmithyHttpRequest> ApplyRequestInterceptorsAsync(
         SmithyContext context,
         SmithyHttpRequest request,
+        IClientInterceptor? authInterceptor,
         CancellationToken cancellationToken
     )
     {
+        // The selected auth interceptor runs after user interceptors in each request phase, so
+        // signing sees the final request and nothing mutates it afterwards.
         foreach (var interceptor in interceptors)
         {
             request = await interceptor
+                .OnBeforeSigningAsync(context, request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (authInterceptor is not null)
+        {
+            request = await authInterceptor
                 .OnBeforeSigningAsync(context, request, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -279,17 +330,39 @@ public sealed class SmithyClientRuntime(
                 .ConfigureAwait(false);
         }
 
+        if (authInterceptor is not null)
+        {
+            request = await authInterceptor
+                .OnBeforeTransmitAsync(context, request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         return request;
     }
 
-    private SmithyHttpRequest ApplyEndpoint(SmithyHttpRequest request)
+    private static SmithyHttpRequest ApplyEndpoint(
+        SmithyHttpRequest request,
+        SmithyEndpoint? resolvedEndpoint
+    )
     {
-        if (endpoint is null || IsHttpAbsoluteUri(request.RequestUri))
+        if (resolvedEndpoint is null)
         {
             return request;
         }
 
-        return CloneRequest(request, ResolveRequestUri(endpoint, request.RequestUri));
+        var resolved = IsHttpAbsoluteUri(request.RequestUri)
+            ? request
+            : CloneRequest(request, ResolveRequestUri(resolvedEndpoint.Uri, request.RequestUri));
+
+        if (resolvedEndpoint.Headers is not null)
+        {
+            foreach (var header in resolvedEndpoint.Headers)
+            {
+                resolved.Headers[header.Key] = [header.Value];
+            }
+        }
+
+        return resolved;
     }
 
     private static SmithyHttpRequest CloneRequest(SmithyHttpRequest request) =>

--- a/packages/NSmithy.Client/SmithyOperationBinding.cs
+++ b/packages/NSmithy.Client/SmithyOperationBinding.cs
@@ -15,7 +15,8 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
     public SmithyOperationBinding(
         ShapeId serviceId,
         ShapeId operationId,
-        IOperationProtocol<TInput, TOutput> protocol
+        IOperationProtocol<TInput, TOutput> protocol,
+        IReadOnlyList<string>? authSchemeIds = null
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceId.Name, nameof(serviceId));
@@ -25,6 +26,7 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
         ServiceId = serviceId;
         OperationId = operationId;
         Protocol = protocol;
+        AuthSchemeIds = authSchemeIds ?? [];
     }
 
     public ShapeId ServiceId { get; }
@@ -32,4 +34,11 @@ public sealed class SmithyOperationBinding<TInput, TOutput>
     public ShapeId OperationId { get; }
 
     public IOperationProtocol<TInput, TOutput> Protocol { get; }
+
+    /// <summary>
+    /// The operation's effective modeled auth scheme ids in Smithy priority order — the
+    /// service's effective schemes, overridden by a per-operation <c>@auth</c> trait. Empty for
+    /// anonymous operations.
+    /// </summary>
+    public IReadOnlyList<string> AuthSchemeIds { get; }
 }

--- a/tests/NSmithy.Tests/Client/SmithyAuthSchemeResolverTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyAuthSchemeResolverTests.cs
@@ -10,89 +10,145 @@ public sealed class SmithyAuthSchemeResolverTests
     private static readonly ServiceSchema Service = Schemas.Service(new ShapeId("example", "Svc"));
 
     [Fact]
-    public void ResolveWithoutAuthSchemesReturnsInterceptorsOnly()
+    public void ResolveInterceptorsWithoutAuthSchemesReturnsEmptyMap()
     {
-        var existing = new MarkerInterceptor("existing");
-
-        var resolved = SmithyAuthSchemeResolver.Resolve(
+        var resolved = SmithyAuthSchemeResolver.ResolveInterceptors(
             Endpoint,
             Service,
             ["aws.auth#sigv4"],
-            authSchemes: null,
-            interceptors: [existing]
+            authSchemes: null
         );
 
-        Assert.Equal([existing], resolved);
+        Assert.Empty(resolved);
     }
 
     [Fact]
-    public void ResolvePicksFirstModeledSchemeRegardlessOfConfiguredOrder()
+    public void ResolveInterceptorsCreatesOneInterceptorPerConfiguredScheme()
     {
-        // Configured in B, A order; modeled prefers A — modeled order wins.
-        var schemeA = new FakeScheme("scheme#a", new MarkerInterceptor("a"));
-        var schemeB = new FakeScheme("scheme#b", new MarkerInterceptor("b"));
+        var a = new MarkerInterceptor("a");
+        var b = new MarkerInterceptor("b");
 
-        var resolved = SmithyAuthSchemeResolver.Resolve(
+        var resolved = SmithyAuthSchemeResolver.ResolveInterceptors(
             Endpoint,
             Service,
             ["scheme#a", "scheme#b"],
-            authSchemes: [schemeB, schemeA]
+            authSchemes: [new FakeScheme("scheme#a", a), new FakeScheme("scheme#b", b)]
         );
 
-        Assert.Equal("a", Assert.IsType<MarkerInterceptor>(Assert.Single(resolved)).Tag);
+        Assert.Same(a, resolved["scheme#a"]);
+        Assert.Same(b, resolved["scheme#b"]);
     }
 
     [Fact]
-    public void ResolveSkipsModeledSchemesWithoutAConfiguredMatch()
+    public void ResolveInterceptorsThrowsWhenNoConfiguredSchemeMatchesServiceSchemes()
     {
-        var schemeB = new FakeScheme("scheme#b", new MarkerInterceptor("b"));
-
-        var resolved = SmithyAuthSchemeResolver.Resolve(
-            Endpoint,
-            Service,
-            ["scheme#a", "scheme#b"],
-            authSchemes: [schemeB]
-        );
-
-        Assert.Equal("b", Assert.IsType<MarkerInterceptor>(Assert.Single(resolved)).Tag);
-    }
-
-    [Fact]
-    public void ResolveAppendsAuthAfterUserInterceptors()
-    {
-        var existing = new MarkerInterceptor("existing");
-        var auth = new MarkerInterceptor("auth");
-        var scheme = new FakeScheme("scheme#a", auth);
-
-        var resolved = SmithyAuthSchemeResolver.Resolve(
-            Endpoint,
-            Service,
-            ["scheme#a"],
-            authSchemes: [scheme],
-            interceptors: [existing]
-        );
-
-        Assert.Equal(2, resolved.Count);
-        Assert.Equal("existing", Assert.IsType<MarkerInterceptor>(resolved[0]).Tag);
-        Assert.Equal("auth", Assert.IsType<MarkerInterceptor>(resolved[1]).Tag);
-    }
-
-    [Fact]
-    public void ResolveThrowsWhenNoConfiguredSchemeMatchesModeledSchemes()
-    {
-        var scheme = new FakeScheme("scheme#c", new MarkerInterceptor("c"));
-
         var error = Assert.Throws<InvalidOperationException>(() =>
-            SmithyAuthSchemeResolver.Resolve(
+            SmithyAuthSchemeResolver.ResolveInterceptors(
                 Endpoint,
                 Service,
                 ["scheme#a", "scheme#b"],
-                authSchemes: [scheme]
+                authSchemes: [new FakeScheme("scheme#c", new MarkerInterceptor("c"))]
             )
         );
 
         Assert.Contains("scheme#c", error.Message, StringComparison.Ordinal);
         Assert.Contains("scheme#a", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectPicksFirstModeledSchemeRegardlessOfConfiguredOrder()
+    {
+        var interceptors = Map(("scheme#b", "b"), ("scheme#a", "a"));
+
+        var selected = SmithyAuthSchemeResolver.SelectInterceptor(
+            ["scheme#a", "scheme#b"],
+            endpointAuthSchemes: null,
+            interceptors
+        );
+
+        Assert.Equal("a", Assert.IsType<MarkerInterceptor>(selected).Tag);
+    }
+
+    [Fact]
+    public void SelectSkipsModeledSchemesWithoutAConfiguredMatch()
+    {
+        var interceptors = Map(("scheme#b", "b"));
+
+        var selected = SmithyAuthSchemeResolver.SelectInterceptor(
+            ["scheme#a", "scheme#b"],
+            endpointAuthSchemes: null,
+            interceptors
+        );
+
+        Assert.Equal("b", Assert.IsType<MarkerInterceptor>(selected).Tag);
+    }
+
+    [Fact]
+    public void SelectReturnsNullForAnonymousOperations()
+    {
+        var interceptors = Map(("scheme#a", "a"));
+
+        Assert.Null(
+            SmithyAuthSchemeResolver.SelectInterceptor([], endpointAuthSchemes: null, interceptors)
+        );
+    }
+
+    [Fact]
+    public void SelectHonorsEndpointNarrowing()
+    {
+        var interceptors = Map(("scheme#a", "a"), ("scheme#b", "b"));
+
+        var selected = SmithyAuthSchemeResolver.SelectInterceptor(
+            ["scheme#a", "scheme#b"],
+            endpointAuthSchemes: ["scheme#b"],
+            interceptors
+        );
+
+        Assert.Equal("b", Assert.IsType<MarkerInterceptor>(selected).Tag);
+    }
+
+    [Fact]
+    public void SelectTreatsFullyNarrowedEndpointAsAnonymous()
+    {
+        var interceptors = Map(("scheme#a", "a"));
+
+        Assert.Null(
+            SmithyAuthSchemeResolver.SelectInterceptor(
+                ["scheme#a"],
+                endpointAuthSchemes: ["scheme#other"],
+                interceptors
+            )
+        );
+    }
+
+    [Fact]
+    public void SelectThrowsWhenOperationSchemesHaveNoConfiguredMatch()
+    {
+        var interceptors = Map(("scheme#c", "c"));
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            SmithyAuthSchemeResolver.SelectInterceptor(
+                ["scheme#a"],
+                endpointAuthSchemes: null,
+                interceptors
+            )
+        );
+
+        Assert.Contains("scheme#a", error.Message, StringComparison.Ordinal);
+        Assert.Contains("scheme#c", error.Message, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, IClientInterceptor> Map(
+        params (string SchemeId, string Tag)[] schemes
+    )
+    {
+        var map = new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal);
+        foreach (var (schemeId, tag) in schemes)
+        {
+            map[schemeId] = new MarkerInterceptor(tag);
+        }
+
+        return map;
     }
 
     private sealed class FakeScheme(string schemeId, IClientInterceptor interceptor)

--- a/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyClientConfigTests.cs
@@ -10,10 +10,12 @@ public sealed class SmithyClientConfigTests
         var interceptor = new NoopInterceptor();
         var strategy = new SmithySimpleRetryStrategy();
         var authScheme = new HttpBearerAuthScheme("token");
+        var endpointResolver = new StaticEndpointResolver(new Uri("https://api.example.com"));
         Func<string> tokenProvider = static () => "token-1";
         var source = new TestConfig
         {
             Endpoint = new Uri("https://api.example.com"),
+            EndpointResolver = endpointResolver,
             RetryStrategy = strategy,
             OperationTimeout = TimeSpan.FromSeconds(10),
             IdempotencyTokenProvider = tokenProvider,
@@ -24,6 +26,7 @@ public sealed class SmithyClientConfigTests
         var copy = new TestConfig(source);
 
         Assert.Equal(source.Endpoint, copy.Endpoint);
+        Assert.Same(endpointResolver, copy.EndpointResolver);
         Assert.Equal(TimeSpan.FromSeconds(10), copy.OperationTimeout);
         // Shallow on purpose: shared strategy instances share client-wide state (retry quota).
         Assert.Same(strategy, copy.RetryStrategy);

--- a/tests/NSmithy.Tests/Client/SmithyEndpointResolutionTests.cs
+++ b/tests/NSmithy.Tests/Client/SmithyEndpointResolutionTests.cs
@@ -1,0 +1,281 @@
+using System.Net;
+using System.Text;
+using NSmithy.Client;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Http;
+
+namespace NSmithy.Tests.Client;
+
+public sealed class SmithyEndpointResolutionTests
+{
+    [Fact]
+    public async Task ResolverRoutesRequestsPerOperation()
+    {
+        var transport = new RecordingTransport();
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpoint: new Uri("https://static.example.com"),
+            endpointResolver: new DelegateResolver(parameters => new SmithyEndpoint(
+                new Uri($"https://{parameters.OperationId.Name.ToLowerInvariant()}.example.com")
+            ))
+        );
+
+        await runtime.InvokeAsync(Binding(), "input");
+
+        Assert.Equal("https://getforecast.example.com/input", transport.Request!.RequestUri);
+    }
+
+    [Fact]
+    public async Task ResolverSeesOperationIdentifiersConfiguredEndpointAndInput()
+    {
+        SmithyEndpointParameters? seen = null;
+        var configured = new Uri("https://static.example.com");
+        var runtime = new SmithyClientRuntime(
+            new RecordingTransport(),
+            endpoint: configured,
+            endpointResolver: new DelegateResolver(parameters =>
+            {
+                seen = parameters;
+                return new SmithyEndpoint(configured);
+            })
+        );
+
+        await runtime.InvokeAsync(Binding(), "input");
+
+        Assert.NotNull(seen);
+        Assert.Equal(ShapeId.Parse("example.weather#Weather"), seen!.ServiceId);
+        Assert.Equal(ShapeId.Parse("example.weather#GetForecast"), seen.OperationId);
+        Assert.Equal(configured, seen.ConfiguredEndpoint);
+        Assert.Equal("input", seen.Input);
+    }
+
+    [Fact]
+    public async Task ResolvedEndpointHeadersAreAppliedToEveryRequest()
+    {
+        var transport = new RecordingTransport();
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpointResolver: new DelegateResolver(_ => new SmithyEndpoint(
+                new Uri("https://api.example.com"),
+                Headers: new Dictionary<string, string> { ["x-endpoint-key"] = "route-1" }
+            ))
+        );
+
+        await runtime.InvokeAsync(Binding(), "input");
+
+        Assert.Equal(["route-1"], transport.Request!.Headers["x-endpoint-key"]);
+    }
+
+    [Fact]
+    public async Task ResolvedEndpointIsExposedInContext()
+    {
+        List<Uri> endpoints = [];
+        var runtime = new SmithyClientRuntime(
+            new RecordingTransport(),
+            [new EndpointRecordingInterceptor(endpoints)],
+            endpoint: new Uri("https://static.example.com"),
+            endpointResolver: new DelegateResolver(_ => new SmithyEndpoint(
+                new Uri("https://resolved.example.com")
+            ))
+        );
+
+        await runtime.InvokeAsync(Binding(), "input");
+
+        Assert.Equal([new Uri("https://resolved.example.com")], endpoints);
+    }
+
+    [Fact]
+    public async Task EndpointAuthNarrowingSelectsTheNarrowedScheme()
+    {
+        var transport = new RecordingTransport();
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpointResolver: new DelegateResolver(_ => new SmithyEndpoint(
+                new Uri("https://api.example.com"),
+                AuthSchemes: ["scheme#b"]
+            )),
+            authSchemes: new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal)
+            {
+                ["scheme#a"] = new HeaderStampingInterceptor("x-auth", "a"),
+                ["scheme#b"] = new HeaderStampingInterceptor("x-auth", "b"),
+            }
+        );
+
+        await runtime.InvokeAsync(Binding(authSchemeIds: ["scheme#a", "scheme#b"]), "input");
+
+        Assert.Equal(["b"], transport.Request!.Headers["x-auth"]);
+    }
+
+    [Fact]
+    public async Task OperationAuthSchemesSelectTheConfiguredInterceptor()
+    {
+        var transport = new RecordingTransport();
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpoint: new Uri("https://api.example.com"),
+            authSchemes: new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal)
+            {
+                ["scheme#a"] = new HeaderStampingInterceptor("x-auth", "a"),
+            }
+        );
+
+        await runtime.InvokeAsync(Binding(authSchemeIds: ["scheme#a"]), "input");
+
+        Assert.Equal(["a"], transport.Request!.Headers["x-auth"]);
+    }
+
+    [Fact]
+    public async Task AnonymousOperationsSendNoAuth()
+    {
+        var transport = new RecordingTransport();
+        var runtime = new SmithyClientRuntime(
+            transport,
+            endpoint: new Uri("https://api.example.com"),
+            authSchemes: new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal)
+            {
+                ["scheme#a"] = new HeaderStampingInterceptor("x-auth", "a"),
+            }
+        );
+
+        await runtime.InvokeAsync(Binding(authSchemeIds: []), "input");
+
+        Assert.False(transport.Request!.Headers.ContainsKey("x-auth"));
+    }
+
+    [Fact]
+    public async Task AuthRunsAfterUserInterceptorsInEachPhase()
+    {
+        List<string> order = [];
+        var runtime = new SmithyClientRuntime(
+            new RecordingTransport(),
+            [new PhaseRecordingInterceptor("user", order)],
+            endpoint: new Uri("https://api.example.com"),
+            authSchemes: new Dictionary<string, IClientInterceptor>(StringComparer.Ordinal)
+            {
+                ["scheme#a"] = new PhaseRecordingInterceptor("auth", order),
+            }
+        );
+
+        await runtime.InvokeAsync(Binding(authSchemeIds: ["scheme#a"]), "input");
+
+        Assert.Equal(["user:signing", "auth:signing", "user:transmit", "auth:transmit"], order);
+    }
+
+    private static SmithyOperationBinding<string, string> Binding(
+        IReadOnlyList<string>? authSchemeIds = null
+    ) =>
+        new(
+            ShapeId.Parse("example.weather#Weather"),
+            ShapeId.Parse("example.weather#GetForecast"),
+            new TextProtocol(),
+            authSchemeIds
+        );
+
+    private sealed class DelegateResolver(Func<SmithyEndpointParameters, SmithyEndpoint> resolve)
+        : IEndpointResolver
+    {
+        public ValueTask<SmithyEndpoint> ResolveEndpointAsync(
+            SmithyEndpointParameters parameters,
+            CancellationToken cancellationToken = default
+        ) => ValueTask.FromResult(resolve(parameters));
+    }
+
+    private sealed class RecordingTransport : IHttpTransport
+    {
+        public SmithyHttpRequest? Request { get; private set; }
+
+        public Task<SmithyHttpResponse> SendAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Request = request;
+            return Task.FromResult(
+                new SmithyHttpResponse(
+                    HttpStatusCode.OK,
+                    "OK",
+                    Encoding.UTF8.GetBytes("serialized output"),
+                    EmptyHeaders,
+                    EmptyHeaders
+                )
+            );
+        }
+    }
+
+    private sealed class EndpointRecordingInterceptor(List<Uri> endpoints) : IClientInterceptor
+    {
+        public void OnBeforeExecution(SmithyContext context)
+        {
+            endpoints.Add(context.Get(SmithyContextKeys.Endpoint));
+        }
+    }
+
+    private sealed class HeaderStampingInterceptor(string name, string value) : IClientInterceptor
+    {
+        public ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            request.Headers[name] = [value];
+            return ValueTask.FromResult(request);
+        }
+    }
+
+    private sealed class PhaseRecordingInterceptor(string tag, List<string> order)
+        : IClientInterceptor
+    {
+        public ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            order.Add($"{tag}:signing");
+            return ValueTask.FromResult(request);
+        }
+
+        public ValueTask<SmithyHttpRequest> OnBeforeTransmitAsync(
+            SmithyContext context,
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            order.Add($"{tag}:transmit");
+            return ValueTask.FromResult(request);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyHeaders { get; } =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+    private sealed class TextProtocol : IOperationProtocol<string, string>
+    {
+        public SmithyHttpRequest SerializeRequest(string input) =>
+            new(HttpMethod.Post, $"/{input}");
+
+        public string DeserializeResponse(SmithyHttpResponse response) => "output";
+
+        public string DeserializeRequest(SmithyHttpRequest request) => request.RequestUri;
+
+        public SmithyHttpResponse SerializeResponse(string output) =>
+            new(HttpStatusCode.OK, "OK", [], EmptyHeaders, EmptyHeaders);
+
+        public bool IsErrorResponse(SmithyHttpResponse response) => (int)response.StatusCode >= 400;
+
+        public string? GetErrorDiscriminator(SmithyHttpResponse response) => null;
+
+        public bool RequiresErrorDiscriminator => false;
+
+        public bool SupportsHttpStatusErrorFallback => true;
+
+        public SmithyHttpResponse SerializeError<TError>(
+            Schema<TError> errorSchema,
+            TError value,
+            string errorShapeId,
+            int statusCode
+        ) => throw new NotSupportedException();
+    }
+}

--- a/website/src/content/docs/guides/client-configuration/authentication.md
+++ b/website/src/content/docs/guides/client-configuration/authentication.md
@@ -18,10 +18,14 @@ var client = new WeatherClient(
     });
 ```
 
-At construction time, NSmithy compares your configured schemes with the auth
-schemes modeled by the service. It installs the first modeled scheme for which
-you supplied runtime configuration. If `AuthSchemes` is empty, requests are sent
-anonymously.
+At construction time, NSmithy validates your configured schemes against the
+auth schemes modeled by the service and prepares one signer per configured
+scheme. On each call it selects the first of the *operation's* effective
+modeled schemes (a per-operation `@auth` trait overrides the service default)
+for which you supplied configuration; operations modeled as anonymous send no
+credentials, and an [endpoint resolver](/smithy-dotnet/guides/client-configuration/)
+can narrow the candidate schemes per endpoint. If `AuthSchemes` is empty,
+requests are sent anonymously.
 
 The generated client sends credentials. Server-side authorization is still
 application code in this preview: generated ASP.NET Core handlers can read

--- a/website/src/content/docs/guides/client-configuration/index.md
+++ b/website/src/content/docs/guides/client-configuration/index.md
@@ -42,6 +42,7 @@ when you want to set client options.
 | --- | --- |
 | `Endpoint` | The service endpoint. Set by the endpoint constructor, and optional for the `HttpClient` constructor. |
 | `Protocol` | The wire protocol. Defaults to the service's primary declared [protocol](/smithy-dotnet/protocols/overview/). |
+| `EndpointResolver` | Per-operation endpoint resolution. Overrides the static `Endpoint` for request routing; can vary the endpoint by operation, add endpoint headers, and narrow auth schemes. |
 | `AuthSchemes` | Configured auth schemes; the resolver installs the first scheme the service models. An empty list means anonymous. |
 | `RetryStrategy` | Runtime-owned retry policy. `null` disables runtime retries. |
 | `OperationTimeout` | Deadline for one operation execution, spanning all retry attempts and backoff delays. Throws `TimeoutException` when exceeded; `null` (default) means no deadline. |


### PR DESCRIPTION
**Stacked on #86** (← #85 ← #84 ← #83 ← #82) — part 6 of the client-runtime series. Implements the design doc's Endpoint Resolution section and the per-operation half of its Auth section.

## Endpoint resolution

```csharp
public interface IEndpointResolver
{
    ValueTask<SmithyEndpoint> ResolveEndpointAsync(SmithyEndpointParameters parameters, CancellationToken ct = default);
}

public sealed record SmithyEndpoint(Uri Uri, IReadOnlyDictionary<string, string>? Headers = null, IReadOnlyList<string>? AuthSchemes = null);
public sealed record SmithyEndpointParameters(ShapeId ServiceId, ShapeId OperationId, Uri? ConfiguredEndpoint, object? Input);
```

- Resolution runs **once per invocation**, before any lifecycle hooks, so interceptors observe the effective endpoint from `OnBeforeExecution` on. Async (vs. the design sketch's sync signature) so discovery-style resolvers can do I/O — design doc updated.
- `Config.EndpointResolver` overrides the static endpoint for routing; a static `Config.Endpoint` is the default via `StaticEndpointResolver` (resolved at construction, per the design).
- Resolved endpoint **headers** are stamped on every request; resolved **AuthSchemes** narrow auth selection (below).

## Per-operation auth

Previously one auth interceptor was chosen at construction from the *service-level* scheme list — per-operation `@auth` was ignored. Now:

- Each operation binding carries the operation's **effective modeled scheme ids** (`ServiceIndex.getEffectiveAuthSchemes(service, operation)` at codegen time — `@auth` overrides the service default; still pure data on the binding).
- `SmithyAuthSchemeResolver` splits into construction-time `ResolveInterceptors` (one interceptor per configured scheme, keyed by id, fail-fast when none are modeled) and per-invocation `SelectInterceptor` (first modeled scheme — narrowed by the endpoint when it provided a list — with a configured interceptor).
- Anonymous operations send no credentials even when schemes are configured; a fully-narrowed endpoint is treated as anonymous; modeled-but-unconfigured throws with both lists in the message.
- The selected auth interceptor runs **after user interceptors in each request phase**, so signing sees the final request — previously this held only by construction order.

## Not in this PR

- `@hostLabel`/endpoint-trait application (the resolver seam now exists; trait-driven resolvers can layer on it).
- The request mutability/`RequestUri`-type riders — deferred to the protocol-split PR where `SmithyHttpRequest` changes anyway.

## Tests

- Runtime: per-operation routing, resolver parameter contents, endpoint headers, context exposure, endpoint auth narrowing, per-op selection, anonymous operations, auth-after-user-interceptor ordering (8 new tests).
- `SmithyAuthSchemeResolverTests` rewritten for the two-phase API (9 tests).
- Codegen: `operationBindingsCarryEffectiveAuthSchemes` — service-effective list on plain operations, `@auth` override honored.
- Full conformance suites pass against regenerated clients.
