### PR TITLE
feat: generate IAsyncEnumerable paginators for @paginated operations

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.PaginatedIndex;
+import software.amazon.smithy.model.knowledge.PaginationInfo;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -65,6 +67,13 @@ public final class ClientGenerator implements Runnable {
           writer.write("");
           for (OperationShape op : operations) {
             writer.write("$L;", operationSignature(sp, op));
+            paginationInfo(op)
+                .ifPresent(
+                    info -> {
+                      writer.write("$L;", paginatorPagesSignature(sp, op));
+                      paginatorItemsSignature(sp, info)
+                          .ifPresent(signature -> writer.write("$L;", signature));
+                    });
           }
         });
     writer.write("");
@@ -392,7 +401,10 @@ public final class ClientGenerator implements Runnable {
           }
           writer.write("");
 
-          for (OperationShape op : operations) writeOperationMethod(sp, model, op);
+          for (OperationShape op : operations) {
+            writeOperationMethod(sp, model, op);
+            paginationInfo(op).ifPresent(info -> writePaginatorMethods(sp, op, info));
+          }
         });
     writer.write("");
     writeConfigClass(typeName);
@@ -706,6 +718,154 @@ public final class ClientGenerator implements Runnable {
             writer.write("$L = input.$L ?? this.idempotencyTokenProvider(),", prop, prop);
           }
         });
+  }
+
+  // ---------------- paginators ----------------
+
+  /**
+   * Resolved pagination for an operation: present when the operation carries {@code @paginated}
+   * (merged with the service-level defaults). Event-stream operations are never paginated.
+   */
+  private java.util.Optional<PaginationInfo> paginationInfo(OperationShape op) {
+    if (isEventStreamOperation(context.model(), op)) {
+      return java.util.Optional.empty();
+    }
+    return PaginatedIndex.of(context.model()).getPaginationInfo(service, op);
+  }
+
+  private String paginatorPagesSignature(SymbolProvider sp, OperationShape op) {
+    Model model = context.model();
+    String inputType =
+        CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getInputShape())));
+    String outputType =
+        CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getOutputShape())));
+    return "System.Collections.Generic.IAsyncEnumerable<"
+        + outputType
+        + "> "
+        + CSharpNaming.typeName(op.getId().getName())
+        + "PagesAsync("
+        + inputType
+        + " input, System.Threading.CancellationToken cancellationToken = default)";
+  }
+
+  /**
+   * The items-level paginator signature, present when {@code @paginated} names an {@code items}
+   * member that resolves to a list. Map-valued items are rare and not generated yet — the pages
+   * paginator still covers them.
+   */
+  private java.util.Optional<String> paginatorItemsSignature(
+      SymbolProvider sp, PaginationInfo info) {
+    return paginatorItemElementType(sp, info)
+        .map(
+            elementType ->
+                "System.Collections.Generic.IAsyncEnumerable<"
+                    + elementType
+                    + "> "
+                    + CSharpNaming.typeName(info.getOperation().getId().getName())
+                    + "ItemsAsync("
+                    + CSharpSymbolProvider.qualified(
+                        sp.toSymbol(
+                            context.model().expectShape(info.getOperation().getInputShape())))
+                    + " input, System.Threading.CancellationToken cancellationToken = default)");
+  }
+
+  private java.util.Optional<String> paginatorItemElementType(
+      SymbolProvider sp, PaginationInfo info) {
+    List<MemberShape> path = info.getItemsMemberPath();
+    if (path.isEmpty()) {
+      return java.util.Optional.empty();
+    }
+    var target = context.model().expectShape(path.get(path.size() - 1).getTarget());
+    if (!target.isListShape()) {
+      return java.util.Optional.empty();
+    }
+    var element = context.model().expectShape(target.asListShape().get().getMember().getTarget());
+    return java.util.Optional.of(CSharpSymbolProvider.qualified(sp.toSymbol(element)));
+  }
+
+  /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */
+  private static String memberPathExpr(String root, List<MemberShape> path) {
+    StringBuilder expr = new StringBuilder(root);
+    for (int i = 0; i < path.size(); i++) {
+      expr.append(i == 0 ? "." : "?.")
+          .append(CSharpNaming.propertyName(path.get(i).getMemberName()));
+    }
+    return expr.toString();
+  }
+
+  /**
+   * Renders the paginator methods for one {@code @paginated} operation. Pages repeat the unary call
+   * while the response carries a continuation token, so every page flows through the normal client
+   * lifecycle (auth, retries, endpoint resolution, telemetry).
+   */
+  private void writePaginatorMethods(SymbolProvider sp, OperationShape op, PaginationInfo info) {
+    String opName = CSharpNaming.typeName(op.getId().getName());
+    String tokenProperty = CSharpNaming.propertyName(info.getInputTokenMember().getMemberName());
+    String outputTokenExpr = memberPathExpr("output", info.getOutputTokenMemberPath());
+
+    writer.write(
+        "public async $L",
+        paginatorPagesSignature(sp, op)
+            .replace(
+                "System.Threading.CancellationToken cancellationToken",
+                "[System.Runtime.CompilerServices.EnumeratorCancellation]"
+                    + " System.Threading.CancellationToken cancellationToken"));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("System.ArgumentNullException.ThrowIfNull(input);");
+          writer.write(
+              "var output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
+              opName);
+          writer.write("yield return output;");
+          writer.write("var token = $L;", outputTokenExpr);
+          writer.write("while (token is not null)");
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                writer.write("input = input with { $L = token };", tokenProperty);
+                writer.write(
+                    "output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
+                    opName);
+                writer.write("yield return output;");
+                writer.write("token = $L;", outputTokenExpr);
+              });
+        });
+    writer.write("");
+
+    paginatorItemsSignature(sp, info)
+        .ifPresent(
+            signature -> {
+              String itemsExpr = memberPathExpr("page", info.getItemsMemberPath());
+              writer.write(
+                  "public async $L",
+                  signature.replace(
+                      "System.Threading.CancellationToken cancellationToken",
+                      "[System.Runtime.CompilerServices.EnumeratorCancellation]"
+                          + " System.Threading.CancellationToken cancellationToken"));
+              writer.openBlock(
+                  "{",
+                  "}",
+                  () -> {
+                    writer.write(
+                        "await foreach (var page in $LPagesAsync(input,"
+                            + " cancellationToken).ConfigureAwait(false))",
+                        opName);
+                    writer.openBlock(
+                        "{",
+                        "}",
+                        () -> {
+                          writer.write("var items = $L;", itemsExpr);
+                          writer.write("if (items is null)");
+                          writer.openBlock("{", "}", () -> writer.write("continue;"));
+                          writer.write("foreach (var item in items.Values)");
+                          writer.openBlock("{", "}", () -> writer.write("yield return item;"));
+                        });
+                  });
+              writer.write("");
+            });
   }
 
   // =====================================================================

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -15,6 +15,7 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -726,9 +727,9 @@ public final class ClientGenerator implements Runnable {
    * Resolved pagination for an operation: present when the operation carries {@code @paginated}
    * (merged with the service-level defaults). Event-stream operations are never paginated.
    */
-  private java.util.Optional<PaginationInfo> paginationInfo(OperationShape op) {
+  private Optional<PaginationInfo> paginationInfo(OperationShape op) {
     if (isEventStreamOperation(context.model(), op)) {
-      return java.util.Optional.empty();
+      return Optional.empty();
     }
     return PaginatedIndex.of(context.model()).getPaginationInfo(service, op);
   }
@@ -753,8 +754,7 @@ public final class ClientGenerator implements Runnable {
    * member that resolves to a list. Map-valued items are rare and not generated yet — the pages
    * paginator still covers them.
    */
-  private java.util.Optional<String> paginatorItemsSignature(
-      SymbolProvider sp, PaginationInfo info) {
+  private Optional<String> paginatorItemsSignature(SymbolProvider sp, PaginationInfo info) {
     return paginatorItemElementType(sp, info)
         .map(
             elementType ->
@@ -769,18 +769,17 @@ public final class ClientGenerator implements Runnable {
                     + " input, System.Threading.CancellationToken cancellationToken = default)");
   }
 
-  private java.util.Optional<String> paginatorItemElementType(
-      SymbolProvider sp, PaginationInfo info) {
+  private Optional<String> paginatorItemElementType(SymbolProvider sp, PaginationInfo info) {
     List<MemberShape> path = info.getItemsMemberPath();
     if (path.isEmpty()) {
-      return java.util.Optional.empty();
+      return Optional.empty();
     }
     var target = context.model().expectShape(path.get(path.size() - 1).getTarget());
     if (!target.isListShape()) {
-      return java.util.Optional.empty();
+      return Optional.empty();
     }
     var element = context.model().expectShape(target.asListShape().get().getMember().getTarget());
-    return java.util.Optional.of(CSharpSymbolProvider.qualified(sp.toSymbol(element)));
+    return Optional.of(CSharpSymbolProvider.qualified(sp.toSymbol(element)));
   }
 
   /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -176,6 +176,92 @@ final class ClientGeneratorTest {
         generated);
   }
 
+  private static final String PAGINATED_MODEL =
+      """
+      $version: "2"
+
+      namespace example.pages
+
+      use aws.protocols#restJson1
+
+      @restJson1
+      @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
+      service Catalog {
+          version: "1"
+          operations: [ListThings, GetThing]
+      }
+
+      @readonly
+      @paginated(items: "items")
+      @http(method: "GET", uri: "/things")
+      operation ListThings {
+          input := {
+              @httpQuery("nextToken")
+              nextToken: String
+
+              @httpQuery("pageSize")
+              pageSize: Integer
+          }
+          output := {
+              nextToken: String
+
+              @required
+              items: Things
+          }
+      }
+
+      @readonly
+      @http(method: "GET", uri: "/things/{id}")
+      operation GetThing {
+          input := {
+              @required
+              @httpLabel
+              id: String
+          }
+          output := {
+              name: String
+          }
+      }
+
+      list Things {
+          member: Thing
+      }
+
+      structure Thing {
+          @required
+          name: String
+      }
+      """;
+
+  @Test
+  void paginatedOperationsGeneratePagesAndItemsPaginators() throws Exception {
+    String generated =
+        renderClient(
+            REST_PROTOCOL_TRAITS, PAGINATED_MODEL, "example.pages#Catalog", "Example.Pages");
+
+    // Pages paginator: repeats the call while the response carries a token.
+    assertTrue(
+        generated.contains(
+            "System.Collections.Generic.IAsyncEnumerable<Example.Example.Pages.ListThingsOutput>"
+                + " ListThingsPagesAsync(Example.Example.Pages.ListThingsInput input,"
+                + " System.Threading.CancellationToken cancellationToken = default);"),
+        generated);
+    assertTrue(generated.contains("input = input with { NextToken = token };"), generated);
+    assertTrue(generated.contains("while (token is not null)"), generated);
+
+    // Items paginator: flattens the pages' list member.
+    assertTrue(
+        generated.contains(
+            "System.Collections.Generic.IAsyncEnumerable<Example.Example.Pages.Thing>"
+                + " ListThingsItemsAsync(Example.Example.Pages.ListThingsInput input,"
+                + " System.Threading.CancellationToken cancellationToken = default);"),
+        generated);
+    assertTrue(generated.contains("foreach (var item in items.Values)"), generated);
+
+    // Unpaginated operations get no paginators.
+    assertFalse(generated.contains("GetThingPagesAsync"), generated);
+  }
+
   @Test
   void endpointConstructorCopiesCallerConfig() throws Exception {
     String generated = renderClient();

--- a/designs/client-architecture.md
+++ b/designs/client-architecture.md
@@ -296,9 +296,12 @@ dimensions.
 ## Pagination
 
 Operations with `@paginated` generate paginator helpers that return
-`IAsyncEnumerable<T>`. Paginators use the normal client lifecycle for each page,
-so auth, retries, endpoint resolution, and telemetry behave like any other
-operation call.
+`IAsyncEnumerable<T>`: `{Operation}PagesAsync` yields each response page while
+the response carries a continuation token, and — when the trait names an
+`items` list member — `{Operation}ItemsAsync` flattens the pages into their
+items. Paginators use the normal client lifecycle for each page, so auth,
+retries, endpoint resolution, and telemetry behave like any other operation
+call.
 
 ## Streaming
 

--- a/examples/rest-json1/client/Program.cs
+++ b/examples/rest-json1/client/Program.cs
@@ -7,20 +7,23 @@ var client = new WeatherClient(new Uri(endpoint));
 var time = await client.GetCurrentTimeAsync(new GetCurrentTimeInput());
 Console.WriteLine($"Current time: {time.Time:u}");
 
-// Paginate through all cities, 3 per page
+// Paginate through all cities, 3 per page. The generated pages paginator repeats the call
+// while the response carries a continuation token; each page goes through the normal client
+// lifecycle (auth, retries, telemetry).
 Console.WriteLine("All cities (paginated, page size 3):");
-string? nextToken = null;
 var page = 1;
-do
+await foreach (var result in client.ListCitiesPagesAsync(new ListCitiesInput(PageSize: 3)))
 {
-    var result = await client.ListCitiesAsync(
-        new ListCitiesInput(NextToken: nextToken, PageSize: 3)
-    );
     Console.WriteLine($"  Page {page++}:");
     foreach (var city in result.Items.Values)
         Console.WriteLine($"    {city.CityId}: {city.Name}");
-    nextToken = result.NextToken;
-} while (nextToken is not null);
+}
+
+// Or flatten the pages with the items paginator.
+var names = new List<string>();
+await foreach (var city in client.ListCitiesItemsAsync(new ListCitiesInput(PageSize: 4)))
+    names.Add(city.Name);
+Console.WriteLine($"All {names.Count} cities, flattened: {string.Join(", ", names)}");
 
 var seattle = await client.GetCityAsync(new GetCityInput("SEA"));
 Console.WriteLine($"Seattle: ({seattle.Coordinates.Latitude}, {seattle.Coordinates.Longitude})");

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
 								{ label: 'Retry', slug: 'guides/client-configuration/retry' },
 								{ label: 'Interceptors', slug: 'guides/client-configuration/interceptors' },
 								{ label: 'Observability', slug: 'guides/client-configuration/observability' },
+								{ label: 'Pagination', slug: 'guides/client-configuration/pagination' },
 								{ label: 'Transport', slug: 'guides/client-configuration/transport' },
 								{ label: 'Dependency Injection', slug: 'guides/client-configuration/dependency-injection' },
 							],

--- a/website/src/content/docs/guides/client-configuration/index.md
+++ b/website/src/content/docs/guides/client-configuration/index.md
@@ -96,6 +96,9 @@ For a long-lived application, prefer registering the client once with
   covers client execution hooks.
 - [Observability](/smithy-dotnet/guides/client-configuration/observability/)
   covers OpenTelemetry tracing and metrics.
+- [Pagination](/smithy-dotnet/guides/client-configuration/pagination/)
+  covers the generated `IAsyncEnumerable` paginators for `@paginated`
+  operations.
 - [Transport](/smithy-dotnet/guides/client-configuration/transport/) covers
   endpoint, `HttpClient`, and low-level runtime ownership.
 - [Dependency Injection](/smithy-dotnet/guides/client-configuration/dependency-injection/)

--- a/website/src/content/docs/guides/client-configuration/pagination.md
+++ b/website/src/content/docs/guides/client-configuration/pagination.md
@@ -1,0 +1,51 @@
+---
+title: Pagination
+description: Generated IAsyncEnumerable paginators for @paginated operations.
+---
+
+Operations modeled with [`@paginated`](https://smithy.io/2.0/spec/behavior-traits.html#paginated-trait)
+generate paginator helpers alongside the normal operation method.
+
+Given a paginated operation:
+
+```smithy
+@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
+service Weather { ... }
+
+@readonly
+@paginated(items: "items")
+@http(method: "GET", uri: "/cities")
+operation ListCities { ... }
+```
+
+the client gains a **pages** paginator that repeats the call while the response
+carries a continuation token:
+
+```csharp
+await foreach (var page in client.ListCitiesPagesAsync(new ListCitiesInput(PageSize: 3)))
+{
+    foreach (var city in page.Items.Values)
+        Console.WriteLine(city.Name);
+}
+```
+
+and — because the trait names an `items` list member — an **items** paginator
+that flattens the pages:
+
+```csharp
+await foreach (var city in client.ListCitiesItemsAsync(new ListCitiesInput(PageSize: 3)))
+    Console.WriteLine(city.Name);
+```
+
+Every page goes through the normal client lifecycle, so auth, retries, endpoint
+resolution, and telemetry behave exactly as they do for a single call — a
+paginated listing that hits a transient error retries that page and continues.
+
+Notes:
+
+- The token, page-size, and items members come from the resolved `@paginated`
+  trait (service-level defaults merged with the operation's trait).
+- Enumeration is lazy: stop iterating and no further requests are sent.
+- Cancellation flows through `WithCancellation(token)` or the method's
+  `CancellationToken` parameter.
+- Operations whose `items` member is a map only generate the pages paginator.


### PR DESCRIPTION
**Stacked on #88** (← #87 ← … ← #82) — the last item from the original design-gap review: the design doc promises "operations with `@paginated` generate paginator helpers that return `IAsyncEnumerable<T>`", and until now pagination only worked by hand-rolling the token loop.

## Generated surface

For a `@paginated` operation (trait resolved via `PaginatedIndex` — service-level defaults merged with the operation's trait):

```csharp
// pages: repeats the call while the response carries a continuation token
IAsyncEnumerable<ListCitiesOutput> ListCitiesPagesAsync(ListCitiesInput input, CancellationToken ct = default);

// items: flattens the pages (generated when @paginated names an items list member)
IAsyncEnumerable<CitySummary> ListCitiesItemsAsync(ListCitiesInput input, CancellationToken ct = default);
```

- Every page goes through the normal client lifecycle — auth, retries, endpoint resolution, telemetry — so a transient failure mid-listing retries that page and continues.
- Enumeration is lazy; stop iterating and no further requests are sent. `[EnumeratorCancellation]` wires `WithCancellation`.
- Nested `outputToken`/`items` paths render as null-conditional chains; map-valued `items` (rare) get the pages paginator only.
- Naming follows the repo's existing convention (event-stream methods already return `IAsyncEnumerable` with an `Async` suffix).

## Example updated

The rest-json1 client's manual `do/while` token loop is replaced with `ListCitiesPagesAsync` (page listing) and `ListCitiesItemsAsync` (flattened) — **verified end-to-end** against the example server: 4 pages of 3/3/3/1, 10 items flattened, retries on the flaky endpoint unaffected.

## Tests & docs

- Codegen: `paginatedOperationsGeneratePagesAndItemsPaginators` — both signatures, the token `with`-loop, items flattening, and no paginators on unpaginated operations.
- Full solution + all conformance suites pass with the regenerated clients.
- Website gains a Pagination guide page (+ side nav); `designs/client-architecture.md` pagination section now names the generated methods.
