### PR TITLE
feat: end-to-end observability in the rest-json1 example

### DIFF
--- a/examples/rest-json1/README.md
+++ b/examples/rest-json1/README.md
@@ -2,7 +2,8 @@
 
 A Weather service built with `aws.protocols#restJson1`. The model is adapted from
 the [Smithy quickstart](https://smithy.io/2.0/quickstart.html) and demonstrates
-resources, pagination, errors, and HTTP binding traits using the AWS REST JSON protocol.
+resources, pagination, errors, retries (`@retryable`), HTTP binding traits, and
+end-to-end OpenTelemetry observability using the AWS REST JSON protocol.
 
 - `contracts`: the Smithy model, packaged as a contracts project.
 - `server`: generated ASP.NET Core endpoints with a handwritten `IWeatherServiceHandler` implementation that supports real server-side pagination.
@@ -52,4 +53,42 @@ curl -i 'http://localhost:5000/cities?pageSize=3'
 curl -i 'http://localhost:5000/cities?pageSize=3&nextToken=CHI'
 curl -i http://localhost:5000/cities/SEA
 curl -i http://localhost:5000/cities/SEA/forecast
+curl -i http://localhost:5000/cities/SEA/flaky-forecast   # 503s two of every three calls
 ```
+
+## Observability
+
+Both the client and the server export OpenTelemetry traces and metrics over
+OTLP to `http://localhost:4317`. Start
+[grafana/otel-lgtm](https://github.com/grafana/docker-otel-lgtm) (Grafana +
+Tempo + Prometheus + Loki in one container) before running the example:
+
+```bash
+docker run --rm -p 3000:3000 -p 4317:4317 -p 4318:4318 grafana/otel-lgtm
+```
+
+Then run the server and client as above and open Grafana at
+[http://localhost:3000](http://localhost:3000) (anonymous admin login).
+
+**Traces** (Explore → Tempo): each client operation is a `weather-client` span
+named `Weather.{Operation}` with one child span per transport attempt; the
+server's ASP.NET Core spans join the same trace via W3C context propagation.
+The interesting ones are the `Weather.GetFlakyForecast` traces — the server
+fails two of every three calls with the model's `@retryable`
+`ServiceUnavailable` error (HTTP 503), and the client's
+`SmithyStandardRetryStrategy` retries with exponential backoff, so each trace
+shows failed attempt spans (status `error`, `error.type` set) followed by a
+successful one, with the backoff visible as gaps between attempts.
+
+**Metrics** (Explore → Prometheus): the client runtime emits, dimensioned by
+`rpc_service` / `rpc_method`:
+
+| Metric | Meaning |
+|--------|---------|
+| `smithy_client_operation_duration_seconds` | End-to-end duration, spanning all attempts and backoff. |
+| `smithy_client_attempts_total` | Transport attempts, including retries — divide by call count to see retry amplification. |
+| `smithy_client_errors_total` | Failed executions, dimensioned by `error_type`. |
+
+The wiring is minimal: the client subscribes its tracer/meter provider to the
+`NSmithy.Client` source and meter (see `client/Program.cs`); the server uses
+standard ASP.NET Core instrumentation (see `server/Program.cs`).

--- a/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
+++ b/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="NSmithy.Client" Version="0.4.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Codecs.Json" Version="0.4.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.4.0-SNAPSHOT" />
+    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/client/Program.cs
+++ b/examples/rest-json1/client/Program.cs
@@ -1,8 +1,31 @@
 using Example.Weather;
+using NSmithy.Client;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 var endpoint = args.Length > 0 ? args[0] : "http://localhost:5000";
 
-var client = new WeatherClient(new Uri(endpoint));
+// Export client telemetry over OTLP (defaults to http://localhost:4317, where
+// grafana/otel-lgtm listens). The NSmithy client runtime emits one span per
+// operation with a child span per transport attempt, plus attempt/error/duration
+// metrics — subscribing to "NSmithy.Client" is all it takes.
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .ConfigureResource(resource => resource.AddService("weather-client"))
+    .AddSource(SmithyClientTelemetry.ActivitySourceName)
+    .AddOtlpExporter()
+    .Build();
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .ConfigureResource(resource => resource.AddService("weather-client"))
+    .AddMeter(SmithyClientTelemetry.MeterName)
+    .AddOtlpExporter()
+    .Build();
+
+using var client = new WeatherClient(
+    new Uri(endpoint),
+    new() { RetryStrategy = new SmithyStandardRetryStrategy(maxAttempts: 4) }
+);
 
 var time = await client.GetCurrentTimeAsync(new GetCurrentTimeInput());
 Console.WriteLine($"Current time: {time.Time:u}");
@@ -27,3 +50,14 @@ Console.WriteLine($"Seattle: ({seattle.Coordinates.Latitude}, {seattle.Coordinat
 
 var forecast = await client.GetForecastAsync(new GetForecastInput("SEA"));
 Console.WriteLine($"Forecast for SEA: {forecast.ChanceOfRain:P0} chance of rain");
+
+// The flaky endpoint fails two of every three calls with a retryable 503; the standard retry
+// strategy retries with backoff, so each call below succeeds after visible retries. In Grafana
+// (Tempo), each Weather.GetFlakyForecast trace shows the failed attempt spans that preceded the
+// successful one.
+Console.WriteLine("Flaky forecasts (each call succeeds after transparent retries):");
+for (var i = 0; i < 3; i++)
+{
+    var flaky = await client.GetFlakyForecastAsync(new GetFlakyForecastInput("SEA"));
+    Console.WriteLine($"  Attempt group {i + 1}: {flaky.ChanceOfRain:P0} chance of rain");
+}

--- a/examples/rest-json1/contracts/model/weather.smithy
+++ b/examples/rest-json1/contracts/model/weather.smithy
@@ -13,7 +13,7 @@ use aws.protocols#restJson1
 service Weather {
     version: "2006-03-01"
     resources: [City]
-    operations: [GetCurrentTime]
+    operations: [GetCurrentTime, GetFlakyForecast]
 }
 
 /// A city with a geographic location and an associated weather forecast.
@@ -127,10 +127,41 @@ structure CitySummary {
     name: String
 }
 
+/// Returns the weather forecast for a city from an unreliable backend.
+///
+/// The server fails transiently on a schedule, returning the retryable
+/// `ServiceUnavailable` error. With a retry strategy configured, the generated
+/// client retries these failures automatically — this operation exists to
+/// demonstrate retries and per-attempt telemetry.
+@readonly
+@http(method: "GET", uri: "/cities/{cityId}/flaky-forecast")
+operation GetFlakyForecast {
+    input := {
+        @required
+        @httpLabel
+        cityId: CityId
+    }
+    output := {
+        /// Probability of rain, between 0.0 (no rain) and 1.0 (certain rain).
+        chanceOfRain: Float
+    }
+    errors: [ServiceUnavailable]
+}
+
 /// Returned when a requested resource does not exist.
 @error("client")
 structure NoSuchResource {
     /// The type of resource that was not found (e.g. `"City"`).
     @required
     resourceType: String
+}
+
+/// Returned when the service is temporarily unable to serve the request.
+/// Marked `@retryable`, so retry strategies treat it as transient regardless
+/// of protocol or status code.
+@error("server")
+@httpError(503)
+@retryable
+structure ServiceUnavailable {
+    message: String
 }

--- a/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
+++ b/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
@@ -17,6 +17,9 @@
   <ItemGroup>
     <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.4.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.4.0-SNAPSHOT" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/server/Program.cs
+++ b/examples/rest-json1/server/Program.cs
@@ -1,8 +1,20 @@
 using Example.Weather;
 using NSmithy.Server.AspNetCore.Docs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddWeatherServiceHandler<WeatherHandler>();
+
+// Export server telemetry over OTLP (defaults to http://localhost:4317, where
+// grafana/otel-lgtm listens). Incoming requests carry the client's trace
+// context, so server spans join the client runtime's operation traces.
+builder
+    .Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("weather-server"))
+    .WithTracing(tracing => tracing.AddAspNetCoreInstrumentation().AddOtlpExporter())
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation().AddOtlpExporter());
 
 var app = builder.Build();
 app.MapSmithyOpenApi();
@@ -82,4 +94,19 @@ internal sealed class WeatherHandler : IWeatherServiceHandler
         GetForecastInput input,
         CancellationToken cancellationToken = default
     ) => Task.FromResult(new GetForecastOutput(ChanceOfRain: 0.4f));
+
+    private int flakyCalls;
+
+    public Task<GetFlakyForecastOutput> GetFlakyForecastAsync(
+        GetFlakyForecastInput input,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Fail two of every three calls with the retryable modeled error, so a client with a
+        // retry strategy succeeds after visible retries (see the attempt spans in Grafana).
+        if (Interlocked.Increment(ref flakyCalls) % 3 != 0)
+            throw new ServiceUnavailable("The forecast backend is overloaded; try again.");
+
+        return Task.FromResult(new GetFlakyForecastOutput(ChanceOfRain: 0.4f));
+    }
 }


### PR DESCRIPTION
The rest-json1 example now demonstrates the client runtime's OpenTelemetry
instrumentation against grafana/otel-lgtm:

- the Weather model gains GetFlakyForecast and a @retryable @httpError(503)
  ServiceUnavailable error; the server fails two of every three calls
- the client configures SmithyStandardRetryStrategy and exports traces/metrics
  over OTLP by subscribing to the NSmithy.Client source and meter
- the server exports ASP.NET Core spans that join the client's traces via W3C
  context propagation

Verified against a running otel-lgtm: Tempo shows Weather.GetFlakyForecast
traces with two errored attempt spans (error.type =
Example.Weather.ServiceUnavailable) nested above the succeeding third, server
spans under each attempt; Prometheus shows smithy_client_attempts_total = 9
for 3 flaky operations and no smithy_client_errors_total (every execution
ultimately succeeded).
