### PR TITLE
docs: Geist fonts for the docs, centered landing hero

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
 					tag: 'link',
 					attrs: {
 						rel: 'stylesheet',
-						href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap',
+						href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap',
 					},
 				},
 			],

--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -113,12 +113,8 @@ const langs = [
           <span class="nsl-chip">+extensible</span>
         </div>
       </div>
-
-      <div class="nsl-hero-art reveal" style="--reveal-delay: 160ms" aria-hidden="true">
-        <div class="nsl-hero-glow"></div>
-        <img class="nsl-anvil" src={logo} alt="" width="340" height="340" />
-      </div>
     </div>
+    <div class="nsl-hero-glow" aria-hidden="true"></div>
   </section>
 
   <!-- Workflow -->
@@ -444,21 +440,18 @@ const langs = [
     border-color: var(--accent);
   }
 
-  /* ── Hero (asymmetric: copy left, forge motif right) ─────────────────────── */
+  /* ── Hero (centered copy over a soft glow) ───────────────────────────────── */
   .nsl-hero {
     position: relative;
-    padding: 72px 40px 92px;
+    padding: 88px 40px 96px;
     overflow: hidden;
   }
   .nsl-hero-inner {
     position: relative;
     z-index: 1;
-    max-width: 1180px;
+    max-width: 860px;
     margin: 0 auto;
-    display: grid;
-    grid-template-columns: 1.05fr 0.95fr;
-    align-items: center;
-    gap: clamp(24px, 4vw, 56px);
+    text-align: center;
   }
   .nsl-hero-copy {
     min-width: 0;
@@ -491,43 +484,36 @@ const langs = [
     font-size: clamp(16px, 1.1vw, 19px);
     line-height: 1.55;
     color: var(--dim);
-    max-width: 540px;
-    margin: 0 0 34px;
+    max-width: 560px;
+    margin: 0 auto 34px;
     text-wrap: pretty;
   }
   .nsl-hero-actions {
     display: flex;
     gap: 14px;
-    justify-content: flex-start;
+    justify-content: center;
     margin-bottom: 34px;
     flex-wrap: wrap;
   }
   .nsl-chips {
     display: flex;
     gap: 10px;
-    justify-content: flex-start;
+    justify-content: center;
     flex-wrap: wrap;
   }
 
-  /* Hero art: static logo over a soft glow */
-  .nsl-hero-art {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 360px;
-  }
+  /* Soft glow behind the centered copy (kept subtle; clipped by the hero). */
   .nsl-hero-glow {
     position: absolute;
-    inset: -8%;
-    background: radial-gradient(closest-side, rgba(109, 74, 255, 0.16), transparent 70%);
+    inset: 0;
+    max-width: 100%;
+    background: radial-gradient(
+      560px 300px at 50% 32%,
+      rgba(109, 74, 255, 0.14),
+      transparent 70%
+    );
     pointer-events: none;
-    z-index: -1;
-  }
-  .nsl-anvil {
-    width: min(330px, 92%);
-    height: auto;
-    filter: drop-shadow(0 16px 36px rgba(109, 74, 255, 0.22));
+    z-index: 0;
   }
   /* Plain text labels, not pills — anything boxed next to the buttons reads as
      clickable. */
@@ -784,29 +770,6 @@ const langs = [
 
   /* ── Responsive ──────────────────────────────────────────────────────────── */
   @media (max-width: 60rem) {
-    .nsl-hero-inner {
-      grid-template-columns: 1fr;
-      text-align: center;
-      gap: 4px;
-    }
-    .nsl-hero-copy {
-      order: 2;
-    }
-    .nsl-hero-art {
-      order: 1;
-      min-height: 200px;
-      margin-bottom: 6px;
-    }
-    .nsl-anvil {
-      width: min(180px, 52%);
-    }
-    .nsl-hero-actions,
-    .nsl-chips {
-      justify-content: center;
-    }
-    .nsl-lead {
-      margin-inline: auto;
-    }
     .nsl-cards {
       grid-template-columns: repeat(2, 1fr);
     }

--- a/website/src/styles/docs-theme.css
+++ b/website/src/styles/docs-theme.css
@@ -3,10 +3,10 @@
  * near-black dark mode so moving between them feels seamless.
  */
 
-/* Fonts — match the landing (IBM Plex Sans body, JetBrains Mono code). */
+/* Fonts — Geist body + Geist Mono code for the docs. */
 :root {
-  --sl-font: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  --sl-font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
+  --sl-font: 'Geist', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --sl-font-mono: 'Geist Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
 }
 
 /* Big headings echo the landing's display face; smaller ones stay in the body


### PR DESCRIPTION
## Summary
- Switch the Starlight docs to **Geist** (body/UI text) and **Geist Mono** (code blocks, inline code, code-frame titles), both loaded via Google Fonts.
- Big docs headings (h1/h2) and the site title stay in **Space Grotesk** so the brand stays cohesive with the landing page; the landing keeps its own IBM Plex Sans / JetBrains Mono styling.
- Landing hero: remove the large logo art column and center the hero copy (badge, headline, lead, buttons, protocol chips), keeping a subtle violet glow behind the text. Drops the now-unused hero-art responsive rules.

## Verification
- `npm run build` passes (31 pages).
- Headless-Chrome screenshots of the landing at 1400px and 500px widths (no horizontal overflow) and of a docs page confirming Geist body + Space Grotesk headings.
