### PR TITLE
fix: substitute release version into packed NSmithy.MSBuild props/targets

### DIFF
--- a/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
+++ b/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
@@ -7,6 +7,7 @@
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_NSmithyPackVersionedBuildFiles</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,27 +19,6 @@
     -->
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
-
-    <!--
-      build/ props: auto-imported for direct consumers only (projects that explicitly
-      reference NSmithy.MSBuild). Sets SmithySources default and other opt-in defaults.
-    -->
-    <None
-      Include="Targets/NSmithy.MSBuild.props"
-      Pack="true"
-      PackagePath="build/NSmithy.MSBuild.props"
-    />
-
-    <!--
-      buildTransitive/ targets: auto-imported for every project that has NSmithy.MSBuild
-      anywhere in its NuGet dependency tree — including server/client projects that get
-      it transitively via NSmithy.Server or NSmithy.Client.
-    -->
-    <None
-      Include="Targets/NSmithy.MSBuild.targets"
-      Pack="true"
-      PackagePath="buildTransitive/NSmithy.MSBuild.targets"
-    />
 
     <!--
       Bundled Smithy CLI — populated by tools/download-smithy-cli.sh.
@@ -79,4 +59,82 @@
       Condition="Exists('tools/smithy-cli/windows-x64/bin/smithy.bat')"
     />
   </ItemGroup>
+
+  <!--
+    build/ props and buildTransitive/ targets:
+      - build/ props are auto-imported for direct consumers only (projects that
+        explicitly reference NSmithy.MSBuild). Sets SmithySources default and
+        other opt-in defaults.
+      - buildTransitive/ targets are auto-imported for every project that has
+        NSmithy.MSBuild anywhere in its NuGet dependency tree — including
+        server/client projects that get it transitively via NSmithy.Server or
+        NSmithy.Client.
+
+    Both files default SmithyCSharpCodegenVersion to the -SNAPSHOT dev version so
+    that in-repo consumers (conformance tests import Targets/ directly) resolve the
+    codegen JAR that `just codegen` publishes to ~/.m2. The published package must
+    instead reference the JAR version released to Maven Central, which matches the
+    package version. So the files are packed via copies under obj/ with the dev
+    version substituted by $(Version) — a no-op for local `just pack` (where
+    $(Version) IS the dev version) and the release version on tag builds (where
+    the workflow passes -p:Version).
+  -->
+  <UsingTask
+    TaskName="_NSmithySubstituteInFile"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll"
+  >
+    <ParameterGroup>
+      <InputFile ParameterType="System.String" Required="true" />
+      <OutputFile ParameterType="System.String" Required="true" />
+      <Find ParameterType="System.String" Required="true" />
+      <ReplaceWith ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var text = File.ReadAllText(InputFile);
+        if (!text.Contains(Find))
+        {
+            Log.LogError(
+                "NSmithy: '" + InputFile + "' does not contain '" + Find + "'. "
+                + "The SmithyCSharpCodegenVersion default must equal "
+                + "$(VersionPrefix)-SNAPSHOT (see Directory.Build.props); bump both together.");
+        }
+        else
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputFile));
+            File.WriteAllText(OutputFile, text.Replace(Find, ReplaceWith));
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="_NSmithyPackVersionedBuildFiles">
+    <PropertyGroup>
+      <_NSmithyPackObjDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'nupkg'))</_NSmithyPackObjDir>
+    </PropertyGroup>
+    <_NSmithySubstituteInFile
+      InputFile="$(MSBuildProjectDirectory)/Targets/NSmithy.MSBuild.props"
+      OutputFile="$(_NSmithyPackObjDir)NSmithy.MSBuild.props"
+      Find="$(VersionPrefix)-SNAPSHOT"
+      ReplaceWith="$(Version)"
+    />
+    <_NSmithySubstituteInFile
+      InputFile="$(MSBuildProjectDirectory)/Targets/NSmithy.MSBuild.targets"
+      OutputFile="$(_NSmithyPackObjDir)NSmithy.MSBuild.targets"
+      Find="$(VersionPrefix)-SNAPSHOT"
+      ReplaceWith="$(Version)"
+    />
+    <ItemGroup>
+      <TfmSpecificPackageFile
+        Include="$(_NSmithyPackObjDir)NSmithy.MSBuild.props"
+        PackagePath="build/NSmithy.MSBuild.props"
+      />
+      <TfmSpecificPackageFile
+        Include="$(_NSmithyPackObjDir)NSmithy.MSBuild.targets"
+        PackagePath="buildTransitive/NSmithy.MSBuild.targets"
+      />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
+++ b/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
@@ -92,7 +92,8 @@
     </ParameterGroup>
     <Task>
       <Using Namespace="System.IO" />
-      <Code Type="Fragment" Language="cs"><![CDATA[
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
         var text = File.ReadAllText(InputFile);
         if (!text.Contains(Find))
         {
@@ -106,7 +107,8 @@
             Directory.CreateDirectory(Path.GetDirectoryName(OutputFile));
             File.WriteAllText(OutputFile, text.Replace(Find, ReplaceWith));
         }
-      ]]></Code>
+      ]]>
+      </Code>
     </Task>
   </UsingTask>
 


### PR DESCRIPTION
## Problem

Every released `NSmithy.MSBuild` package shipped the hardcoded `-SNAPSHOT` dev default for `SmithyCSharpCodegenVersion` in its packed `build/NSmithy.MSBuild.props` and `buildTransitive/NSmithy.MSBuild.targets`. Server/client projects therefore synthesize a `smithy-build.json` referencing `io.github.thomaslaich.nsmithy:smithy-csharp-codegen:<x.y.z>-SNAPSHOT` — a Maven version that only exists in a dev `~/.m2` (published by `just codegen`), never on Maven Central. Codegen fails on any clean machine following the quickstart.

This was never caught because:
- dev machines always have the SNAPSHOT JAR in `~/.m2`, and
- the release workflow's `-p:Version` only sets the nupkg version — the props/targets were packed verbatim.

The default was also manually maintained: **v0.3.0 shipped a stale `0.2.0-SNAPSHOT` default**.

## Fix

Pack transformed copies from `obj/` instead of the raw files, replacing `$(VersionPrefix)-SNAPSHOT` with `$(Version)` (via the documented `TargetsForTfmSpecificContentInPackage` extension point + a small inline `RoslynCodeTaskFactory` task):

- **Local dev pack** (`just pack`): `$(Version)` *is* `0.4.0-SNAPSHOT` → substitution is a no-op, examples/dev flow unchanged.
- **Release pack** (workflow passes `-p:Version=<tag>`): packed default becomes the tag version, matching the JAR that `just publish-codegen` pushes to Maven Central.
- The in-tree files keep the `-SNAPSHOT` default: conformance tests `<Import>` `Targets/` directly and resolve the dev JAR from `~/.m2`, including during release CI.
- The task **errors if the file default drifts from `$(VersionPrefix)`**, so the v0.3.0-style stale default now fails the pack instead of shipping silently.

A side benefit: releases no longer require bumping the MSBuild targets default before tagging — the packed version is derived from the tag.

## Verification

Packed `NSmithy.MSBuild` three ways and inspected the nupkgs:
- default version → packed files identical to before (still `0.4.0-SNAPSHOT`), no duplicate archive entries
- `-p:Version=0.4.0` → packed default is `0.4.0` in both props and targets
- `-p:VersionPrefix=9.9.9` (simulated drift) → pack fails with a clear error

## Follow-ups (not in this PR)

- Single version source (VERSION file) shared by `Directory.Build.props` / `build.gradle.kts`, and the same substitution for the hardcoded `0.4.0` pins in `NSmithy.Templates`
- Deprecate the broken `NSmithy.MSBuild` 0.4.0 on nuget.org (workaround: set `<SmithyCSharpCodegenVersion>0.4.0</SmithyCSharpCodegenVersion>`)
- Longer term: bundle the codegen JAR in the package (next to the Smithy CLI + JRE) and inject a `file://` Maven repo at synthesis time, making version skew unrepresentable
