### PR TITLE
fix: correct quick-start client setup, stale template refs; add rpcv2Cbor protocol option

### DIFF
--- a/templates/NSmithy.Templates/content/nsmithy-client/.template.config/template.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/.template.config/template.json
@@ -48,6 +48,7 @@
       "choices": [
         { "choice": "restJson1",     "description": "aws.protocols#restJson1 — AWS REST/JSON protocol" },
         { "choice": "simpleRestJson","description": "alloy#simpleRestJson — Alloy REST/JSON protocol" },
+        { "choice": "rpcv2Cbor",     "description": "smithy.protocols#rpcv2Cbor — Smithy RPC v2 CBOR protocol" },
         { "choice": "grpc",          "description": "alloy.proto#grpc — gRPC protocol (experimental)" }
       ],
       "defaultValue": "restJson1",
@@ -65,6 +66,7 @@
     },
     "IsRestJson1":    { "type": "computed", "value": "(Protocol == \"restJson1\")" },
     "IsSimpleRestJson":{ "type": "computed", "value": "(Protocol == \"simpleRestJson\")" },
+    "IsRpcv2Cbor":    { "type": "computed", "value": "(Protocol == \"rpcv2Cbor\")" },
     "IsGrpc":         { "type": "computed", "value": "(Protocol == \"grpc\")" },
     "IsMaven":        { "type": "computed", "value": "(Contracts == \"maven\")" },
     "IsNuget":        { "type": "computed", "value": "(Contracts == \"nuget\")" }

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -14,15 +14,17 @@
     <PackageReference Include="NSmithy.Core" Version="0.5.0" />
     <PackageReference Include="NSmithy.Http" Version="0.5.0" />
     <PackageReference Include="NSmithy.MSBuild" Version="0.5.0" PrivateAssets="all" />
-    <!--
-      The HelloService model declares both @simpleRestJson and @grpc, so the generated client
-      supports both protocols (pick one via the constructor's `protocol:` parameter, e.g.
-      new GrpcProtocol()) and references both protocol packages. Native gRPC needs no
-      Grpc.Net.Client / Google.Protobuf / protoc.
-    -->
+    <!-- Runtime packages for the protocol the contracts model declares. -->
+    <!--#if (IsGrpc)-->
+    <!-- Native gRPC: no Grpc.Net.Client / Google.Protobuf / protoc needed. -->
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0" />
+    <!--#elif (IsRpcv2Cbor)-->
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0" />
+    <!--#else-->
     <PackageReference Include="NSmithy.Codecs.Json" Version="0.5.0" />
     <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0" />
+    <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->
     <PackageReference Include="MyService.Contracts" Version="1.0.0" />

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -3,6 +3,13 @@
   "maven": {
     "dependencies": [
       "io.github.YOUR_ORG:your-service-contracts:1.0.0",
+      //#if (IsRestJson1)
+      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      //#elseif (IsRpcv2Cbor)
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
+      //#elseif (IsSimpleRestJson || IsGrpc)
+      "com.disneystreaming.alloy:alloy-core:0.3.38",
+      //#endif
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0"
     ]
   },

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/.template.config/template.json
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/.template.config/template.json
@@ -18,6 +18,7 @@
       "choices": [
         { "choice": "restJson1",     "description": "aws.protocols#restJson1 — AWS REST/JSON protocol" },
         { "choice": "simpleRestJson","description": "alloy#simpleRestJson — Alloy REST/JSON protocol" },
+        { "choice": "rpcv2Cbor",     "description": "smithy.protocols#rpcv2Cbor — Smithy RPC v2 CBOR protocol" },
         { "choice": "grpc",          "description": "alloy.proto#grpc — gRPC protocol (experimental)" }
       ],
       "defaultValue": "restJson1",
@@ -25,6 +26,7 @@
     },
     "IsRestJson1":    { "type": "computed", "value": "(Protocol == \"restJson1\")" },
     "IsSimpleRestJson":{ "type": "computed", "value": "(Protocol == \"simpleRestJson\")" },
+    "IsRpcv2Cbor":    { "type": "computed", "value": "(Protocol == \"rpcv2Cbor\")" },
     "IsGrpc":         { "type": "computed", "value": "(Protocol == \"grpc\")" }
   },
   "specialCustomOperations": {

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/model/service.smithy
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/model/service.smithy
@@ -6,6 +6,8 @@ namespace example.hello
 use aws.protocols#restJson1
 //#elseif (IsSimpleRestJson)
 use alloy#simpleRestJson
+//#elseif (IsRpcv2Cbor)
+use smithy.protocols#rpcv2Cbor
 //#elseif (IsGrpc)
 use alloy.proto#grpc
 use alloy.proto#protoIndex
@@ -16,6 +18,8 @@ use alloy.proto#protoIndex
 @restJson1
 //#elseif (IsSimpleRestJson)
 @simpleRestJson
+//#elseif (IsRpcv2Cbor)
+@rpcv2Cbor
 //#elseif (IsGrpc)
 @grpc
 //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
@@ -5,6 +5,8 @@
     "dependencies": [
       //#if (IsRestJson1)
       "software.amazon.smithy:smithy-aws-traits:1.71.0"
+      //#elseif (IsRpcv2Cbor)
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38"
       //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-server/.template.config/template.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/.template.config/template.json
@@ -18,6 +18,7 @@
       "choices": [
         { "choice": "restJson1",     "description": "aws.protocols#restJson1 — AWS REST/JSON protocol" },
         { "choice": "simpleRestJson","description": "alloy#simpleRestJson — Alloy REST/JSON protocol" },
+        { "choice": "rpcv2Cbor",     "description": "smithy.protocols#rpcv2Cbor — Smithy RPC v2 CBOR protocol" },
         { "choice": "grpc",          "description": "alloy.proto#grpc — gRPC protocol (experimental)" }
       ],
       "defaultValue": "restJson1",
@@ -42,6 +43,7 @@
     },
     "IsRestJson1":    { "type": "computed", "value": "(Protocol == \"restJson1\")" },
     "IsSimpleRestJson":{ "type": "computed", "value": "(Protocol == \"simpleRestJson\")" },
+    "IsRpcv2Cbor":    { "type": "computed", "value": "(Protocol == \"rpcv2Cbor\")" },
     "IsGrpc":         { "type": "computed", "value": "(Protocol == \"grpc\")" },
     "IsHttp":         { "type": "computed", "value": "(Protocol == \"restJson1\" || Protocol == \"simpleRestJson\")" }
   },

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -18,9 +18,9 @@
     <!--#if (WithDocs)-->
     <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.5.0" />
     <!--#endif-->
-    <!--#if (IsGrpc)-->
-    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
+    <!--#if (IsRpcv2Cbor)-->
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0" />
     <!--#endif-->
     <!--#if (WithContracts)-->
     <ProjectReference Include="../ContractsName/ContractsName.csproj" />

--- a/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
+++ b/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
@@ -10,12 +10,13 @@ using NSmithy.Server.AspNetCore.Docs;
 var builder = WebApplication.CreateBuilder(args);
 
 //#if (IsGrpc)
+// Native gRPC: the generated server speaks the gRPC wire format itself via
+// NSmithy.Protocols.Grpc — no Grpc.AspNetCore / Grpc.Tools / protoc needed.
 builder.WebHost.ConfigureKestrel(options =>
 {
     options.ListenLocalhost(5000, o => o.Protocols = HttpProtocols.Http1);
     options.ListenLocalhost(5001, o => o.Protocols = HttpProtocols.Http2);
 });
-builder.Services.AddGrpc();
 
 //#endif
 builder.Services.AddHelloServiceHandler<HelloHandler>();
@@ -30,12 +31,11 @@ app.MapSmithyDocs();
 app.MapSmithyDocs();
 
 //#endif
-//#if (IsHttp)
-app.MapHelloServiceHttp();
-
-//#endif
 //#if (IsGrpc)
 app.MapHelloServiceGrpc();
+
+//#else
+app.MapHelloServiceHttp();
 
 //#endif
 app.Run();

--- a/templates/NSmithy.Templates/content/nsmithy-server/model/service.smithy
+++ b/templates/NSmithy.Templates/content/nsmithy-server/model/service.smithy
@@ -6,6 +6,8 @@ namespace example.hello
 use aws.protocols#restJson1
 //#elseif (IsSimpleRestJson)
 use alloy#simpleRestJson
+//#elseif (IsRpcv2Cbor)
+use smithy.protocols#rpcv2Cbor
 //#elseif (IsGrpc)
 use alloy.proto#grpc
 use alloy.proto#protoIndex
@@ -16,6 +18,8 @@ use alloy.proto#protoIndex
 @restJson1
 //#elseif (IsSimpleRestJson)
 @simpleRestJson
+//#elseif (IsRpcv2Cbor)
+@rpcv2Cbor
 //#elseif (IsGrpc)
 @grpc
 //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -5,6 +5,8 @@
     "dependencies": [
       //#if (IsRestJson1)
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      //#elseif (IsRpcv2Cbor)
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif

--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -26,7 +26,7 @@ const features = [
   { t: 'Extensible', d: 'Add protocols and generators through a plugin surface — the model stays the single source of truth.' },
 ];
 
-// Each pill links to that language's official Smithy code generator.
+// Each pill links to that language's Smithy code generator.
 const langs = [
   { name: 'C#', url: repo },
   { name: 'Java', url: 'https://github.com/smithy-lang/smithy-java' },
@@ -36,6 +36,9 @@ const langs = [
   { name: 'Swift', url: 'https://github.com/smithy-lang/smithy-swift' },
   { name: 'Kotlin', url: 'https://github.com/smithy-lang/smithy-kotlin' },
   { name: 'Go', url: 'https://github.com/aws/smithy-go' },
+  { name: 'Scala', url: 'https://github.com/disneystreaming/smithy4s' },
+  { name: 'Ruby', url: 'https://github.com/smithy-lang/smithy-ruby' },
+  { name: 'Dafny', url: 'https://github.com/smithy-lang/smithy-dafny' },
 ];
 ---
 

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -81,16 +81,22 @@ dotnet new nsmithy-client -n HelloWorld.Client
 dotnet sln add HelloWorld.Client
 ```
 
-The client template defaults to a Maven contracts reference for production use.
-For local development, open `HelloWorld.Client/HelloWorld.Client.csproj` and
-replace the `SmithyMavenDependency` placeholder with a `ProjectReference`:
+The client template defaults to a Maven contracts reference for production use:
+it ships a `smithy-build.json` that pulls the contracts model from a Maven JAR.
+For local development, switch to the sibling contracts project instead. Delete
+the client's `smithy-build.json` — when no `smithy-build.json` exists at the
+project root, NSmithy synthesizes one from the contracts `ProjectReference`:
+
+```shell
+rm HelloWorld.Client/smithy-build.json
+```
+
+Then add a `ProjectReference` to `HelloWorld.Client/HelloWorld.Client.csproj`:
 
 ```xml
-<!-- remove this -->
-<SmithyMavenDependency Include="io.github.YOUR_ORG:your-service-contracts:1.0.0" />
-
-<!-- add this instead -->
-<ProjectReference Include="../HelloWorld.Contracts/HelloWorld.Contracts.csproj" />
+<ItemGroup>
+  <ProjectReference Include="../HelloWorld.Contracts/HelloWorld.Contracts.csproj" />
+</ItemGroup>
 ```
 
 Then run the client with the server still running:
@@ -208,6 +214,7 @@ All three templates accept `--protocol`:
 | --- | --- |
 | `restJson1` | `aws.protocols#restJson1` (default) |
 | `simpleRestJson` | `alloy#simpleRestJson` |
+| `rpcv2Cbor` | `smithy.protocols#rpcv2Cbor` |
 | `grpc` | `alloy.proto#grpc` (experimental) |
 
 Additional options:


### PR DESCRIPTION
## Quick-start fix

The client section instructed users to replace a `SmithyMavenDependency` item in the csproj — but that MSBuild item does not exist in the implementation. The real mechanism (per `NSmithy.MSBuild.targets`): a `smithy-build.json` at the project root always takes precedence, and `_PrepareSmithyBuildFile` only synthesizes one from a contracts `ProjectReference` when no local file exists. The doc now says to delete the client's `smithy-build.json` and add a `ProjectReference`.

## Template fixes

- **Client csproj**: protocol runtime packages are now conditional on `--protocol`. Previously it referenced both `NSmithy.Protocols.RestJson` and `NSmithy.Protocols.Grpc` unconditionally, with a comment describing a dual-protocol model the templates never generate.
- **Client smithy-build.json**: adds the protocol trait Maven dependency (`smithy-aws-traits` / `smithy-protocol-traits` / `alloy-core`) so the Smithy CLI can resolve the traits used by the contracts JAR.
- **Server csproj / Program.cs**: drops `Grpc.AspNetCore`, `Grpc.Tools`, and `AddGrpc()` — stale from before native gRPC. The generated server speaks the gRPC wire format via `NSmithy.Protocols.Grpc`, which flows transitively from `NSmithy.Server.AspNetCore` (matches `examples/grpc`).

## rpcv2Cbor

All three templates now accept `--protocol rpcv2Cbor` (model trait, `smithy-protocol-traits` Maven dep, `NSmithy.Codecs.Cbor` + `NSmithy.Protocols.RpcV2Cbor` packages, `MapXxxHttp()` mapping), mirroring `examples/rpcv2cbor`. Added to the quick-start protocol table.

## Landing page

Ecosystem section now includes Scala (smithy4s), Ruby (smithy-ruby), and Dafny (smithy-dafny).

## Verification

- Rendered all 20 combinations (4 protocols × {contracts, server standalone, server --contracts --with-docs, client maven, client nuget}) with `dotnet new` from the local template folders; conditional output correct in every case (spot-checked csproj/model/smithy-build/Program.cs for rpcv2Cbor, grpc, restJson1).
- `npm run build` (website) passes; `treefmt` clean.

## Out of scope, worth a follow-up

`reference/msbuild.md` documents `SmithyMavenDependency` items as additive inputs to the synthesized smithy-build.json — that feature does not exist in `NSmithy.MSBuild.targets`. Left untouched since it may be planned work (there is a `smithy-build` worktree).
