### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ the conformance projects resolve
 ## Conventions and gotchas
 
 - **Versioning is tag-driven.** Local builds use the `VersionPrefix` /
-  `VersionSuffix` in `Directory.Build.props` (currently `0.5.0` + `SNAPSHOT`); the
+  `VersionSuffix` in `Directory.Build.props` (currently `0.6.0` + `SNAPSHOT`); the
   release workflow overrides the version from the GitHub release tag. When bumping
   the version, update `Directory.Build.props`, `codegen/build.gradle.kts`, the
   `NSmithy.MSBuild` targets, templates, examples, conformance `smithy-build.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,37 @@ and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.0]
+
+This release adds a debug-logging interceptor to the client runtime, fixes the
+quick-start template setup, and reworks the examples: one solution with an
+index README, and a full-featured rpcv2Cbor example.
+
 ### Added
 
 - **`DebugInterceptor`.** A built-in client interceptor that logs the typed
   input and output, each transport attempt's request and response, and a hex
   dump of the body bytes. Useful for inspecting what a protocol puts on the
-  wire. (#100)
+  wire. The rpcv2cbor example client enables it with `--debug`. (#100)
+- **`rpcv2Cbor` template option.** The `dotnet new` templates accept
+  `--protocol rpcv2Cbor`. (#97)
+
+### Changed
+
+- **Examples reworked.** All examples live in a single solution with an index
+  README; the rpcv2cbor example is now the same Weather service as the
+  rest-json1 example (resources, pagination, errors, retries) served over
+  CBOR, and the grpc example README describes the actual native-gRPC
+  LibraryService. (#98, #99)
+
+### Fixed
+
+- **Quick-start template setup.** The client template's project setup was
+  corrected and stale template references were removed. (#97)
+
+### Packages
+
+All packages are published to NuGet at `0.6.0`.
 
 ## [0.5.0]
 
@@ -269,7 +294,8 @@ All published to NuGet at `0.1.0`:
 - **Protocols:** `NSmithy.Protocols.Rest`, `NSmithy.Protocols.RestJson`, `NSmithy.Protocols.RestXml`, `NSmithy.Protocols.RpcV2Cbor`
 - **Tooling:** `NSmithy.Templates` (project templates), `dotnet-nsmithy` (CLI tool)
 
-[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/thomaslaich/smithy-dotnet/compare/v0.2.0...v0.3.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <Authors>Thomas Laich</Authors>
     <Description>NSmithy — C# code generation and runtime toolkit for Smithy models.</Description>

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -22,7 +22,7 @@ allprojects {
     // The release pipeline overrides this with `-Pversion=<x.y.z>` so the published
     // Maven Central artifact carries the matching release version.
     version = (findProperty("version") as String?).takeUnless { it.isNullOrBlank() || it == "unspecified" }
-        ?: "0.5.0-SNAPSHOT"
+        ?: "0.6.0-SNAPSHOT"
 }
 
 subprojects {

--- a/examples/aws-localstack/client/NSmithy.Examples.AwsLocalStack.Client.csproj
+++ b/examples/aws-localstack/client/NSmithy.Examples.AwsLocalStack.Client.csproj
@@ -13,13 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Aws" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.AwsJson" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Aws" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Xml" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.AwsJson" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/aws-localstack/smithy-build.json
+++ b/examples/aws-localstack/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/grpc-streaming/client/NSmithy.Examples.GrpcStreaming.Client.csproj
+++ b/examples/grpc-streaming/client/NSmithy.Examples.GrpcStreaming.Client.csproj
@@ -14,9 +14,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../contracts/Streaming.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/grpc-streaming/contracts/Streaming.Contracts.csproj
+++ b/examples/grpc-streaming/contracts/Streaming.Contracts.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc-streaming/grpcnet-client/NSmithy.Examples.GrpcStreaming.GrpcNetClient.csproj
+++ b/examples/grpc-streaming/grpcnet-client/NSmithy.Examples.GrpcStreaming.GrpcNetClient.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc-streaming/grpcnet-server/NSmithy.Examples.GrpcStreaming.GrpcNetServer.csproj
+++ b/examples/grpc-streaming/grpcnet-server/NSmithy.Examples.GrpcStreaming.GrpcNetServer.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc-streaming/server/NSmithy.Examples.GrpcStreaming.Server.csproj
+++ b/examples/grpc-streaming/server/NSmithy.Examples.GrpcStreaming.Server.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../contracts/Streaming.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
+++ b/examples/grpc/client/NSmithy.Examples.Grpc.Client.csproj
@@ -19,9 +19,9 @@
   -->
   <ItemGroup>
     <ProjectReference Include="../contracts/Library.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/contracts/Library.Contracts.csproj
+++ b/examples/grpc/contracts/Library.Contracts.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
+++ b/examples/grpc/server/NSmithy.Examples.Grpc.Server.csproj
@@ -17,9 +17,9 @@
   -->
   <ItemGroup>
     <ProjectReference Include="../contracts/Library.Contracts.csproj" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
+++ b/examples/polyglot/dotnet/NSmithy.Polyglot.DotNet.Client.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Http" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Http" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -8,7 +8,7 @@
     ],
     "dependencies": [
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT"
     ]
   },
   "projections": {

--- a/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
+++ b/examples/rest-json1/client/NSmithy.Examples.RestJson1.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.6.0-SNAPSHOT" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RestJson1.Contracts.csproj" />

--- a/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
+++ b/examples/rest-json1/contracts/NSmithy.Examples.RestJson1.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
+++ b/examples/rest-json1/server/NSmithy.Examples.RestJson1.Server.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.6.0-SNAPSHOT" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />

--- a/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
+++ b/examples/rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.6.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
+++ b/examples/rpcv2cbor/contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
+++ b/examples/rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.RpcV2Cbor.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
+++ b/examples/simple-rest-json/client/NSmithy.Examples.SimpleRestJson.Client.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.6.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
+++ b/examples/simple-rest-json/contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
     <SmithyPublish>true</SmithyPublish>
     <SmithyMavenGroupId>io.github.thomaslaich.nsmithy.examples</SmithyMavenGroupId>
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0-SNAPSHOT" />
   </ItemGroup>
 </Project>

--- a/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
+++ b/examples/simple-rest-json/server/NSmithy.Examples.SimpleRestJson.Server.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0-SNAPSHOT" />
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.5.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.6.0-SNAPSHOT" />
     <ProjectReference Include="../contracts/NSmithy.Examples.SimpleRestJson.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
@@ -13,7 +13,7 @@
       artifacts in your contracts smithy-build.json should use this version.
     -->
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
-    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.5.0-SNAPSHOT</SmithyCSharpCodegenVersion>
+    <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.6.0-SNAPSHOT</SmithyCSharpCodegenVersion>
     <!--
       Set to 'true' to inject the smithy-docgen plugin into the synthesized smithy-build.json
       and copy the generated HTML docs to wwwroot/docs/.

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -37,7 +37,7 @@
   <PropertyGroup>
     <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''"
-      >0.5.0-SNAPSHOT</SmithyCSharpCodegenVersion
+      >0.6.0-SNAPSHOT</SmithyCSharpCodegenVersion
     >
     <SmithyGenerateDocs Condition="'$(SmithyGenerateDocs)' == ''">false</SmithyGenerateDocs>
     <SmithyOpenApiProtocol Condition="'$(SmithyOpenApiProtocol)' == ''"></SmithyOpenApiProtocol>

--- a/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-client/MyService.csproj
@@ -10,20 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Client" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Core" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Http" Version="0.5.0" />
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Client" Version="0.6.0" />
+    <PackageReference Include="NSmithy.Core" Version="0.6.0" />
+    <PackageReference Include="NSmithy.Http" Version="0.6.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0" PrivateAssets="all" />
     <!-- Runtime packages for the protocol the contracts model declares. -->
     <!--#if (IsGrpc)-->
     <!-- Native gRPC: no Grpc.Net.Client / Google.Protobuf / protoc needed. -->
-    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Protocols.Grpc" Version="0.6.0" />
     <!--#elif (IsRpcv2Cbor)-->
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.6.0" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.6.0" />
     <!--#else-->
-    <PackageReference Include="NSmithy.Codecs.Json" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Codecs.Json" Version="0.6.0" />
+    <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.6.0" />
     <!--#endif-->
     <!--#if (IsNuget)-->
     <!-- Replace with your actual contracts package name and version -->

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -10,7 +10,7 @@
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0"
     ]
   },
   "plugins": {

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/MyService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.MSBuild" Version="0.5.0" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.6.0" />
   </ItemGroup>
 
 

--- a/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
+++ b/templates/NSmithy.Templates/content/nsmithy-server/MyService.csproj
@@ -14,13 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0" />
     <!--#if (WithDocs)-->
-    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.6.0" />
     <!--#endif-->
     <!--#if (IsRpcv2Cbor)-->
-    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.5.0" />
-    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.5.0" />
+    <PackageReference Include="NSmithy.Codecs.Cbor" Version="0.6.0" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.6.0" />
     <!--#endif-->
     <!--#if (WithContracts)-->
     <ProjectReference Include="../ContractsName/ContractsName.csproj" />

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -10,7 +10,7 @@
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0"
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0"
     ]
   },
   "plugins": {

--- a/tests/Conformance/AwsJson/smithy-build.json
+++ b/tests/Conformance/AwsJson/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -13,7 +13,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT",
       "software.amazon.smithy:smithy-aws-traits:1.71.0",
       "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
     ]

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -10,7 +10,7 @@
       }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT",
       "software.amazon.smithy:smithy-protocol-traits:1.71.0",
       "software.amazon.smithy:smithy-protocol-tests:1.71.0"
     ]

--- a/tests/Conformance/SimpleRestJson/smithy-build.json
+++ b/tests/Conformance/SimpleRestJson/smithy-build.json
@@ -6,7 +6,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.5.0-SNAPSHOT",
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.6.0-SNAPSHOT",
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       "com.disneystreaming.alloy:alloy-protocol-tests:0.3.38"
     ]

--- a/website/src/content/docs/contributing/releasing.md
+++ b/website/src/content/docs/contributing/releasing.md
@@ -18,13 +18,13 @@ GitHub release tags should match the package version with a `v` prefix.
 
 Example:
 
-- release tag: `v0.5.0`
-- package version: `0.5.0`
+- release tag: `v0.6.0`
+- package version: `0.6.0`
 
 ## GitHub Release Flow
 
 1. In GitHub, create a new release.
-2. Create a new tag using the `v<package-version>` format (e.g. `v0.5.0`).
+2. Create a new tag using the `v<package-version>` format (e.g. `v0.6.0`).
 3. Publish the release.
 
 Publishing the GitHub release triggers the workflow in `.github/workflows/release.yml`,

--- a/website/src/content/docs/guides/distributing-contracts.md
+++ b/website/src/content/docs/guides/distributing-contracts.md
@@ -128,7 +128,7 @@ dependencies automatically:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.5.0" />
+  <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.6.0" />
   <PackageReference Include="MyService.Contracts" Version="1.0.0" />
 </ItemGroup>
 ```

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -32,7 +32,7 @@ ASP.NET Core's static file middleware can serve it.
 Add `NSmithy.Server.AspNetCore.Docs` to your server project:
 
 ```xml
-<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.5.0" />
+<PackageReference Include="NSmithy.Server.AspNetCore.Docs" Version="0.6.0" />
 ```
 
 This package provides the `MapSmithyOpenApi()` and `MapSmithyDocs()` extension


### PR DESCRIPTION
Bumps all dev versions `0.5.0-SNAPSHOT` → `0.6.0-SNAPSHOT` (`Directory.Build.props`, `codegen/build.gradle.kts`, `NSmithy.MSBuild` targets defaults, examples, conformance `smithy-build.json` files), template and website docs package pins `0.5.0` → `0.6.0`, and adds the 0.6.0 changelog section covering #97 (template fixes + rpcv2Cbor protocol option), #98/#99 (examples rework), and #100 (`DebugInterceptor`).

Verified with `just build` after publishing the 0.6.0-SNAPSHOT codegen JAR to the local Maven cache: build succeeded with 0 warnings, 0 errors.

After merging: create a GitHub release with tag `v0.6.0` to trigger the publish workflow.
