### PR TITLE
style(landing): remove scroll reveals and kickers; widgets click-to-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 
 **[Docs](https://thomaslaich.github.io/smithy-dotnet/)** · **[Examples](examples/README.md)** · **[Design Docs](designs/README.md)** · **[smithy.io](https://smithy.io)**
 
-NSmithy is a .NET toolkit that turns a [Smithy](https://smithy.io) model into idiomatic C# at build time. From a single contract you get typed clients, server scaffolding, and shared model types, fully integrated into your MSBuild workflow.
+NSmithy is a .NET toolkit that turns a [Smithy](https://smithy.io) model into idiomatic C# at build time.
 
 ## Features
 
-- **Contract-first**: The Smithy model is the source of truth. NSmithy generates C# model types, typed clients, and ASP.NET Core server handlers from it.
-- **Protocol-agnostic**: The same model can target multiple protocols and wire formats; switching protocols requires no changes to client or server code.
+- **Contract-first**: The Smithy model is the source of truth. NSmithy generates C# model types, clients, and ASP.NET Core server stubs from it.
+- **Protocol-agnostic**: The same model can target multiple protocols; switching protocols requires no changes to client or server code.
 - **Part of the Smithy ecosystem**: A .NET service built with NSmithy can be called from clients generated for Java, TypeScript, Python, Go, Rust, Swift, and more, and vice versa.
-- **Smithy-native architecture**: Follows Smithy's official [code generator guidance](https://smithy.io/2.0/guides/building-codegen/index.html), with a clear boundary between generated code and runtime libraries.
 - **Protocol support**: REST JSON, REST XML, AWS JSON, RPC v2 CBOR, and native gRPC.
 - **Streaming support**: Event streaming, bidirectional streaming, and streaming blob payloads.
+- **Smithy-native architecture**: Follows Smithy's official [code generator guidance](https://smithy.io/2.0/guides/building-codegen/index.html).
 - **Conformance-tested**: Tested against official Smithy, AWS, and alloy conformance suites.
 
 ## Development

--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -42,36 +42,6 @@ const langs = [
 ];
 ---
 
-<script is:inline>
-  // Scroll reveal: add `reveal-ready` synchronously (before content paints) so
-  // .reveal elements start hidden without a flash, then reveal as they enter view.
-  (function () {
-    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    document.documentElement.classList.add('reveal-ready');
-    function init() {
-      var els = document.querySelectorAll('.reveal');
-      if (!('IntersectionObserver' in window)) {
-        els.forEach(function (el) { el.classList.add('is-visible'); });
-        return;
-      }
-      var io = new IntersectionObserver(
-        function (entries) {
-          entries.forEach(function (e) {
-            if (e.isIntersecting) {
-              e.target.classList.add('is-visible');
-              io.unobserve(e.target);
-            }
-          });
-        },
-        { threshold: 0.1, rootMargin: '0px 0px -8% 0px' }
-      );
-      els.forEach(function (el) { io.observe(el); });
-    }
-    if (document.readyState !== 'loading') init();
-    else document.addEventListener('DOMContentLoaded', init);
-  })();
-</script>
-
 <div class="nsl not-content">
   <!-- Header -->
   <header class="nsl-header">
@@ -96,19 +66,19 @@ const langs = [
   <section class="nsl-hero">
     <div class="nsl-hero-inner">
       <div class="nsl-hero-copy">
-        <a class="nsl-badge reveal" href="https://smithy.io">
+        <a class="nsl-badge" href="https://smithy.io">
           Built on the Smithy IDL&nbsp;·&nbsp;smithy.io <span aria-hidden="true">↗</span>
         </a>
-        <h1 class="nsl-h1 reveal" style="--reveal-delay: 60ms">Smithy code generation for&nbsp;.NET</h1>
-        <p class="nsl-lead reveal" style="--reveal-delay: 120ms">
+        <h1 class="nsl-h1">Smithy code generation for&nbsp;.NET</h1>
+        <p class="nsl-lead">
           NSmithy generates typed servers, clients, and API documentation for .NET from a single
           Smithy model. Code generation runs as part of <code>dotnet build</code>.
         </p>
-        <div class="nsl-hero-actions reveal" style="--reveal-delay: 180ms">
+        <div class="nsl-hero-actions">
           <a class="nsl-btn nsl-btn-primary" href={intro}>Get Started</a>
           <a class="nsl-btn nsl-btn-ghost" href={repo}>View on GitHub</a>
         </div>
-        <div class="nsl-chips reveal" style="--reveal-delay: 240ms">
+        <div class="nsl-chips">
           <span class="nsl-chip">REST</span>
           <span class="nsl-chip">JSON-RPC</span>
           <span class="nsl-chip">CBOR-RPC</span>
@@ -122,30 +92,27 @@ const langs = [
 
   <!-- Workflow -->
   <section id="workflow" class="nsl-section">
-    <div class="nsl-sechead reveal">
-      <div class="nsl-kicker">The workflow</div>
+    <div class="nsl-sechead">
       <h2 class="nsl-h2">From model to runtime</h2>
       <p class="nsl-secp">Describe operations, shapes, and traits once. <code>dotnet&nbsp;build</code> emits the server stub, the client, and the docs.</p>
     </div>
-    <div class="reveal"><Walkthrough /></div>
+    <div><Walkthrough /></div>
   </section>
 
   <!-- Protocols -->
   <section id="protocols" class="nsl-section">
-    <div class="nsl-sechead nsl-sechead-wide reveal">
-      <div class="nsl-kicker">Protocol agnostic</div>
+    <div class="nsl-sechead nsl-sechead-wide">
       <h2 class="nsl-h2">The protocol is a trait on the model</h2>
       <p class="nsl-secp">Handler and client code stay the same. Changing the protocol trait on the service changes the wire format — REST, JSON-RPC, binary CBOR, or gRPC over HTTP/2.</p>
     </div>
-    <div class="reveal"><ProtocolSwitch /></div>
+    <div><ProtocolSwitch /></div>
   </section>
 
   <!-- Ecosystem -->
   <section id="ecosystem" class="nsl-section nsl-eco">
-    <div class="nsl-kicker reveal">Cross-ecosystem</div>
-    <h2 class="nsl-h2 reveal" style="--reveal-delay: 60ms">Part of the Smithy ecosystem</h2>
-    <p class="nsl-secp nsl-eco-p reveal" style="--reveal-delay: 120ms">Smithy is the IDL behind AWS's public APIs. The same model works with the official Smithy code generators for other languages.</p>
-    <div class="nsl-langs reveal" style="--reveal-delay: 180ms">
+    <h2 class="nsl-h2">Part of the Smithy ecosystem</h2>
+    <p class="nsl-secp nsl-eco-p">Smithy is the IDL behind AWS's public APIs. The same model works with the official Smithy code generators for other languages.</p>
+    <div class="nsl-langs">
       {
         langs.map((l) => (
           <a
@@ -166,7 +133,7 @@ const langs = [
     <div class="nsl-cards">
       {
         features.map((f, i) => (
-          <div class="nsl-card reveal" style={`--reveal-delay: ${(i % 3) * 60}ms`}>
+          <div class="nsl-card">
             <span class="nsl-card-mark" />
             <h3 class="nsl-card-t">{f.t}</h3>
             <p class="nsl-card-d" set:html={f.d} />
@@ -178,9 +145,8 @@ const langs = [
 
   <!-- Docs -->
   <section class="nsl-section">
-    <div class="nsl-docs reveal">
+    <div class="nsl-docs">
       <div>
-        <div class="nsl-kicker">Documentation</div>
         <h2 class="nsl-h2 nsl-docs-h">Generated API documentation</h2>
         <p class="nsl-secp nsl-docs-p">
           <code>app.MapSmithyOpenApi()</code> mounts an interactive Scalar explorer;
@@ -210,7 +176,7 @@ const langs = [
 
   <!-- CTA -->
   <section class="nsl-section">
-    <div class="nsl-cta reveal">
+    <div class="nsl-cta">
       <div class="nsl-cta-inner">
         <h2 class="nsl-cta-h">Get started</h2>
         <p class="nsl-cta-p">The quick start walks through modeling, building, and calling a small service.</p>
@@ -267,29 +233,6 @@ const langs = [
     --accentText: #5b35e0;
     --accentSoft: rgba(109, 74, 255, 0.09);
     --pill: #f1f1f5;
-  }
-
-  /* ── Scroll reveal (deliberately subtle: short rise, gentle fade) ────────── */
-  .reveal {
-    transition:
-      opacity 0.5s ease-out,
-      transform 0.5s ease-out;
-    transition-delay: var(--reveal-delay, 0s);
-  }
-  html.reveal-ready .reveal {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  html.reveal-ready .reveal.is-visible {
-    opacity: 1;
-    transform: none;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .reveal {
-      opacity: 1 !important;
-      transform: none !important;
-      transition: none !important;
-    }
   }
 
   /* ── Neutralise Starlight chrome on the landing page only ────────────────── */
@@ -546,14 +489,6 @@ const langs = [
   }
   .nsl-sechead-wide {
     max-width: 740px;
-  }
-  .nsl-kicker {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 12px;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--accentText);
-    margin-bottom: 14px;
   }
   .nsl-h2 {
     font-family: 'Space Grotesk', sans-serif;

--- a/website/src/components/landing/ProtocolSwitch.astro
+++ b/website/src/components/landing/ProtocolSwitch.astro
@@ -2,8 +2,8 @@
 /**
  * ProtocolSwitch — "The protocol is a trait on the model" widget.
  * Ported from the Claude Design "ProtocolSwitch.dc.html". The same GetForecast
- * operation rendered across four protocols; auto-cycles every 4.2s, pauses on
- * hover. Always-dark code panel (does not follow the page theme).
+ * operation rendered across four protocols; click the tabs to switch.
+ * Always-dark code panel (does not follow the page theme).
  */
 type Proto = { name: string; sub: string; cap: string; req: string; res: string };
 
@@ -54,7 +54,7 @@ function hl(code: string): string {
 const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.res) }));
 ---
 
-<div class="psw" data-cycle="4200">
+<div class="psw">
   <div class="psw__bar">
     <span class="psw__diamond"></span>
     <span class="psw__op">GetForecast</span>
@@ -98,9 +98,6 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
   </div>
 
   <div class="psw__foot">
-    <div class="psw__dots">
-      {panels.map((_, i) => <button type="button" class={`psw__dot${i === 0 ? ' is-active' : ''}`} data-idx={i} aria-label={`Protocol ${i + 1}`} />)}
-    </div>
     {
       panels.map((p, i) => (
         <span class={`psw__cap${i === 0 ? ' is-active' : ''}`} data-idx={i} hidden={i !== 0}>
@@ -196,8 +193,8 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
   }
 
   /* Panels — all stacked in one grid cell so the widget height is fixed to the
-     tallest protocol and never jumps as it auto-cycles. On mobile the auto-cycle
-     is disabled and this stacking is dropped (see the stacked media query). */
+     tallest protocol and never jumps as the visitor switches. On mobile this
+     stacking is dropped (see the stacked media query). */
   .psw__panels {
     display: grid;
   }
@@ -209,7 +206,7 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
     visibility: hidden;
     pointer-events: none;
   }
-  /* Footer: carousel dots + caption (matches the Walkthrough widget) */
+  /* Footer: caption for the active protocol (matches the Walkthrough widget) */
   .psw__foot {
     display: flex;
     align-items: center;
@@ -217,26 +214,6 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
     padding: 11px 15px;
     border-top: 1px solid #1b1b25;
     background: #0e0e15;
-  }
-  .psw__dots {
-    display: flex;
-    gap: 7px;
-    align-items: center;
-    flex: none;
-  }
-  .psw__dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 4px;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    background: #2c2c3a;
-    transition: all 0.35s ease;
-  }
-  .psw__dot.is-active {
-    width: 22px;
-    background: #6d4aff;
   }
   .psw__cap {
     margin: 0;
@@ -302,8 +279,8 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
       border-left: none;
       border-top: 1px solid #17171f;
     }
-    /* Stacked: auto-cycle is off (see script), so the panel follows the active
-       protocol's natural height instead of reserving the tallest one's. */
+    /* Stacked: the panel follows the active protocol's natural height instead
+       of reserving the tallest one's. */
     .psw__panel:not(.is-active) {
       display: none;
     }
@@ -314,25 +291,15 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
   document.querySelectorAll<HTMLElement>('.psw').forEach((root) => {
     const tabs = Array.from(root.querySelectorAll<HTMLElement>('.psw__tab'));
     const panels = Array.from(root.querySelectorAll<HTMLElement>('.psw__panel'));
-    const dots = Array.from(root.querySelectorAll<HTMLElement>('.psw__dot'));
     const caps = Array.from(root.querySelectorAll<HTMLElement>('.psw__cap'));
-    const interval = Number(root.dataset.cycle || '4200');
-    // On mobile the request/response columns stack vertically; the panels then
-    // take their natural height, so auto-cycling would make the page jump. Skip
-    // the auto-advance while stacked (manual tab/dot taps still work).
-    const stacked = window.matchMedia?.('(max-width: 40rem)');
-    let idx = 0;
-    let paused = false;
 
     function show(n: number) {
-      idx = n;
       tabs.forEach((t, i) => {
         const on = i === n;
         t.classList.toggle('is-active', on);
         t.setAttribute('aria-selected', on ? 'true' : 'false');
       });
       panels.forEach((p, i) => p.classList.toggle('is-active', i === n));
-      dots.forEach((d, i) => d.classList.toggle('is-active', i === n));
       caps.forEach((c, i) => {
         const on = i === n;
         c.classList.toggle('is-active', on);
@@ -341,19 +308,6 @@ const panels = protocols.map((p) => ({ ...p, reqHtml: hl(p.req), resHtml: hl(p.r
       });
     }
 
-    [...tabs, ...dots].forEach((el, i) =>
-      el.addEventListener('click', () => {
-        paused = true;
-        show(i % tabs.length);
-      })
-    );
-    root.addEventListener('mouseenter', () => (paused = true));
-    root.addEventListener('mouseleave', () => (paused = false));
-
-    if (!window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setInterval(() => {
-        if (!paused && !stacked?.matches) show((idx + 1) % tabs.length);
-      }, interval);
-    }
+    tabs.forEach((el, i) => el.addEventListener('click', () => show(i)));
   });
 </script>

--- a/website/src/components/landing/Walkthrough.astro
+++ b/website/src/components/landing/Walkthrough.astro
@@ -2,8 +2,8 @@
 /**
  * Walkthrough — "From model to runtime" widget.
  * Ported from the Claude Design "Walkthrough.dc.html" (forge variant). Source
- * weather.smithy on the left forges into a tabbed Server/Client/Docs output;
- * auto-cycles the 3 outputs every 3.6s, pauses on hover. Always-dark panel.
+ * weather.smithy on the left forges into a tabbed Server/Client output;
+ * click the tabs to switch. Always-dark panel.
  */
 const model = `$version: "2"
 namespace example.weather
@@ -101,7 +101,7 @@ const modelHtml = hl(model, 'smithy');
 const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
 ---
 
-<div class="wt" data-cycle="3600">
+<div class="wt">
   <div class="wt__bar">
     <span class="wt__diamond"></span>
     <span class="wt__title">smithy&nbsp;build</span>
@@ -144,9 +144,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
   </div>
 
   <div class="wt__foot">
-    <div class="wt__dots">
-      {tabs.map((_, i) => <button type="button" class={`wt__dot${i === 0 ? ' is-active' : ''}`} data-idx={i} aria-label={`Step ${i + 1}`} />)}
-    </div>
     {
       tabs.map((t, i) => (
         <span class={`wt__cap${i === 0 ? ' is-active' : ''}`} data-idx={i} hidden={i !== 0}>
@@ -298,9 +295,9 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
   }
 
   /* Output code panels — all stacked in one grid cell so the widget height is
-     fixed to the tallest tab (Server) and never jumps as it auto-cycles or the
-     visitor switches between Server and Client. On mobile the auto-cycle is
-     disabled and this stacking is dropped (see the stacked media query below). */
+     fixed to the tallest tab (Server) and never jumps as the visitor switches
+     between Server and Client. On mobile this stacking is dropped (see the
+     stacked media query below). */
   .wt__panels {
     display: grid;
   }
@@ -334,7 +331,7 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     border-radius: 4px;
   }
 
-  /* Footer: dots + caption */
+  /* Footer: caption for the active tab */
   .wt__foot {
     display: flex;
     align-items: center;
@@ -342,26 +339,6 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
     padding: 11px 15px;
     border-top: 1px solid #1b1b25;
     background: #0e0e15;
-  }
-  .wt__dots {
-    display: flex;
-    gap: 7px;
-    align-items: center;
-    flex: none;
-  }
-  .wt__dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 4px;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    background: #2c2c3a;
-    transition: all 0.35s ease;
-  }
-  .wt__dot.is-active {
-    width: 22px;
-    background: #6d4aff;
   }
   .wt__cap {
     font-size: 11.5px;
@@ -396,8 +373,8 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
       border-left: none;
       border-top: 1px solid #17171f;
     }
-    /* Stacked: auto-cycle is off (see script), so the output follows the active
-       tab's natural height instead of reserving the tallest tab's height. */
+    /* Stacked: the output follows the active tab's natural height instead of
+       reserving the tallest tab's height. */
     .wt__outcode:not(.is-active) {
       display: none;
     }
@@ -408,18 +385,9 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
   document.querySelectorAll<HTMLElement>('.wt').forEach((root) => {
     const tabs = Array.from(root.querySelectorAll<HTMLElement>('.wt__tab'));
     const outs = Array.from(root.querySelectorAll<HTMLElement>('.wt__outcode'));
-    const dots = Array.from(root.querySelectorAll<HTMLElement>('.wt__dot'));
     const caps = Array.from(root.querySelectorAll<HTMLElement>('.wt__cap'));
-    const interval = Number(root.dataset.cycle || '3600');
-    // On mobile the source/output sections stack vertically; the panels then
-    // take their natural height, so auto-cycling would make the page jump. Skip
-    // the auto-advance while stacked (manual tab/dot taps still work).
-    const stacked = window.matchMedia?.('(max-width: 52rem)');
-    let idx = 0;
-    let paused = false;
 
     function show(n: number) {
-      idx = n;
       const toggle = (els: HTMLElement[], hideAttr: boolean) =>
         els.forEach((el, i) => {
           const on = i === n;
@@ -432,23 +400,9 @@ const tabsHtml = tabs.map((t) => ({ ...t, codeHtml: hl(t.code, 'csharp') }));
       tabs.forEach((t, i) => t.setAttribute('aria-selected', i === n ? 'true' : 'false'));
       toggle(tabs, false);
       toggle(outs, false);
-      toggle(dots, false);
       toggle(caps, true);
     }
 
-    [...tabs, ...dots].forEach((el) =>
-      el.addEventListener('click', () => {
-        paused = true;
-        show(Number(el.dataset.idx));
-      })
-    );
-    root.addEventListener('mouseenter', () => (paused = true));
-    root.addEventListener('mouseleave', () => (paused = false));
-
-    if (!window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setInterval(() => {
-        if (!paused && !stacked?.matches) show((idx + 1) % tabs.length);
-      }, interval);
-    }
+    tabs.forEach((el) => el.addEventListener('click', () => show(Number(el.dataset.idx))));
   });
 </script>

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -8,7 +8,7 @@ by AWS for describing services. A Smithy model defines an API's operations,
 input and output shapes, errors, and traits. Tooling can then use that model to
 generate clients, servers, documentation, and protocol-specific bindings. Smithy
 is used for AWS public APIs and has generators for Java, Kotlin, TypeScript,
-Python, Rust, Swift, Go, Scala, Ruby, C#, and more.
+Python, Rust, Swift, Go, Scala, Ruby, and now C#.
 
 ## Why Smithy?
 
@@ -23,7 +23,7 @@ NSmithy brings Smithy code generation into .NET projects. It integrates with
 MSBuild, so `dotnet build` also runs Smithy codegen. From your `.smithy` model
 files it generates:
 
-- **Typed C# records** for all shapes (structures, unions, enums).
+- **C# records** for all shapes (structures, unions, enums).
 - **Typed async client interfaces and implementations** per service.
 - **ASP.NET Core minimal API handler interfaces and routing adapters** per service.
 


### PR DESCRIPTION
Tones down the landing page's marketing conventions while keeping layout, branding, and content:

- **Scroll reveals removed**: the IntersectionObserver fade-in script, all `reveal` classes / `--reveal-delay` styles, and the reveal CSS block are gone; content renders immediately.
- **Kicker labels removed**: the all-caps eyebrow labels ("THE WORKFLOW", "PROTOCOL AGNOSTIC", "CROSS-ECOSYSTEM", "DOCUMENTATION") and their CSS.
- **Widgets are click-to-switch**: Walkthrough and ProtocolSwitch no longer auto-cycle; tabs switch on click, and the carousel dots (now-redundant cycle affordance) are removed from both footers. The hover-pause and mobile cycle-suppression logic goes with them, which simplifies both scripts considerably.

Copy, hero, feature cards, glows, and the violet accent are unchanged.

Verified with a production build (31 pages, no errors) and a full-page headless screenshot: layout intact, no leftover spacing where kickers were, widget footers show the active caption only.
