### PR TITLE
feat: bundle Smithy codegen dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,9 @@ jobs:
         run: devenv shell -- just publish-codegen "${{ steps.version.outputs.version }}"
       - name: Build, test, and pack
         # NSmithy.* .nupkg version comes from the release tag (overrides
-        # VersionPrefix/VersionSuffix in Directory.Build.props). Tests still
-        # build against the local SNAPSHOT codegen JAR published to ~/.m2 by
-        # `just codegen` so test smithy-build.json files don't need to be
-        # rewritten at release time.
+        # VersionPrefix/VersionSuffix in Directory.Build.props). `just codegen`
+        # stages the bundled Maven repo used by in-repo builds; conformance-only
+        # Smithy protocol-test artifacts are still resolved from Maven Central.
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: devenv shell -- just ci

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -5,7 +5,13 @@
 // implementations. See codegen/README.md for the rationale and how it relates
 // to docs/architecture/hybrid-codegen.md.
 
+import java.io.File
+import java.security.MessageDigest
 import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.maven.MavenModule
+import org.gradle.maven.MavenPomArtifact
 
 plugins {
     `java-library`
@@ -73,5 +79,96 @@ subprojects {
     // shipped generator code.
     tasks.named<JavaCompile>("compileTestJava") {
         options.errorprone.isEnabled.set(false)
+    }
+}
+
+// ============================================================================
+// Bundled Maven repo for offline codegen (consumed by NSmithy.MSBuild).
+//
+// Assembles the codegen toolchain (smithy-csharp-codegen + smithy-proto-codegen)
+// and the first-party Smithy trait packages our protocols need, plus their full
+// runtime closure (JARs *and* POMs), into a Maven-layout directory. NSmithy.MSBuild
+// points the Smithy CLI at it via SMITHY_MAVEN_REPOS, so `smithy build` resolves the
+// codegen plugin and model traits from local files — Smithy's own offline mechanism,
+// which (unlike a bare classpath) loads the build plugin correctly.
+//
+//   gradle :bundleMavenRepo   -> codegen/build/maven-bundle
+// ============================================================================
+repositories {
+    mavenCentral()
+    mavenLocal() // our plugins are resolved here (published just below)
+}
+
+val codegenBundle: Configuration by configurations.creating
+
+dependencies {
+    val smithyVer = property("smithyVersion") as String
+    codegenBundle("io.github.thomaslaich.nsmithy:smithy-csharp-codegen:${project.version}")
+    codegenBundle("io.github.thomaslaich.nsmithy:smithy-proto-codegen:${project.version}")
+    codegenBundle("software.amazon.smithy:smithy-aws-traits:$smithyVer")
+    codegenBundle("software.amazon.smithy:smithy-protocol-traits:$smithyVer")
+    codegenBundle("software.amazon.smithy:smithy-docgen:$smithyVer")
+    codegenBundle("software.amazon.smithy:smithy-openapi:$smithyVer")
+    codegenBundle("com.disneystreaming.alloy:alloy-core:0.3.38")
+}
+
+tasks.register("bundleMavenRepo") {
+    // Resolve our plugins from ~/.m2 at the current version, so the bundle never
+    // depends on a Maven Central publish having propagated.
+    dependsOn(":smithy-csharp-codegen:publishToMavenLocal", ":smithy-proto-codegen:publishToMavenLocal")
+    val conf = codegenBundle
+    val outDir = layout.buildDirectory.dir("maven-bundle")
+    inputs.files(conf)
+    outputs.dir(outDir)
+    doLast {
+        val repo = outDir.get().asFile
+        repo.deleteRecursively()
+        repo.mkdirs()
+
+        fun artifactDir(group: String, name: String, ver: String) =
+            repo.resolve("${group.replace('.', '/')}/$name/$ver").apply { mkdirs() }
+
+        // Artifact JARs.
+        conf.resolvedConfiguration.resolvedArtifacts.forEach { art ->
+            val id = art.moduleVersion.id
+            val classifier = art.classifier?.let { "-$it" } ?: ""
+            art.file.copyTo(
+                artifactDir(id.group, id.name, id.version)
+                    .resolve("${id.name}-${id.version}$classifier.${art.extension ?: "jar"}"),
+                overwrite = true,
+            )
+        }
+
+        // POMs — the resolver reads them to reconstruct the dependency graph.
+        val componentIds = conf.incoming.resolutionResult.allComponents
+            .mapNotNull { it.id as? ModuleComponentIdentifier }
+        val pomResult = dependencies.createArtifactResolutionQuery()
+            .forComponents(componentIds)
+            .withArtifacts(MavenModule::class.java, MavenPomArtifact::class.java)
+            .execute()
+        pomResult.resolvedComponents.forEach { comp ->
+            val id = comp.id as? ModuleComponentIdentifier ?: return@forEach
+            comp.getArtifacts(MavenPomArtifact::class.java).forEach { r ->
+                if (r is ResolvedArtifactResult) {
+                    r.file.copyTo(
+                        artifactDir(id.group, id.module, id.version)
+                            .resolve("${id.module}-${id.version}.pom"),
+                        overwrite = true,
+                    )
+                }
+            }
+        }
+        // SHA-1 checksums alongside each artifact so the resolver doesn't warn about
+        // being unable to verify integrity.
+        repo.walkTopDown()
+            .filter { it.isFile && (it.extension == "jar" || it.extension == "pom") }
+            .forEach { f ->
+                val hex = MessageDigest.getInstance("SHA-1")
+                    .digest(f.readBytes())
+                    .joinToString("") { b -> "%02x".format(b.toInt() and 0xff) }
+                File(f.parentFile, "${f.name}.sha1").writeText(hex)
+            }
+
+        logger.lifecycle("Bundled Maven repo -> ${repo.absolutePath}")
     }
 }

--- a/codegen/smithy-csharp-codegen/build.gradle.kts
+++ b/codegen/smithy-csharp-codegen/build.gradle.kts
@@ -46,7 +46,7 @@ mavenPublishing {
     coordinates(group.toString(), "smithy-csharp-codegen", version.toString())
 
     pom {
-        name.set("NSmithy smithy-csharp-codegen Smithy plugin")
+        name.set("NSmithy C# Codegen Plugin")
         description.set("Smithy build plugin that generates C# client/server code for Smithy models. Consumed by NSmithy.MSBuild via the Smithy CLI.")
         url.set("https://github.com/thomaslaich/smithy-dotnet")
         inceptionYear.set("2026")

--- a/codegen/smithy-proto-codegen/build.gradle.kts
+++ b/codegen/smithy-proto-codegen/build.gradle.kts
@@ -42,7 +42,7 @@ mavenPublishing {
     coordinates(group.toString(), "smithy-proto-codegen", version.toString())
 
     pom {
-        name.set("NSmithy smithy-proto-codegen Smithy plugin")
+        name.set("NSmithy Proto Codegen Plugin")
         description.set("Smithy build plugin that generates proto3 .proto files for services annotated with alloy's @grpc trait.")
         url.set("https://github.com/thomaslaich/smithy-dotnet")
         inceptionYear.set("2026")

--- a/examples/aws-localstack/smithy-build.json
+++ b/examples/aws-localstack/smithy-build.json
@@ -3,7 +3,6 @@
   "sources": ["model"],
   "maven": {
     "repositories": [
-      { "url": "file://~/.m2/repository" },
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -3,7 +3,6 @@
   "sources": ["../java/smithy/model/java-hello.smithy"],
   "maven": {
     "repositories": [
-      { "url": "file://~/.m2/repository" },
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [

--- a/justfile
+++ b/justfile
@@ -12,12 +12,15 @@ fmt:
 check-format:
     treefmt --ci
 
-# Build & publish the Smithy → C# codegen JAR to the local Maven cache so that
-# `smithy build` (invoked from each .csproj via NSmithy.MSBuild) can resolve
-
-# `io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.1.0-SNAPSHOT` from ~/.m2.
+# Stage the bundled Maven repo consumed by NSmithy.MSBuild during `dotnet build`.
 codegen:
-    cd codegen && gradle :smithy-csharp-codegen:clean :smithy-csharp-codegen:publishToMavenLocal :smithy-proto-codegen:clean :smithy-proto-codegen:publishToMavenLocal
+    # bundleMavenRepo builds the plugins and assembles the offline Maven bundle
+    # (it depends on publishToMavenLocal). Staging it into tools/maven-repo means
+    # in-repo builds (conformance/examples) resolve NSmithy codegen from the bundle
+    # too, so no smithy-build.json needs a ~/.m2 repository entry.
+    cd codegen && gradle bundleMavenRepo
+    find packages/NSmithy.MSBuild/tools/maven-repo -mindepth 1 -not -name .gitignore -delete
+    cp -R codegen/build/maven-bundle/. packages/NSmithy.MSBuild/tools/maven-repo/
 
 # Publish the codegen JARs to Maven Central via the Sonatype Central Portal.
 # Used by the release workflow; expects MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD
@@ -35,6 +38,9 @@ test:
     dotnet test NSmithy.slnx --configuration Release --no-build --disable-build-servers
 
 pack:
+    cd codegen && gradle bundleMavenRepo ${VERSION:+-Pversion=$VERSION}
+    find packages/NSmithy.MSBuild/tools/maven-repo -mindepth 1 -not -name .gitignore -delete
+    cp -R codegen/build/maven-bundle/. packages/NSmithy.MSBuild/tools/maven-repo/
     bash packages/NSmithy.MSBuild/tools/download-smithy-cli.sh
     dotnet pack NSmithy.slnx --configuration Release --no-build --output artifacts/packages ${VERSION:+-p:Version=$VERSION}
 

--- a/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
+++ b/packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj
@@ -58,6 +58,20 @@
       PackagePath="tools/smithy-cli/windows-x64/"
       Condition="Exists('tools/smithy-cli/windows-x64/bin/smithy.bat')"
     />
+
+    <!--
+      Bundled Maven repo — populated by `gradle :bundleMavenRepo` (run from `just pack`).
+      The codegen plugin + first-party trait packages + their runtime closure, in Maven
+      layout (JARs and POMs). The targets file points `smithy build` at it via
+      SMITHY_MAVEN_REPOS so codegen resolves from local files instead of the network.
+      Platform-independent, so bundled once (unlike the per-platform CLI).
+    -->
+    <None
+      Include="tools/maven-repo/**/*"
+      Exclude="tools/maven-repo/.gitignore"
+      Pack="true"
+      PackagePath="tools/maven-repo/"
+    />
   </ItemGroup>
 
   <!--
@@ -138,5 +152,16 @@
         PackagePath="buildTransitive/NSmithy.MSBuild.targets"
       />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_NSmithyValidateBundledMavenRepo" BeforeTargets="Pack">
+    <ItemGroup>
+      <_NSmithyBundledMavenRepoJar Include="$(MSBuildProjectDirectory)/tools/maven-repo/**/*.jar" />
+      <_NSmithyBundledMavenRepoPom Include="$(MSBuildProjectDirectory)/tools/maven-repo/**/*.pom" />
+    </ItemGroup>
+    <Error
+      Text="NSmithy: tools/maven-repo is empty. Run `just pack` or `cd codegen &amp;&amp; gradle bundleMavenRepo` and copy codegen/build/maven-bundle into packages/NSmithy.MSBuild/tools/maven-repo before packing NSmithy.MSBuild."
+      Condition="'@(_NSmithyBundledMavenRepoJar)' == '' or '@(_NSmithyBundledMavenRepoPom)' == ''"
+    />
   </Target>
 </Project>

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -273,6 +273,17 @@
     <SmithyCliPath>smithy</SmithyCliPath>
   </PropertyGroup>
 
+  <!-- ================================================================
+       Bundled Maven repo (populated by `gradle :bundleMavenRepo`, packed into
+       tools/maven-repo/). When present, codegen resolves the plugin + first-party
+       trait packages from it via SMITHY_MAVEN_REPOS against an isolated cache —
+       Smithy's own offline mechanism. Absent (e.g. falling back to `smithy` on PATH
+       in-repo), resolution uses the config's maven block as before.
+       ================================================================ -->
+  <PropertyGroup>
+    <_SmithyBundledMavenRepo>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/maven-repo'))</_SmithyBundledMavenRepo>
+  </PropertyGroup>
+
   <PropertyGroup>
     <SmithyGenerateServer Condition="'$(SmithyGenerateServer)' == ''">true</SmithyGenerateServer>
     <SmithyEmitGeneratedFiles Condition="'$(SmithyEmitGeneratedFiles)' == ''"
@@ -281,16 +292,6 @@
     <SmithyStampFile Condition="'$(SmithyStampFile)' == ''"
       >$(SmithyBuildOutputPath)NSmithy.Generated.stamp</SmithyStampFile
     >
-    <SmithyMavenLocalRepository
-      Condition="'$(SmithyMavenLocalRepository)' == '' and '$(USERPROFILE)' != ''"
-      >$(USERPROFILE)/.m2/repository</SmithyMavenLocalRepository
-    >
-    <SmithyMavenLocalRepository
-      Condition="'$(SmithyMavenLocalRepository)' == '' and '$(HOME)' != ''"
-      >$(HOME)/.m2/repository</SmithyMavenLocalRepository
-    >
-    <_SmithyCSharpCodegenJar>$(SmithyMavenLocalRepository)/io/github/thomaslaich/nsmithy/smithy-csharp-codegen/$(SmithyCSharpCodegenVersion)/smithy-csharp-codegen-$(SmithyCSharpCodegenVersion).jar</_SmithyCSharpCodegenJar>
-    <_SmithyProtoCodegenJar>$(SmithyMavenLocalRepository)/io/github/thomaslaich/nsmithy/smithy-proto-codegen/$(SmithyCSharpCodegenVersion)/smithy-proto-codegen-$(SmithyCSharpCodegenVersion).jar</_SmithyProtoCodegenJar>
     <SmithyBaseNamespace Condition="'$(SmithyBaseNamespace)' == ''"></SmithyBaseNamespace>
   </PropertyGroup>
 
@@ -300,13 +301,10 @@
       Exclude="$(MSBuildProjectDirectory)/obj/**;$(MSBuildProjectDirectory)/bin/**;$(SmithyBuildOutputPath)**"
     />
     <_SmithyGeneratorInput Include="$(SmithyBuildFile)" Condition="Exists('$(SmithyBuildFile)')" />
+    <!-- Rebuild when the bundled codegen plugin/traits change (e.g. package upgrade). -->
     <_SmithyGeneratorInput
-      Include="$(_SmithyCSharpCodegenJar)"
-      Condition="Exists('$(_SmithyCSharpCodegenJar)')"
-    />
-    <_SmithyGeneratorInput
-      Include="$(_SmithyProtoCodegenJar)"
-      Condition="'$(SmithyGrpc)' == 'true' and Exists('$(_SmithyProtoCodegenJar)')"
+      Include="$(_SmithyBundledMavenRepo)/**/*.jar"
+      Condition="Exists('$(_SmithyBundledMavenRepo)')"
     />
     <Watch Include="$(SmithyBuildFile)" Condition="Exists('$(SmithyBuildFile)')" />
     <Watch Include="@(_SmithyGeneratorInput)" />
@@ -416,8 +414,19 @@
     Outputs="$(SmithyStampFile)"
   >
     <MakeDir Directories="$(SmithyBuildOutputPath)" />
+    <!-- Point the CLI at the bundled Maven repo with an isolated cache so codegen
+         resolves the plugin + traits from local files. Only when the repo actually
+         holds jars (the dir itself is committed just to carry a .gitignore); otherwise
+         leave the CLI's default (network) resolution in place. -->
+    <ItemGroup>
+      <_SmithyBundleJar Include="$(_SmithyBundledMavenRepo)/**/*.jar" />
+    </ItemGroup>
+    <PropertyGroup Condition="'@(_SmithyBundleJar)' != ''">
+      <_SmithyMavenEnv>SMITHY_MAVEN_REPOS=$([System.Uri]::new('$(_SmithyBundledMavenRepo)').AbsoluteUri);SMITHY_MAVEN_CACHE=$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(IntermediateOutputPath)smithy-maven-cache'))</_SmithyMavenEnv>
+    </PropertyGroup>
     <Exec
       Command="&quot;$(SmithyCliPath)&quot; build --config &quot;$(SmithyBuildFile)&quot; --output &quot;$(SmithyBuildOutputPath.TrimEnd('/').TrimEnd('\\'))&quot; $(SmithyExtraArgs)"
+      EnvironmentVariables="$(_SmithyMavenEnv)"
       WorkingDirectory="$(MSBuildProjectDirectory)"
     />
     <Touch Files="$(SmithyStampFile)" AlwaysCreate="true" />

--- a/packages/NSmithy.MSBuild/tools/maven-repo/.gitignore
+++ b/packages/NSmithy.MSBuild/tools/maven-repo/.gitignore
@@ -1,0 +1,4 @@
+# Bundled Maven repo — run `gradle :bundleMavenRepo` (via `just pack`) to populate.
+# Included in the NuGet package but not committed to git.
+*
+!.gitignore

--- a/tests/Conformance/AwsJson/smithy-build.json
+++ b/tests/Conformance/AwsJson/smithy-build.json
@@ -3,9 +3,6 @@
   "maven": {
     "repositories": [
       {
-        "url": "file://~/.m2/repository"
-      },
-      {
         "url": "https://repo.maven.apache.org/maven2/"
       }
     ],

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -6,9 +6,6 @@
   "maven": {
     "repositories": [
       {
-        "url": "file://~/.m2/repository"
-      },
-      {
         "url": "https://repo.maven.apache.org/maven2/"
       }
     ],

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -3,9 +3,6 @@
   "maven": {
     "repositories": [
       {
-        "url": "file://~/.m2/repository"
-      },
-      {
         "url": "https://repo.maven.apache.org/maven2/"
       }
     ],

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -3,9 +3,6 @@
   "maven": {
     "repositories": [
       {
-        "url": "file://~/.m2/repository"
-      },
-      {
         "url": "https://repo.maven.apache.org/maven2/"
       }
     ],

--- a/tests/Conformance/SimpleRestJson/smithy-build.json
+++ b/tests/Conformance/SimpleRestJson/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "maven": {
     "repositories": [
-      { "url": "file://~/.m2/repository" },
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -86,6 +86,17 @@ Generated constructors do not implement full Smithy validation semantics.
 Generated C# nullability is authoritative, but external request binding and
 deserialization still need more protocol-aware runtime validation.
 
+## Extra Smithy Maven Dependencies Are External
+
+`NSmithy.MSBuild` bundles the Smithy CLI, the NSmithy codegen plugins, and the
+common Smithy/alloy trait dependencies used by the templates and examples. A
+project that declares additional `maven.dependencies` in `smithy-build.json`
+must make those artifacts available through its configured Maven repositories.
+
+The repository's conformance projects intentionally use official Smithy/AWS and
+alloy protocol-test artifacts from Maven Central; those test fixtures are not
+bundled into the consumer MSBuild package.
+
 ## Codec Performance And AOT Are Still Maturing
 
 The codecs (`NSmithy.Codecs.Json`, `Cbor`, `Xml`, `Proto`) are schema-driven —

--- a/website/src/content/docs/reference/msbuild.md
+++ b/website/src/content/docs/reference/msbuild.md
@@ -25,7 +25,7 @@ with the .NET toolchain.
 | `SmithyBuildOutputPath` | `$(IntermediateOutputPath)Smithy/` | Root directory for all Smithy build output. |
 | `SmithyStampFile` | `$(SmithyBuildOutputPath)NSmithy.Generated.stamp` | Incremental build stamp file. Smithy codegen is skipped when inputs have not changed since this file was last written. |
 | `SmithyEmitGeneratedFiles` | `false` | Show generated `.g.cs` files in IDE project views when `true`. |
-| `SmithyCliPath` | `smithy` | Smithy CLI executable. Resolved from `PATH` by default. |
+| `SmithyCliPath` | bundled CLI | Smithy CLI executable. Set this to override the bundled executable. |
 
 ### gRPC / Protobuf
 
@@ -79,6 +79,12 @@ NSmithy bundles the Smithy CLI (version 1.71.0) inside `NSmithy.MSBuild` and
 selects the correct platform binary automatically. No separate installation is
 required. The bundle is self-contained and includes a JRE, so Java does not
 need to be installed either.
+
+NSmithy.MSBuild also bundles the NSmithy Smithy codegen plugins plus the common
+Smithy and alloy trait/doc/openapi dependencies used by the templates and
+examples. Additional Maven dependencies declared in `smithy-build.json` are not
+mirrored into the package; they remain the consuming project's responsibility
+and may require access to the configured Maven repositories.
 
 Set `SmithyCliPath` to override the bundled binary with a specific executable,
 for example when testing against a different CLI version:


### PR DESCRIPTION
## Summary
- bundle the NSmithy codegen Maven repo into NSmithy.MSBuild packages
- stage the bundle from just codegen/pack and fail pack when the bundle is missing
- document that conformance protocol-test artifacts remain external Maven dependencies

## Validation
- just fmt
- dotnet msbuild packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj /t:_NSmithyValidateBundledMavenRepo /v:minimal