### PR TITLE
feat: add rpcv2cbor event streaming

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -92,7 +92,7 @@ public final class ClientGenerator implements Runnable {
     // callers selecting another declared protocol reference its namespace from their own code.
     writer.addImport(ProtocolSupport.runtimeProtocolNamespace(kinds.get(0)));
     if (operations.stream().anyMatch(op -> isEventStreamOperation(model, op))
-        && supportsEventStreamOperations()) {
+        && ProtocolSupport.declaredKinds(service).contains(Kind.GRPC)) {
       writer.addImport(RuntimeTypes.NSMITHY_PROTOCOLS_GRPC);
     }
 
@@ -857,7 +857,8 @@ public final class ClientGenerator implements Runnable {
   }
 
   private boolean supportsEventStreamOperations() {
-    return ProtocolSupport.declaredKinds(service).contains(Kind.GRPC);
+    return ProtocolSupport.declaredKinds(service).stream()
+        .anyMatch(kind -> kind == Kind.GRPC || kind == Kind.RPC_V2_CBOR);
   }
 
   private boolean isInputStreaming(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -162,7 +162,7 @@ public final class ServerGenerator implements Runnable {
               SchemaGenerator.serviceSchemaAccessor(context, service));
           for (OperationShape op : ops) {
             if (isEventStreamOperation(context.model(), op)) {
-              if (kind == Kind.GRPC) {
+              if (supportsEventStreamOperations(kind)) {
                 writeEventStreamProtocolField(sp, op);
               }
               continue;
@@ -188,8 +188,8 @@ public final class ServerGenerator implements Runnable {
                 writer.write("System.ArgumentNullException.ThrowIfNull(endpoints);");
                 writer.write("");
                 for (OperationShape op : ops) {
-                  if (isEventStreamOperation(context.model(), op) && kind != Kind.GRPC) {
-                    // Event streams are only served over gRPC today; other protocols skip them.
+                  if (isEventStreamOperation(context.model(), op)
+                      && !supportsEventStreamOperations(kind)) {
                     continue;
                   }
                   writeOperationMap(kind, op);
@@ -429,6 +429,10 @@ public final class ServerGenerator implements Runnable {
 
   private static String serviceContractName(String serviceTypeName) {
     return serviceTypeName.endsWith("Service") ? serviceTypeName : serviceTypeName + "Service";
+  }
+
+  private static boolean supportsEventStreamOperations(Kind kind) {
+    return kind == Kind.GRPC || kind == Kind.RPC_V2_CBOR;
   }
 
   private String opHandlerName(OperationShape op) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ All .NET projects are collected in a single solution, [`examples.slnx`](examples
 | [rest-json1](rest-json1/) | `aws.protocols#restJson1` | Weather service: resources, pagination, errors, retries, OpenTelemetry |
 | [simple-rest-json](simple-rest-json/) | `alloy#simpleRestJson` | Pizza Admin service: unions, enums, maps, errors, API-key auth |
 | [rpcv2cbor](rpcv2cbor/) | `smithy.protocols#rpcv2Cbor` | The rest-json1 Weather service over CBOR: resources, pagination, errors, retries |
+| [rpcv2cbor-streaming](rpcv2cbor-streaming/) | `smithy.protocols#rpcv2Cbor` | Bidirectional rpcv2Cbor event streaming (chat service) |
 | [grpc](grpc/) | `alloy.proto#grpc` | Library service over native gRPC (no protoc): proto codec features like sparse maps, oneOf unions, enums |
 | [grpc-streaming](grpc-streaming/) | `alloy.proto#grpc` | Bidirectional gRPC event streaming (chat service), with a `Grpc.Net` interop comparison |
 | [aws-localstack](aws-localstack/) | AWS JSON, restXml, restJson1 | Generated AWS clients with SigV4 signing against LocalStack |

--- a/examples/examples.slnx
+++ b/examples/examples.slnx
@@ -14,6 +14,11 @@
     <Project Path="rpcv2cbor/server/NSmithy.Examples.RpcV2Cbor.Server.csproj" />
     <Project Path="rpcv2cbor/client/NSmithy.Examples.RpcV2Cbor.Client.csproj" />
   </Folder>
+  <Folder Name="/rpcv2cbor-streaming/">
+    <Project Path="rpcv2cbor-streaming/contracts/RpcV2CborStreaming.Contracts.csproj" />
+    <Project Path="rpcv2cbor-streaming/server/NSmithy.Examples.RpcV2CborStreaming.Server.csproj" />
+    <Project Path="rpcv2cbor-streaming/client/NSmithy.Examples.RpcV2CborStreaming.Client.csproj" />
+  </Folder>
   <Folder Name="/grpc/">
     <Project Path="grpc/contracts/Library.Contracts.csproj" />
     <Project Path="grpc/server/NSmithy.Examples.Grpc.Server.csproj" />

--- a/examples/rpcv2cbor-streaming/README.md
+++ b/examples/rpcv2cbor-streaming/README.md
@@ -1,0 +1,38 @@
+# rpcv2Cbor Streaming Example
+
+This example demonstrates Smithy-modeled rpcv2Cbor event streaming with a small
+multi-client chat service.
+
+- `WatchRoom` is server streaming.
+- `UploadTranscript` is client streaming.
+- `Chat` is bidirectional streaming.
+
+## Run
+
+From the repository root, build and pack local packages:
+
+```bash
+just build
+just pack
+```
+
+Start the server. It defaults to port `5004` and serves cleartext HTTP/2 so the
+duplex stream can send and receive messages at the same time.
+
+```bash
+cd examples/rpcv2cbor-streaming
+dotnet run --project server
+```
+
+In another shell, run a client. The user name is the first argument; the endpoint
+or port is optional and comes last. The client defaults to
+`http://localhost:5004`.
+
+```bash
+cd examples/rpcv2cbor-streaming
+dotnet run --project client -- alice
+```
+
+Open another shell and run a second client with another user name. Messages typed
+in either client are broadcast to every connected client. Submit an empty line to
+disconnect.

--- a/examples/rpcv2cbor-streaming/client/NSmithy.Examples.RpcV2CborStreaming.Client.csproj
+++ b/examples/rpcv2cbor-streaming/client/NSmithy.Examples.RpcV2CborStreaming.Client.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace></RootNamespace>
+    <SmithyService>example.chat#ChatService</SmithyService>
+    <SmithyGeneratedNamespaces>example.chat</SmithyGeneratedNamespaces>
+    <SmithyGenerateServer>false</SmithyGenerateServer>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../contracts/RpcV2CborStreaming.Contracts.csproj" />
+    <PackageReference Include="NSmithy.Client" Version="0.0.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Core" Version="0.0.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.0.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.0.0-SNAPSHOT" />
+  </ItemGroup>
+</Project>

--- a/examples/rpcv2cbor-streaming/client/Program.cs
+++ b/examples/rpcv2cbor-streaming/client/Program.cs
@@ -1,0 +1,103 @@
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using Example.Chat;
+using NSmithy.Protocols.RpcV2Cbor;
+
+var (user, endpoint) = ParseArgs(args, "http://localhost:5004");
+
+using var httpClient = new HttpClient
+{
+    DefaultRequestVersion = System.Net.HttpVersion.Version20,
+    DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact,
+};
+
+using var client = new ChatServiceClient(
+    httpClient,
+    new() { Endpoint = new Uri(endpoint), Protocol = new RpcV2CborProtocol() }
+);
+
+Console.WriteLine($"Connected to {endpoint} as {user}.");
+Console.WriteLine("Type a message and press Enter. Submit an empty line to exit.");
+Console.WriteLine();
+
+using var cts = new CancellationTokenSource();
+var exiting = false;
+try
+{
+    await foreach (
+        var item in client.ChatAsync(ReadConsoleEvents(user, () => exiting = true, cts), cts.Token)
+    )
+    {
+        if (item is ChatEvent.Message message)
+            Console.WriteLine($"{message.Value.User}: {message.Value.Text}");
+    }
+}
+catch (OperationCanceledException) when (exiting || cts.IsCancellationRequested) { }
+catch (HttpRequestException ex)
+{
+    Console.WriteLine($"Could not connect to {endpoint}: {ex.Message}");
+}
+catch (IOException ex)
+{
+    Console.WriteLine($"Disconnected unexpectedly: {ex.Message}");
+}
+
+Console.WriteLine("Disconnected.");
+
+static async IAsyncEnumerable<ChatEvent> ReadConsoleEvents(
+    string user,
+    Action exiting,
+    CancellationTokenSource cancellationTokenSource,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default
+)
+{
+    while (!cancellationToken.IsCancellationRequested)
+    {
+        var line = await Task.Run(Console.ReadLine, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            exiting();
+            await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+            yield break;
+        }
+
+        yield return ChatEvent.FromMessage(new MessageEvent(User: user, Text: line));
+    }
+}
+
+static (string User, string Endpoint) ParseArgs(string[] args, string defaultEndpoint)
+{
+    var user = Environment.UserName;
+    var endpoint = defaultEndpoint;
+
+    if (args.Length == 1)
+    {
+        if (LooksLikeEndpoint(args[0]))
+            endpoint = NormalizeEndpoint(args[0]);
+        else
+            user = args[0];
+    }
+    else if (args.Length >= 2)
+    {
+        if (LooksLikeEndpoint(args[0]))
+        {
+            endpoint = NormalizeEndpoint(args[0]);
+            user = args[1];
+        }
+        else
+        {
+            user = args[0];
+            endpoint = NormalizeEndpoint(args[1]);
+        }
+    }
+
+    return (user, endpoint);
+}
+
+static bool LooksLikeEndpoint(string value) =>
+    value.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+    || value.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+    || int.TryParse(value, out _);
+
+static string NormalizeEndpoint(string value) =>
+    int.TryParse(value, out var port) ? $"http://localhost:{port}" : value;

--- a/examples/rpcv2cbor-streaming/contracts/RpcV2CborStreaming.Contracts.csproj
+++ b/examples/rpcv2cbor-streaming/contracts/RpcV2CborStreaming.Contracts.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <SmithyPublish>true</SmithyPublish>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSmithy.MSBuild" Version="0.0.0-SNAPSHOT" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/examples/rpcv2cbor-streaming/contracts/model/chat.smithy
+++ b/examples/rpcv2cbor-streaming/contracts/model/chat.smithy
@@ -1,0 +1,57 @@
+$version: "2"
+
+namespace example.chat
+
+use smithy.api#streaming
+use smithy.protocols#rpcv2Cbor
+
+@rpcv2Cbor
+service ChatService {
+    version: "2026-07-28"
+    operations: [WatchRoom, UploadTranscript, Chat]
+}
+
+/// Server-streaming: one request, many events.
+operation WatchRoom {
+    input := {
+        @required
+        room: String
+    }
+    output := {
+        events: ChatEvent
+    }
+}
+
+/// Client-streaming: many events, one summary.
+operation UploadTranscript {
+    input := {
+        events: ChatEvent
+    }
+    output := {
+        @required
+        accepted: Integer
+    }
+}
+
+/// Bidirectional streaming: many events in both directions.
+operation Chat {
+    input := {
+        events: ChatEvent
+    }
+    output := {
+        events: ChatEvent
+    }
+}
+
+@streaming
+union ChatEvent {
+    message: MessageEvent
+}
+
+structure MessageEvent {
+    @required
+    user: String
+
+    @required
+    text: String
+}

--- a/examples/rpcv2cbor-streaming/contracts/smithy-build.json
+++ b/examples/rpcv2cbor-streaming/contracts/smithy-build.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "sources": ["model"],
+  "maven": {
+    "dependencies": [
+      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
+    ]
+  }
+}

--- a/examples/rpcv2cbor-streaming/server/NSmithy.Examples.RpcV2CborStreaming.Server.csproj
+++ b/examples/rpcv2cbor-streaming/server/NSmithy.Examples.RpcV2CborStreaming.Server.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace></RootNamespace>
+    <SmithyService>example.chat#ChatService</SmithyService>
+    <SmithyGeneratedNamespaces>example.chat</SmithyGeneratedNamespaces>
+    <SmithyGenerateClient>false</SmithyGenerateClient>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RestorePackagesPath>$(MSBuildProjectDirectory)/obj/packages</RestorePackagesPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../contracts/RpcV2CborStreaming.Contracts.csproj" />
+    <PackageReference Include="NSmithy.Core" Version="0.0.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.MSBuild" Version="0.0.0-SNAPSHOT" PrivateAssets="all" />
+    <PackageReference Include="NSmithy.Protocols.RpcV2Cbor" Version="0.0.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Server.AspNetCore" Version="0.0.0-SNAPSHOT" />
+  </ItemGroup>
+</Project>

--- a/examples/rpcv2cbor-streaming/server/Program.cs
+++ b/examples/rpcv2cbor-streaming/server/Program.cs
@@ -1,0 +1,192 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Example.Chat;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+var port = args.Length > 0 && int.TryParse(args[0], out var parsedPort) ? parsedPort : 5004;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(
+        port,
+        listenOptions =>
+        {
+            listenOptions.Protocols = HttpProtocols.Http2;
+        }
+    );
+});
+builder.Services.AddSingleton<ChatRooms>();
+builder.Services.AddChatServiceHandler<ChatHandler>();
+
+var app = builder.Build();
+app.MapChatServiceRpcV2Cbor();
+app.Run();
+
+internal sealed class ChatHandler(ChatRooms rooms) : IChatServiceHandler
+{
+    public async IAsyncEnumerable<ChatEvent> WatchRoomAsync(
+        WatchRoomInput input,
+        [System.Runtime.CompilerServices.EnumeratorCancellation]
+            CancellationToken cancellationToken = default
+    )
+    {
+        for (var i = 1; i <= 3; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(25, cancellationToken);
+            yield return ChatEvent.FromMessage(
+                new MessageEvent(User: "server", Text: $"{input.Room}: update {i}")
+            );
+        }
+    }
+
+    public async Task<UploadTranscriptOutput> UploadTranscriptAsync(
+        IAsyncEnumerable<ChatEvent> input,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var accepted = 0;
+        await foreach (var item in input.WithCancellation(cancellationToken))
+        {
+            if (item is ChatEvent.Message)
+                accepted++;
+        }
+
+        return new UploadTranscriptOutput(accepted);
+    }
+
+    public async IAsyncEnumerable<ChatEvent> ChatAsync(
+        IAsyncEnumerable<ChatEvent> input,
+        [System.Runtime.CompilerServices.EnumeratorCancellation]
+            CancellationToken cancellationToken = default
+    )
+    {
+        var fallbackUser = $"user-{Guid.NewGuid():N}"[..13];
+        var room = rooms.Join("general");
+        var inbound = Task.Run(
+            () => PublishIncomingMessagesAsync(input, room, fallbackUser, cancellationToken),
+            cancellationToken
+        );
+
+        try
+        {
+            room.Publish(new MessageEvent(User: "server", Text: $"{fallbackUser} joined"));
+            await foreach (var message in room.ReadAllAsync(cancellationToken))
+            {
+                yield return ChatEvent.FromMessage(message);
+            }
+        }
+        finally
+        {
+            room.Publish(new MessageEvent(User: "server", Text: $"{fallbackUser} left"));
+            room.Leave();
+            await WaitForInboundAsync(inbound).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task PublishIncomingMessagesAsync(
+        IAsyncEnumerable<ChatEvent> input,
+        ChatRoomSubscription room,
+        string fallbackUser,
+        CancellationToken cancellationToken
+    )
+    {
+        await foreach (var item in input.WithCancellation(cancellationToken))
+        {
+            if (item is ChatEvent.Message message)
+            {
+                var text = message.Value.Text.Trim();
+                if (text.Length > 0)
+                {
+                    room.Publish(
+                        new MessageEvent(User: message.Value.User ?? fallbackUser, Text: text),
+                        includeSender: false
+                    );
+                }
+            }
+        }
+    }
+
+    private static async Task WaitForInboundAsync(Task inbound)
+    {
+        try
+        {
+            await inbound.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+        catch (IOException) { }
+    }
+}
+
+internal sealed class ChatRooms
+{
+    private readonly ConcurrentDictionary<string, ChatRoom> rooms = [];
+
+    public ChatRoomSubscription Join(string name)
+    {
+        var room = rooms.GetOrAdd(name, static _ => new ChatRoom());
+        return room.Subscribe();
+    }
+}
+
+internal sealed class ChatRoom
+{
+    private readonly ConcurrentDictionary<Guid, Channel<MessageEvent>> subscribers = [];
+
+    public ChatRoomSubscription Subscribe()
+    {
+        var id = Guid.NewGuid();
+        var channel = Channel.CreateUnbounded<MessageEvent>(
+            new UnboundedChannelOptions { SingleReader = true }
+        );
+        subscribers[id] = channel;
+        return new ChatRoomSubscription(
+            message => Publish(id, message, includeSender: true),
+            (message, includeSender) => Publish(id, message, includeSender),
+            () => Unsubscribe(id),
+            channel.Reader
+        );
+    }
+
+    private void Publish(Guid senderId, MessageEvent message, bool includeSender)
+    {
+        foreach (var (id, subscriber) in subscribers)
+        {
+            if (!includeSender && id == senderId)
+                continue;
+
+            subscriber.Writer.TryWrite(message);
+        }
+    }
+
+    private void Unsubscribe(Guid id)
+    {
+        if (subscribers.TryRemove(id, out var channel))
+            channel.Writer.TryComplete();
+    }
+}
+
+internal sealed class ChatRoomSubscription(
+    Action<MessageEvent> publish,
+    Action<MessageEvent, bool> publishWithOptions,
+    Action leave,
+    ChannelReader<MessageEvent> reader
+) : IAsyncDisposable
+{
+    public void Publish(MessageEvent message) => publish(message);
+
+    public void Publish(MessageEvent message, bool includeSender) =>
+        publishWithOptions(message, includeSender);
+
+    public void Leave() => leave();
+
+    public IAsyncEnumerable<MessageEvent> ReadAllAsync(CancellationToken cancellationToken) =>
+        reader.ReadAllAsync(cancellationToken);
+
+    public ValueTask DisposeAsync()
+    {
+        leave();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/packages/NSmithy.Protocols.RpcV2Cbor/NSmithy.Protocols.RpcV2Cbor.csproj
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/NSmithy.Protocols.RpcV2Cbor.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="../NSmithy.Codecs.Cbor/NSmithy.Codecs.Cbor.csproj" />
+    <ProjectReference Include="../NSmithy.EventStream/NSmithy.EventStream.csproj" />
     <ProjectReference Include="../NSmithy.Http/NSmithy.Http.csproj" />
   </ItemGroup>
 </Project>

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -1,6 +1,9 @@
+using System.Net;
+using System.Runtime.CompilerServices;
 using NSmithy.Codecs.Cbor;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
+using NSmithy.EventStream;
 using NSmithy.Http;
 
 namespace NSmithy.Protocols.RpcV2Cbor;
@@ -8,6 +11,7 @@ namespace NSmithy.Protocols.RpcV2Cbor;
 public sealed class RpcV2CborProtocol : IProtocol
 {
     private const string ContentType = "application/cbor";
+    private const string EventStreamContentType = "application/vnd.amazon.eventstream";
 
     // Smithy 2.0 wraps `input: Unit` / `output: Unit` in synthetic structures that carry
     // this trait pointing back to the original `smithy.api#Unit` shape id.
@@ -41,6 +45,60 @@ public sealed class RpcV2CborProtocol : IProtocol
         {
             ArgumentNullException.ThrowIfNull(operation);
             return new OperationProtocol<TInput, TOutput>(service, operation);
+        }
+
+        public IOutputEventStreamOperationProtocol<
+            TInput,
+            TOutputEvent
+        > ForOutputEventStreamOperation<TInput, TOutput, TOutputEvent>(
+            OperationSchema<TInput, TOutput> operation,
+            Schema<TOutputEvent> outputEvent
+        )
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            ArgumentNullException.ThrowIfNull(outputEvent);
+            return new OutputEventStreamOperationProtocol<TInput, TOutput, TOutputEvent>(
+                service,
+                operation,
+                outputEvent
+            );
+        }
+
+        public IInputEventStreamOperationProtocol<
+            TInputEvent,
+            TOutput
+        > ForInputEventStreamOperation<TInput, TInputEvent, TOutput>(
+            OperationSchema<TInput, TOutput> operation,
+            Schema<TInputEvent> inputEvent
+        )
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            ArgumentNullException.ThrowIfNull(inputEvent);
+            return new InputEventStreamOperationProtocol<TInput, TInputEvent, TOutput>(
+                service,
+                operation,
+                inputEvent
+            );
+        }
+
+        public IDuplexEventStreamOperationProtocol<
+            TInputEvent,
+            TOutputEvent
+        > ForDuplexEventStreamOperation<TInput, TOutput, TInputEvent, TOutputEvent>(
+            OperationSchema<TInput, TOutput> operation,
+            Schema<TInputEvent> inputEvent,
+            Schema<TOutputEvent> outputEvent
+        )
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            ArgumentNullException.ThrowIfNull(inputEvent);
+            ArgumentNullException.ThrowIfNull(outputEvent);
+            return new DuplexEventStreamOperationProtocol<
+                TInput,
+                TOutput,
+                TInputEvent,
+                TOutputEvent
+            >(service, operation, inputEvent, outputEvent);
         }
     }
 
@@ -84,9 +142,7 @@ public sealed class RpcV2CborProtocol : IProtocol
 
         public SmithyHttpRequest SerializeRequest(TInput input)
         {
-            var request = new SmithyHttpRequest(HttpMethod.Post, requestUri);
-            request.Headers["Smithy-Protocol"] = ["rpc-v2-cbor"];
-            request.Headers["Accept"] = [ContentType];
+            var request = BaseRequest(requestUri, ContentType);
             if (!inputIsUnit)
             {
                 request.Body = new SmithyHttpBody.Bytes(requestCodec.Serialize(input));
@@ -201,6 +257,241 @@ public sealed class RpcV2CborProtocol : IProtocol
             body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
     }
 
+    private sealed class OutputEventStreamOperationProtocol<TInput, TOutput, TOutputEvent>
+        : IOutputEventStreamOperationProtocol<TInput, TOutputEvent>
+    {
+        private readonly string requestUri;
+        private readonly bool inputIsUnit;
+        private readonly ICborCodec<TInput>? requestCodec;
+        private readonly ICborCodec<TOutputEvent> responseCodec;
+        private readonly IUnionSchema responseEvent;
+
+        public OutputEventStreamOperationProtocol(
+            ServiceSchema service,
+            OperationSchema<TInput, TOutput> operation,
+            Schema<TOutputEvent> outputEvent
+        )
+        {
+            requestUri = RequestUri(service, operation);
+            inputIsUnit = IsUnit<TInput>(operation.Input);
+            requestCodec = inputIsUnit
+                ? null
+                : CborCodec.FromSchema(operation.Input, materializeTopLevelDefaults: false);
+            responseCodec = CborCodec.FromSchema(outputEvent);
+            responseEvent =
+                outputEvent.Resolved as IUnionSchema
+                ?? throw new InvalidOperationException(
+                    "rpcv2Cbor event streams must target a union schema."
+                );
+            EnsureNoInitialResponseMembers<TOutput>(operation.Output);
+        }
+
+        public SmithyHttpRequest SerializeRequest(TInput input)
+        {
+            var request = BaseRequest(requestUri, EventStreamContentType);
+            if (!inputIsUnit)
+            {
+                request.Body = new SmithyHttpBody.Bytes(requestCodec!.Serialize(input));
+                request.ContentType = ContentType;
+            }
+
+            return request;
+        }
+
+        public TInput DeserializeRequest(SmithyHttpRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (inputIsUnit)
+            {
+                return default!;
+            }
+
+            var content = BodyBytes(request.Body);
+            return content.Length == 0 ? default! : requestCodec!.Deserialize(content);
+        }
+
+        public IAsyncEnumerable<TOutputEvent> DeserializeResponseEventsAsync(
+            SmithyHttpClientResponse response,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            EnsureEventStreamResponse(response);
+            return ReadResponseEventsAsync(response, responseCodec, cancellationToken);
+        }
+
+        public SmithyHttpServerResponse SerializeResponse(
+            IAsyncEnumerable<TOutputEvent> output,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(output);
+            return StreamingResponse(
+                FrameEventsAsync(output, responseCodec, responseEvent, cancellationToken)
+            );
+        }
+    }
+
+    private sealed class InputEventStreamOperationProtocol<TInput, TInputEvent, TOutput>
+        : IInputEventStreamOperationProtocol<TInputEvent, TOutput>
+    {
+        private readonly string requestUri;
+        private readonly bool outputIsUnit;
+        private readonly ICborCodec<TInputEvent> requestCodec;
+        private readonly IUnionSchema requestEvent;
+        private readonly ICborCodec<TOutput>? responseCodec;
+
+        public InputEventStreamOperationProtocol(
+            ServiceSchema service,
+            OperationSchema<TInput, TOutput> operation,
+            Schema<TInputEvent> inputEvent
+        )
+        {
+            requestUri = RequestUri(service, operation);
+            EnsureNoInitialRequestMembers<TInput>(operation.Input);
+            outputIsUnit = IsUnit<TOutput>(operation.Output);
+            requestCodec = CborCodec.FromSchema(inputEvent);
+            requestEvent =
+                inputEvent.Resolved as IUnionSchema
+                ?? throw new InvalidOperationException(
+                    "rpcv2Cbor event streams must target a union schema."
+                );
+            responseCodec = outputIsUnit ? null : CborCodec.FromSchema(operation.Output);
+        }
+
+        public SmithyHttpRequest SerializeRequest(
+            IAsyncEnumerable<TInputEvent> input,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return BaseStreamingRequest(
+                requestUri,
+                ContentType,
+                FrameEventsAsync(input, requestCodec, requestEvent, cancellationToken)
+            );
+        }
+
+        public IAsyncEnumerable<TInputEvent> DeserializeRequestEventsAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return ReadRequestEventsAsync(RequestStream(request), requestCodec, cancellationToken);
+        }
+
+        public ValueTask<TOutput> DeserializeResponseAsync(
+            SmithyHttpClientResponse response,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            EnsureResponse(response);
+            if (outputIsUnit)
+            {
+                DisposeResponseBody(response);
+                return ValueTask.FromResult((TOutput)(object)SmithyUnit.Value);
+            }
+
+            return DeserializeSingleResponseAsync(response, responseCodec!, cancellationToken);
+        }
+
+        public SmithyHttpServerResponse SerializeResponse(TOutput output)
+        {
+            if (outputIsUnit)
+            {
+                return BufferedResponse(
+                    200,
+                    ReadOnlyMemory<byte>.Empty,
+                    headers => headers["Smithy-Protocol"] = ["rpc-v2-cbor"]
+                );
+            }
+
+            return BufferedResponse(
+                200,
+                responseCodec!.Serialize(output),
+                headers =>
+                {
+                    headers["Smithy-Protocol"] = ["rpc-v2-cbor"];
+                    headers["Content-Type"] = [ContentType];
+                }
+            );
+        }
+    }
+
+    private sealed class DuplexEventStreamOperationProtocol<
+        TInput,
+        TOutput,
+        TInputEvent,
+        TOutputEvent
+    >(
+        ServiceSchema service,
+        OperationSchema<TInput, TOutput> operation,
+        Schema<TInputEvent> inputEvent,
+        Schema<TOutputEvent> outputEvent
+    ) : IDuplexEventStreamOperationProtocol<TInputEvent, TOutputEvent>
+    {
+        private readonly string requestUri = RequestUri(service, operation);
+        private readonly ICborCodec<TInputEvent> requestCodec = CborCodec.FromSchema(inputEvent);
+        private readonly IUnionSchema requestEvent =
+            inputEvent.Resolved as IUnionSchema
+            ?? throw new InvalidOperationException(
+                "rpcv2Cbor event streams must target a union schema."
+            );
+        private readonly ICborCodec<TOutputEvent> responseCodec = CborCodec.FromSchema(outputEvent);
+        private readonly IUnionSchema responseEvent =
+            outputEvent.Resolved as IUnionSchema
+            ?? throw new InvalidOperationException(
+                "rpcv2Cbor event streams must target a union schema."
+            );
+
+        public SmithyHttpRequest SerializeRequest(
+            IAsyncEnumerable<TInputEvent> input,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            EnsureNoInitialRequestMembers<TInput>(operation.Input);
+            EnsureNoInitialResponseMembers<TOutput>(operation.Output);
+            return BaseStreamingRequest(
+                requestUri,
+                EventStreamContentType,
+                FrameEventsAsync(input, requestCodec, requestEvent, cancellationToken)
+            );
+        }
+
+        public IAsyncEnumerable<TInputEvent> DeserializeRequestEventsAsync(
+            SmithyHttpRequest request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return ReadRequestEventsAsync(RequestStream(request), requestCodec, cancellationToken);
+        }
+
+        public IAsyncEnumerable<TOutputEvent> DeserializeResponseEventsAsync(
+            SmithyHttpClientResponse response,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            EnsureEventStreamResponse(response);
+            return ReadResponseEventsAsync(response, responseCodec, cancellationToken);
+        }
+
+        public SmithyHttpServerResponse SerializeResponse(
+            IAsyncEnumerable<TOutputEvent> output,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(output);
+            return StreamingResponse(
+                FrameEventsAsync(output, responseCodec, responseEvent, cancellationToken)
+            );
+        }
+    }
+
     /// <summary>
     /// Serializes a modeled error into a rpcv2Cbor error response: a CBOR body carrying a
     /// <c>__type</c> discriminator (the absolute shape id) plus the error's members, with the
@@ -249,6 +540,261 @@ public sealed class RpcV2CborProtocol : IProtocol
     {
         await Task.CompletedTask.ConfigureAwait(false);
         yield return chunk;
+    }
+
+    private static SmithyHttpRequest BaseRequest(string requestUri, string accept)
+    {
+        var request = new SmithyHttpRequest(HttpMethod.Post, requestUri);
+        request.Headers["Smithy-Protocol"] = ["rpc-v2-cbor"];
+        request.Headers["Accept"] = [accept];
+        return request;
+    }
+
+    private static SmithyHttpRequest BaseStreamingRequest(
+        string requestUri,
+        string accept,
+        IAsyncEnumerable<ReadOnlyMemory<byte>> body
+    )
+    {
+        var request = BaseRequest(requestUri, accept);
+        request.Body = new SmithyHttpBody.EventStreaming(body);
+        request.ContentType = EventStreamContentType;
+        return request;
+    }
+
+    private static SmithyHttpServerResponse StreamingResponse(
+        IAsyncEnumerable<ReadOnlyMemory<byte>> body
+    )
+    {
+        var response = new SmithyHttpServerResponse { StatusCode = 200, Body = body };
+        response.Headers["Smithy-Protocol"] = ["rpc-v2-cbor"];
+        response.Headers["Content-Type"] = [EventStreamContentType];
+        return response;
+    }
+
+    private static string RequestUri<TInput, TOutput>(
+        ServiceSchema service,
+        OperationSchema<TInput, TOutput> operation
+    ) => $"/service/{service.Id.Name}/operation/{operation.Id.Name}";
+
+    private static async IAsyncEnumerable<ReadOnlyMemory<byte>> FrameEventsAsync<T>(
+        IAsyncEnumerable<T> events,
+        ICborCodec<T> codec,
+        IUnionSchema eventSchema,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        await foreach (
+            var value in events.WithCancellation(cancellationToken).ConfigureAwait(false)
+        )
+        {
+            var message = new EventStreamMessage(
+                new Dictionary<string, EventStreamHeaderValue>
+                {
+                    [EventStreamHeaders.MessageType] = new EventStreamHeaderValue.Text(
+                        EventStreamHeaders.EventMessageType
+                    ),
+                    [EventStreamHeaders.EventType] = new EventStreamHeaderValue.Text(
+                        eventSchema.GetCaseObject(value!).Name
+                    ),
+                    [EventStreamHeaders.ContentType] = new EventStreamHeaderValue.Text(ContentType),
+                },
+                codec.Serialize(value)
+            );
+            yield return message.Encode();
+        }
+    }
+
+    private static async IAsyncEnumerable<T> ReadRequestEventsAsync<T>(
+        Stream body,
+        ICborCodec<T> codec,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        await foreach (
+            var message in EventStreamMessageReader.ReadAllAsync(body, cancellationToken)
+        )
+        {
+            var value = DeserializeEventMessage(codec, message);
+            if (value is not null)
+            {
+                yield return value;
+            }
+        }
+    }
+
+    private static async IAsyncEnumerable<T> ReadResponseEventsAsync<T>(
+        SmithyHttpClientResponse response,
+        ICborCodec<T> codec,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        var body = ResponseStream(response);
+        await using (body.ConfigureAwait(false))
+        {
+            await foreach (
+                var message in EventStreamMessageReader.ReadAllAsync(body, cancellationToken)
+            )
+            {
+                var value = DeserializeEventMessage(codec, message);
+                if (value is not null)
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
+
+    private static async ValueTask<T> DeserializeSingleResponseAsync<T>(
+        SmithyHttpClientResponse response,
+        ICborCodec<T> codec,
+        CancellationToken cancellationToken
+    )
+    {
+        var body = ResponseStream(response);
+        await using (body.ConfigureAwait(false))
+        {
+            using var stream = new MemoryStream();
+            await body.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+            var content = stream.ToArray();
+            return content.Length == 0 ? default! : codec.Deserialize(content);
+        }
+    }
+
+    private static T? DeserializeEventMessage<T>(ICborCodec<T> codec, EventStreamMessage message)
+    {
+        var messageType = message.StringHeader(EventStreamHeaders.MessageType);
+        if (
+            !string.Equals(
+                messageType,
+                EventStreamHeaders.EventMessageType,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            ThrowEventStreamException(message);
+        }
+
+        var contentType = message.StringHeader(EventStreamHeaders.ContentType);
+        if (
+            contentType is not null
+            && !string.Equals(contentType, ContentType, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            throw new InvalidDataException(
+                $"Expected rpcv2Cbor event payload content type '{ContentType}' but received '{contentType}'."
+            );
+        }
+
+        return codec.Deserialize(message.Payload.ToArray());
+    }
+
+    private static void ThrowEventStreamException(EventStreamMessage message)
+    {
+        var messageType = message.StringHeader(EventStreamHeaders.MessageType);
+        if (
+            string.Equals(
+                messageType,
+                EventStreamHeaders.ErrorMessageType,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            var code = message.StringHeader(EventStreamHeaders.ErrorCode) ?? "UnknownError";
+            var text = message.StringHeader(EventStreamHeaders.ErrorMessage);
+            throw new InvalidOperationException(
+                string.IsNullOrEmpty(text) ? code : $"{code}: {text}"
+            );
+        }
+
+        if (
+            string.Equals(
+                messageType,
+                EventStreamHeaders.ExceptionMessageType,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            var type = message.StringHeader(EventStreamHeaders.ExceptionType) ?? "UnknownException";
+            throw new InvalidOperationException($"rpcv2Cbor event stream exception: {type}.");
+        }
+
+        throw new InvalidDataException(
+            $"Unknown rpcv2Cbor event stream message type '{messageType ?? "<missing>"}'."
+        );
+    }
+
+    private static Stream RequestStream(SmithyHttpRequest request) =>
+        request.Body switch
+        {
+            SmithyHttpBody.Streaming streaming => streaming.Content,
+            SmithyHttpBody.Bytes bytes => new MemoryStream(bytes.Content, writable: false),
+            _ => Stream.Null,
+        };
+
+    private static Stream ResponseStream(SmithyHttpClientResponse response) =>
+        response.Body switch
+        {
+            SmithyHttpBody.Streaming streaming => streaming.Content,
+            SmithyHttpBody.Bytes bytes => new MemoryStream(bytes.Content, writable: false),
+            _ => Stream.Null,
+        };
+
+    private static void DisposeResponseBody(SmithyHttpClientResponse response)
+    {
+        if (response.Body is SmithyHttpBody.Streaming streaming)
+        {
+            streaming.Content.Dispose();
+        }
+    }
+
+    private static byte[] BodyBytes(SmithyHttpBody body) =>
+        body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
+
+    private static void EnsureEventStreamResponse(SmithyHttpClientResponse response)
+    {
+        EnsureResponse(response);
+        if (response.StatusCode == HttpStatusCode.OK && IsEventStreamContentType(response))
+        {
+            return;
+        }
+
+        DisposeResponseBody(response);
+        throw new InvalidOperationException(
+            $"Expected a rpcv2Cbor event stream response but received HTTP {(int)response.StatusCode}."
+        );
+    }
+
+    private static bool IsEventStreamContentType(SmithyHttpClientResponse response) =>
+        response.ContentHeaders.TryGetValue("Content-Type", out var contentType)
+        && contentType.Any(value =>
+            value.StartsWith(EventStreamContentType, StringComparison.OrdinalIgnoreCase)
+        );
+
+    private static bool IsUnit<T>(Schema schema) =>
+        typeof(T) == typeof(SmithyUnit) || IsUnitSchema(schema);
+
+    private static void EnsureNoInitialRequestMembers<T>(Schema<T> input) =>
+        EnsureNoInitialMembers(input, "request");
+
+    private static void EnsureNoInitialResponseMembers<T>(Schema<T> output) =>
+        EnsureNoInitialMembers(output, "response");
+
+    private static void EnsureNoInitialMembers(Schema schema, string direction)
+    {
+        if (IsUnitSchema(schema))
+        {
+            return;
+        }
+
+        if (schema.Resolved is IStructSchema structure && structure.Members.Count <= 1)
+        {
+            return;
+        }
+
+        throw new NotSupportedException(
+            $"rpcv2Cbor event streaming with non-streaming initial {direction} members is not supported by the current generated streaming surface."
+        );
     }
 
     private static T DeserializeRequiredBody<T>(ICodec<T> codec, byte[] content)

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -283,7 +283,7 @@ public sealed class RpcV2CborProtocol : IProtocol
                 ?? throw new InvalidOperationException(
                     "rpcv2Cbor event streams must target a union schema."
                 );
-            EnsureNoInitialResponseMembers<TOutput>(operation.Output);
+            EnsureNoInitialResponseMembers(operation.Output);
         }
 
         public SmithyHttpRequest SerializeRequest(TInput input)
@@ -348,7 +348,7 @@ public sealed class RpcV2CborProtocol : IProtocol
         )
         {
             requestUri = RequestUri(service, operation);
-            EnsureNoInitialRequestMembers<TInput>(operation.Input);
+            EnsureNoInitialRequestMembers(operation.Input);
             outputIsUnit = IsUnit<TOutput>(operation.Output);
             requestCodec = CborCodec.FromSchema(inputEvent);
             requestEvent =
@@ -452,8 +452,8 @@ public sealed class RpcV2CborProtocol : IProtocol
         )
         {
             ArgumentNullException.ThrowIfNull(input);
-            EnsureNoInitialRequestMembers<TInput>(operation.Input);
-            EnsureNoInitialResponseMembers<TOutput>(operation.Output);
+            EnsureNoInitialRequestMembers(operation.Input);
+            EnsureNoInitialResponseMembers(operation.Output);
             return BaseStreamingRequest(
                 requestUri,
                 EventStreamContentType,

--- a/tests/NSmithy.Tests/NSmithy.Tests.csproj
+++ b/tests/NSmithy.Tests/NSmithy.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="../../packages/NSmithy.Http/NSmithy.Http.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Codecs.Json/NSmithy.Codecs.Json.csproj" />
     <ProjectReference Include="../../packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj" />
+    <ProjectReference Include="../../packages/NSmithy.Protocols.RpcV2Cbor/NSmithy.Protocols.RpcV2Cbor.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Protocols.Rest/NSmithy.Protocols.Rest.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Protocols.RestJson/NSmithy.Protocols.RestJson.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Server.AspNetCore/NSmithy.Server.AspNetCore.csproj" />

--- a/tests/NSmithy.Tests/Protocols/RpcV2Cbor/RpcV2CborStreamingProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/RpcV2Cbor/RpcV2CborStreamingProtocolTests.cs
@@ -1,0 +1,264 @@
+using NSmithy.Codecs.Cbor;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.EventStream;
+using NSmithy.Http;
+using NSmithy.Protocols.RpcV2Cbor;
+
+namespace NSmithy.Tests.Protocols.RpcV2Cbor;
+
+public sealed class RpcV2CborStreamingProtocolTests
+{
+    public sealed record Echo(string Message);
+
+    public abstract record ChatEvent
+    {
+        private ChatEvent() { }
+
+        public sealed record Message(Echo Value) : ChatEvent;
+    }
+
+    public sealed class EchoBuilder
+    {
+        public string? Message { get; set; }
+    }
+
+    public sealed class EnvelopeBuilder
+    {
+        public string? Name { get; set; }
+
+        public ChatEvent? Events { get; set; }
+    }
+
+    private static IServiceProtocol BuildServiceProtocol() =>
+        new RpcV2CborProtocol().ForService(
+            Schemas.Service(ShapeId.Parse("example.greeter#Greeter"))
+        );
+
+    private static Schema<Echo> EchoSchema(string name) =>
+        Schemas
+            .Structure<Echo, EchoBuilder>(ShapeId.Parse($"example.greeter#{name}"))
+            .Required("message", x => x.Message, (b, v) => b.Message = v, Schemas.String)
+            .Build(() => new EchoBuilder(), b => new Echo(b.Message!));
+
+    private static Schema<ChatEvent> ChatEventSchema(string name) =>
+        Schemas
+            .Union<ChatEvent>(ShapeId.Parse($"example.greeter#{name}"))
+            .Case(
+                "message",
+                static value => value is ChatEvent.Message,
+                static value => ((ChatEvent.Message)value).Value,
+                static value => new ChatEvent.Message(value!),
+                EchoSchema($"{name}Message")
+            )
+            .Build();
+
+    private static Schema<EnvelopeBuilder> StreamEnvelopeSchema(string name) =>
+        Schemas
+            .Structure<EnvelopeBuilder, EnvelopeBuilder>(ShapeId.Parse($"example.greeter#{name}"))
+            .Required("events", x => x.Events!, (b, v) => b.Events = v, ChatEventSchema("Events"))
+            .Build(() => new EnvelopeBuilder(), b => b);
+
+    private static Schema<EnvelopeBuilder> InitialEnvelopeSchema(string name) =>
+        Schemas
+            .Structure<EnvelopeBuilder, EnvelopeBuilder>(ShapeId.Parse($"example.greeter#{name}"))
+            .Required("name", x => x.Name!, (b, v) => b.Name = v, Schemas.String)
+            .Required("events", x => x.Events!, (b, v) => b.Events = v, ChatEventSchema("Events"))
+            .Build(() => new EnvelopeBuilder(), b => b);
+
+    private static OperationSchema<Echo, EnvelopeBuilder> OutputOperation(string name) =>
+        Schemas.Operation(
+            ShapeId.Parse($"example.greeter#{name}"),
+            EchoSchema($"{name}Input"),
+            StreamEnvelopeSchema($"{name}Output")
+        );
+
+    private static OperationSchema<EnvelopeBuilder, Echo> InputOperation(string name) =>
+        Schemas.Operation(
+            ShapeId.Parse($"example.greeter#{name}"),
+            StreamEnvelopeSchema($"{name}Input"),
+            EchoSchema($"{name}Output")
+        );
+
+    private static OperationSchema<Echo, EnvelopeBuilder> OutputOperationWithInitial(string name) =>
+        Schemas.Operation(
+            ShapeId.Parse($"example.greeter#{name}"),
+            EchoSchema($"{name}Input"),
+            InitialEnvelopeSchema($"{name}Output")
+        );
+
+    [Fact]
+    public async Task ServerStreamingSerializesUnaryRequestAndReadsCborEventStream()
+    {
+        var protocol = BuildServiceProtocol()
+            .ForOutputEventStreamOperation(OutputOperation("Watch"), ChatEventSchema("WatchEvent"));
+
+        var request = protocol.SerializeRequest(new Echo("start"));
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/service/Greeter/operation/Watch", request.RequestUri);
+        Assert.Equal("application/cbor", request.ContentType);
+        Assert.Equal(["application/vnd.amazon.eventstream"], request.Headers["Accept"]);
+
+        var response = await ToClientResponseAsync(
+            protocol.SerializeResponse(ToAsync([new ChatEvent.Message(new Echo("one"))]))
+        );
+
+        var events = await CollectAsync(protocol.DeserializeResponseEventsAsync(response));
+        var message = Assert.IsType<ChatEvent.Message>(Assert.Single(events));
+        Assert.Equal(new Echo("one"), message.Value);
+    }
+
+    [Fact]
+    public async Task ClientStreamingSerializesEventStreamRequest()
+    {
+        var protocol = BuildServiceProtocol()
+            .ForInputEventStreamOperation(InputOperation("Upload"), ChatEventSchema("UploadEvent"));
+
+        var request = protocol.SerializeRequest(ToAsync([new ChatEvent.Message(new Echo("one"))]));
+
+        Assert.Equal("/service/Greeter/operation/Upload", request.RequestUri);
+        Assert.Equal("application/vnd.amazon.eventstream", request.ContentType);
+        Assert.Equal(["application/cbor"], request.Headers["Accept"]);
+
+        var framed = await BodyBytesAsync(request.Body);
+        var message = Assert.Single(await ReadMessagesAsync(framed));
+        Assert.Equal("event", message.StringHeader(":message-type"));
+        Assert.Equal("message", message.StringHeader(":event-type"));
+        Assert.Equal("application/cbor", message.StringHeader(":content-type"));
+
+        var value = CborCodec
+            .FromSchema(ChatEventSchema("UploadEvent"))
+            .Deserialize(message.Payload.ToArray());
+        var chat = Assert.IsType<ChatEvent.Message>(value);
+        Assert.Equal(new Echo("one"), chat.Value);
+    }
+
+    [Fact]
+    public async Task BidirectionalStreamingUsesEventStreamForRequestAndResponse()
+    {
+        var protocol = BuildServiceProtocol()
+            .ForDuplexEventStreamOperation(
+                InputOperation("Chat"),
+                ChatEventSchema("ChatInputEvent"),
+                ChatEventSchema("ChatOutputEvent")
+            );
+
+        var request = protocol.SerializeRequest(ToAsync([new ChatEvent.Message(new Echo("in"))]));
+
+        Assert.Equal("application/vnd.amazon.eventstream", request.ContentType);
+        Assert.Equal(["application/vnd.amazon.eventstream"], request.Headers["Accept"]);
+        Assert.Single(await ReadMessagesAsync(await BodyBytesAsync(request.Body)));
+
+        var response = await ToClientResponseAsync(
+            protocol.SerializeResponse(ToAsync([new ChatEvent.Message(new Echo("out"))]))
+        );
+
+        var events = await CollectAsync(protocol.DeserializeResponseEventsAsync(response));
+        var message = Assert.IsType<ChatEvent.Message>(Assert.Single(events));
+        Assert.Equal(new Echo("out"), message.Value);
+    }
+
+    [Fact]
+    public void StreamingOperationsRejectUnsupportedInitialMembers()
+    {
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            BuildServiceProtocol()
+                .ForOutputEventStreamOperation(
+                    OutputOperationWithInitial("WatchWithInitial"),
+                    ChatEventSchema("WatchEvent")
+                )
+        );
+
+        Assert.Contains("initial response members", ex.Message);
+    }
+
+    private static async Task<SmithyHttpClientResponse> ToClientResponseAsync(
+        SmithyHttpServerResponse response
+    )
+    {
+        var body = new MemoryStream();
+        await foreach (var chunk in response.Body)
+        {
+            body.Write(chunk.Span);
+        }
+
+        var headers = response.Headers.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value,
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        return new SmithyHttpClientResponse(
+            (System.Net.HttpStatusCode)response.StatusCode,
+            null,
+            new SmithyHttpBody.Streaming(new MemoryStream(body.ToArray())),
+            headers,
+            headers,
+            _ => null
+        );
+    }
+
+    private static async Task<byte[]> BodyBytesAsync(SmithyHttpBody body)
+    {
+        var stream = new MemoryStream();
+        await foreach (var chunk in BodyChunks(body))
+        {
+            stream.Write(chunk.Span);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static IAsyncEnumerable<ReadOnlyMemory<byte>> BodyChunks(SmithyHttpBody body) =>
+        body switch
+        {
+            SmithyHttpBody.EventStreaming eventStreaming => eventStreaming.Content,
+            SmithyHttpBody.Bytes bytes => ToAsyncBytes([bytes.Content]),
+            _ => ToAsyncBytes([]),
+        };
+
+    private static async Task<List<EventStreamMessage>> ReadMessagesAsync(byte[] framed)
+    {
+        var messages = new List<EventStreamMessage>();
+        await foreach (
+            var message in EventStreamMessageReader.ReadAllAsync(new MemoryStream(framed))
+        )
+        {
+            messages.Add(message);
+        }
+
+        return messages;
+    }
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+    private static async IAsyncEnumerable<ReadOnlyMemory<byte>> ToAsyncBytes(
+        IEnumerable<byte[]> values
+    )
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> values)
+    {
+        var result = new List<T>();
+        await foreach (var value in values)
+        {
+            result.Add(value);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- add rpcv2cbor event-stream operation protocol bindings for output, input, and duplex streams
- frame CBOR event payloads with Amazon Event Stream messages and rpcv2cbor headers
- wire rpcv2cbor streaming operations through generated clients and ASP.NET Core server endpoints
- add focused rpcv2cbor streaming protocol tests

## Notes
- non-streaming initial request/response members are rejected for now because the generated streaming API has no envelope shape to carry them without dropping modeled data

## Verification
- dotnet test tests/NSmithy.Tests/NSmithy.Tests.csproj --filter FullyQualifiedName~RpcV2CborStreamingProtocolTests
- gradle :smithy-csharp-codegen:test
- just build