### PR TITLE
fix: clarify grpc stream wrapper diagnostics

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
@@ -439,6 +439,16 @@ public final class ShapeSupport {
       return;
     }
 
+    String members =
+        structure.members().stream()
+            .sorted(Comparator.comparing(MemberShape::getMemberName))
+            .map(
+                member ->
+                    member.getMemberName()
+                        + (isEventStreamMember(model, member) ? " (event stream)" : ""))
+            .reduce((left, right) -> left + ", " + right)
+            .orElse("<none>");
+
     throw new CodegenException(
         "gRPC event-stream operation "
             + op.getId()
@@ -448,7 +458,9 @@ public final class ShapeSupport {
             + shapeId
             + " must contain exactly one event-stream member. Native gRPC flattens the Smithy "
             + direction
-            + " wrapper to 'stream <Event>', so sibling members cannot be represented.");
+            + " wrapper to 'stream <Event>', so sibling members cannot be represented. Members: "
+            + members
+            + ".");
   }
 
   public static boolean isStreamingBlobMember(Model model, MemberShape member) {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -172,6 +172,7 @@ final class ClientGeneratorTest {
                 "gRPC event-stream operation example.streaming#Chat input shape"
                     + " example.streaming#ChatInput must contain exactly one event-stream member"),
         ex.getMessage());
+    assertTrue(ex.getMessage().contains("Members: events (event stream), room."), ex.getMessage());
   }
 
   private static final String REST_PROTOCOL_TRAITS =

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -220,6 +220,7 @@ final class ServerGeneratorTest {
                 "gRPC event-stream operation example.streaming#Chat input shape"
                     + " example.streaming#ChatInput must contain exactly one event-stream member"),
         ex.getMessage());
+    assertTrue(ex.getMessage().contains("Members: events (event stream), room."), ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Part of #116.

Includes wrapper member names in the gRPC event-stream sibling-member diagnostic.