### PR TITLE
fix: clarify unsupported prelude schema diagnostics

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -58,7 +59,14 @@ public final class SchemaGenerator {
         case "Document" -> "Schemas.Document";
         case "Unit" -> "Schemas.Unit";
         default ->
-            throw new IllegalArgumentException("Unsupported prelude shape: " + shape.getId());
+            throw new CodegenException(
+                "Unsupported Smithy prelude schema shape "
+                    + shape.getId()
+                    + " ("
+                    + shape.getType()
+                    + "). Supported prelude schema shapes: "
+                    + supportedPreludeSchemaShapeNames()
+                    + ".");
       };
     }
 
@@ -95,6 +103,25 @@ public final class SchemaGenerator {
       case STRUCTURE, UNION, LIST, SET, MAP -> true;
       default -> false;
     };
+  }
+
+  private static String supportedPreludeSchemaShapeNames() {
+    return String.join(
+        ", ",
+        "Boolean",
+        "Byte",
+        "Short",
+        "Integer",
+        "Long",
+        "Float",
+        "Double",
+        "BigInteger",
+        "BigDecimal",
+        "String",
+        "Blob",
+        "Timestamp",
+        "Document",
+        "Unit");
   }
 
   public static String schemaClassName(GenerationContext context, Shape shape) {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGeneratorTest.java
@@ -1,0 +1,29 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+final class SchemaGeneratorTest {
+
+  @Test
+  void unsupportedPreludeSchemaDiagnosticNamesSupportedShapes() {
+    var shape = StructureShape.builder().id(ShapeId.from("smithy.api#Unsupported")).build();
+
+    CodegenException ex =
+        assertThrows(
+            CodegenException.class, () -> SchemaGenerator.shapeSchemaAccessor(null, shape));
+
+    assertTrue(
+        ex.getMessage().contains("Unsupported Smithy prelude schema shape smithy.api#Unsupported"),
+        ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("Supported prelude schema shapes: Boolean, Byte"),
+        ex.getMessage());
+    assertTrue(ex.getMessage().contains("Document, Unit."), ex.getMessage());
+  }
+}


### PR DESCRIPTION
Part of #116.

Reports unsupported Smithy prelude schema shapes with the shape ID, shape type, and supported prelude schema names.