### PR TITLE
Make server mappers protocol-selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHelloServiceHandler<HelloHandler>();
 
 var app = builder.Build();
-app.MapHelloServiceRestJson1();
+app.MapHelloService();
 app.Run();
 
 internal sealed class HelloHandler : IHelloServiceHandler

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -3,8 +3,8 @@
  *   - one `I{Operation}Handler` per operation (streaming surface derived from the model)
  *   - aggregate `I{Service}ServiceHandler`
  *   - `{Service}ServiceServerExtensions` with AddXxxHandler<THandler>(IServiceCollection)
- *   - one `{Service}Service{Protocol}Extensions` per declared server protocol, each with a
- *     `Map{Service}Service{Protocol}(IEndpointRouteBuilder)` that binds routes to the shared handler
+ *   - `{Service}ServiceProtocols` flags and `Map{Service}Service(..., protocols)` that bind
+ *     selected protocol routes to the shared handler
  *
  * Endpoints are thin: each maps a route to a handler method and the operation's bound protocol and
  * delegates to SmithyAspNetCoreHost, which runs the shared SmithyServerRuntime dispatch. No
@@ -104,18 +104,19 @@ public final class ServerGenerator implements Runnable {
     writer.write("public interface $L$L { }", aggInterface, inherits);
     writer.write("");
 
-    writeServerExtensions(ops, contract, aggInterface);
-
-    for (Kind kind : serverKinds) {
+    if (emitsAspNetCore) {
+      writeProtocolEnum(contract, serverKinds);
       writer.write("");
-      writeProtocolExtensions(kind, ops, contract);
     }
+
+    writeServerExtensions(ops, contract, aggInterface, serverKinds);
   }
 
   // ---------------- DI registration ----------------
 
   private void writeServerExtensions(
-      List<OperationShape> ops, String contract, String aggInterface) {
+      List<OperationShape> ops, String contract, String aggInterface, List<Kind> serverKinds) {
+    String protocolEnum = protocolEnumName(contract);
     writer.write("public static class $LServerExtensions", contract);
     writer.openBlock(
         "{",
@@ -145,63 +146,166 @@ public final class ServerGenerator implements Runnable {
                 }
                 writer.write("return services;");
               });
+
+          if (serverKinds.isEmpty()) {
+            return;
+          }
+
+          writer.write("");
+          writeProtocolFields(ops, serverKinds);
+          writer.write("");
+          writeSelectableMapMethod(contract, serverKinds, protocolEnum);
+          writer.write("");
+          writeRouteConflictHelper(contract, protocolEnum);
+
+          for (Kind kind : serverKinds) {
+            writer.write("");
+            writeProtocolMapHelper(kind, ops, contract, protocolEnum);
+          }
         });
   }
 
-  // ---------------- per-protocol endpoint extensions ----------------
+  // ---------------- endpoint mapping ----------------
 
-  private void writeProtocolExtensions(Kind kind, List<OperationShape> ops, String contract) {
-    String suffix = mapSuffix(kind);
-    writer.write("public static class $L$LExtensions", contract, suffix);
+  private void writeProtocolEnum(String contract, List<Kind> serverKinds) {
+    String enumName = protocolEnumName(contract);
+    writer.write("[System.Flags]");
+    writer.write("public enum $L", enumName);
     writer.openBlock(
         "{",
         "}",
         () -> {
+          writer.write("None = 0,");
+          for (int i = 0; i < serverKinds.size(); i++) {
+            Kind kind = serverKinds.get(i);
+            writer.write("$L = $L,", mapSuffix(kind), 1 << i);
+          }
           writer.write(
-              "private static readonly IServiceProtocol ServiceProtocol = new $L().ForService($L);",
-              ProtocolSupport.protocolType(kind),
-              SchemaGenerator.serviceSchemaAccessor(context, service));
-          for (OperationShape op : ops) {
-            if (!canBindOperation(kind, op)) {
-              continue;
-            }
-            writer.write(
-                "private static readonly IOperationProtocol<$L, $L> $LProtocol ="
-                    + " ServiceProtocol.ForOperation($L);",
-                SchemaGenerator.operationShapeType(context, op.getInputShape()),
-                SchemaGenerator.operationShapeType(context, op.getOutputShape()),
-                CSharpNaming.typeName(op.getId().getName()),
-                SchemaGenerator.operationSchemaAccessor(context, op));
+              "All = $L,",
+              serverKinds.stream()
+                  .map(ServerGenerator::mapSuffix)
+                  .collect(Collectors.joining(" | ")));
+        });
+  }
+
+  private void writeProtocolFields(List<OperationShape> ops, List<Kind> serverKinds) {
+    for (Kind kind : serverKinds) {
+      writer.write(
+          "private static readonly IServiceProtocol $LServiceProtocol = new $L().ForService($L);",
+          mapSuffix(kind),
+          ProtocolSupport.protocolType(kind),
+          SchemaGenerator.serviceSchemaAccessor(context, service));
+      for (OperationShape op : ops) {
+        if (!canBindOperation(kind, op)) {
+          continue;
+        }
+        writer.write(
+            "private static readonly IOperationProtocol<$L, $L> $L ="
+                + " $LServiceProtocol.ForOperation($L);",
+            SchemaGenerator.operationShapeType(context, op.getInputShape()),
+            SchemaGenerator.operationShapeType(context, op.getOutputShape()),
+            operationProtocolField(kind, op),
+            mapSuffix(kind),
+            SchemaGenerator.operationSchemaAccessor(context, op));
+      }
+    }
+  }
+
+  private void writeSelectableMapMethod(
+      String contract, List<Kind> serverKinds, String protocolEnum) {
+    writer.write(
+        "public static IEndpointRouteBuilder Map$L(this IEndpointRouteBuilder endpoints,"
+            + " $L protocols = $L.$L)",
+        contract,
+        protocolEnum,
+        protocolEnum,
+        mapSuffix(serverKinds.get(0)));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("System.ArgumentNullException.ThrowIfNull(endpoints);");
+          writer.write("if ((protocols & ~$L.All) != 0)", protocolEnum);
+          writer.openBlock(
+              "{",
+              "}",
+              () ->
+                  writer.write(
+                      "throw new System.ArgumentOutOfRangeException(nameof(protocols), protocols,"
+                          + " \"Unknown $L value.\");",
+                      protocolEnum));
+          writer.write("");
+          writer.write(
+              "var mappedRoutes = new System.Collections.Generic.HashSet<string>("
+                  + "System.StringComparer.Ordinal);");
+          for (Kind kind : serverKinds) {
+            writer.write("if ((protocols & $L.$L) != 0)", protocolEnum, mapSuffix(kind));
+            writer.openBlock(
+                "{",
+                "}",
+                () -> writer.write("Map$L$L(endpoints, mappedRoutes);", contract, mapSuffix(kind)));
           }
           writer.write("");
+          writer.write("return endpoints;");
+        });
+  }
 
-          writer.write(
-              "public static IEndpointRouteBuilder Map$L$L(this IEndpointRouteBuilder endpoints)",
-              contract,
-              suffix);
+  private void writeRouteConflictHelper(String contract, String protocolEnum) {
+    writer.write(
+        "private static void EnsureRouteAvailable(System.Collections.Generic.HashSet<string>"
+            + " mappedRoutes, string method, string routePattern, $L protocol)",
+        protocolEnum);
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("var route = method + \" \" + routePattern;");
+          writer.write("if (!mappedRoutes.Add(route))");
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(endpoints);");
-                writer.write("");
-                for (OperationShape op : ops) {
-                  if (!canBindOperation(kind, op)) {
-                    continue;
-                  }
-                  writeOperationMap(kind, op);
-                  writer.write("");
-                }
-                writer.write("return endpoints;");
+                writer.write(
+                    "throw new System.InvalidOperationException(\"Mapping \" + protocol + \" for"
+                        + " $L would register duplicate route '\" + route + \"'. Map conflicting"
+                        + " protocols on different endpoint route builders, hosts, or ports.\");",
+                    contract);
               });
         });
   }
 
-  private void writeOperationMap(Kind kind, OperationShape op) {
+  private void writeProtocolMapHelper(
+      Kind kind, List<OperationShape> ops, String contract, String protocolEnum) {
+    writer.write(
+        "private static void Map$L$L(IEndpointRouteBuilder endpoints,"
+            + " System.Collections.Generic.HashSet<string> mappedRoutes)",
+        contract,
+        mapSuffix(kind));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          for (OperationShape op : ops) {
+            if (!canBindOperation(kind, op)) {
+              continue;
+            }
+            writeOperationMap(kind, op, protocolEnum);
+            writer.write("");
+          }
+        });
+  }
+
+  private void writeOperationMap(Kind kind, OperationShape op, String protocolEnum) {
     String opInterface = opHandlerName(op);
     boolean rest = kind == Kind.SIMPLE_REST_JSON || kind == Kind.REST_JSON_1;
     if (rest) {
       HttpTrait http = op.expectTrait(HttpTrait.class);
+      writer.write(
+          "EnsureRouteAvailable(mappedRoutes, $L, $L, $L.$L);",
+          CSharpNaming.formatString(http.getMethod()),
+          CSharpNaming.formatString(routePattern(http)),
+          protocolEnum,
+          mapSuffix(kind));
       writer.openBlock(
           "endpoints.MapMethods($L, [$L], async (HttpContext httpContext, $L handler,"
               + " System.Threading.CancellationToken"
@@ -230,6 +334,11 @@ public final class ServerGenerator implements Runnable {
                 + "/"
                 + op.getId().getName()
             : "/service/" + service.getId().getName() + "/operation/" + op.getId().getName();
+    writer.write(
+        "EnsureRouteAvailable(mappedRoutes, \"POST\", $L, $L.$L);",
+        CSharpNaming.formatString(uri),
+        protocolEnum,
+        mapSuffix(kind));
     writer.openBlock(
         "endpoints.MapPost($L, async (HttpContext httpContext, $L handler,"
             + " System.Threading.CancellationToken cancellationToken) => {",
@@ -246,7 +355,6 @@ public final class ServerGenerator implements Runnable {
 
   private void writeDispatch(Kind kind, OperationShape op) {
     Model model = context.model();
-    String opProtocol = CSharpNaming.typeName(op.getId().getName()) + "Protocol";
     boolean streamRequestBody =
         isInputStreaming(model, op)
             || ((kind == Kind.SIMPLE_REST_JSON || kind == Kind.REST_JSON_1)
@@ -254,7 +362,7 @@ public final class ServerGenerator implements Runnable {
     writer.write(
         "await SmithyAspNetCoreHost.DispatchAsync(httpContext, $L, $L, $L,"
             + " cancellationToken).ConfigureAwait(false);",
-        opProtocol,
+        operationProtocolField(kind, op),
         unaryAdapter(op),
         streamRequestBody ? "true" : "false");
   }
@@ -343,6 +451,14 @@ public final class ServerGenerator implements Runnable {
       case GRPC -> "Grpc";
       default -> throw new IllegalStateException("Unsupported server protocol: " + kind);
     };
+  }
+
+  private static String protocolEnumName(String contract) {
+    return contract + "Protocols";
+  }
+
+  private static String operationProtocolField(Kind kind, OperationShape op) {
+    return CSharpNaming.typeName(op.getId().getName()) + mapSuffix(kind) + "Protocol";
   }
 
   private static String serviceContractName(String serviceTypeName) {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -135,6 +135,46 @@ final class ServerGeneratorTest {
       structure restJson1 {}
       """;
 
+  private static final String MULTI_PROTOCOL_TRAITS =
+      """
+      $version: "2"
+
+      namespace aws.protocols
+
+      use smithy.api#protocolDefinition
+      use smithy.api#trait
+
+      @trait(selector: "service")
+      @protocolDefinition
+      structure restJson1 {}
+
+      ---
+
+      $version: "2"
+
+      namespace alloy
+
+      use smithy.api#protocolDefinition
+      use smithy.api#trait
+
+      @trait(selector: "service")
+      @protocolDefinition
+      structure simpleRestJson {}
+
+      ---
+
+      $version: "2"
+
+      namespace smithy.protocols
+
+      use smithy.api#protocolDefinition
+      use smithy.api#trait
+
+      @trait(selector: "service")
+      @protocolDefinition
+      structure rpcv2Cbor {}
+      """;
+
   private static final String REST_STREAMING_MODEL =
       """
       $version: "2"
@@ -178,6 +218,37 @@ final class ServerGeneratorTest {
       }
       """;
 
+  private static final String MULTI_PROTOCOL_MODEL =
+      """
+      $version: "2"
+
+      namespace example.multi
+
+      use alloy#simpleRestJson
+      use aws.protocols#restJson1
+      use smithy.protocols#rpcv2Cbor
+
+      @rpcv2Cbor
+      @simpleRestJson
+      @restJson1
+      service MultiService {
+          version: "1"
+          operations: [GetThing]
+      }
+
+      @http(method: "GET", uri: "/things/{id}")
+      operation GetThing {
+          input := {
+              @required
+              @httpLabel
+              id: String
+          }
+          output := {
+              name: String
+          }
+      }
+      """;
+
   @Test
   void streamingGrpcServerUsesAsyncEnumerableHandlersAndStreamingWriter() throws Exception {
     String generated = renderServer();
@@ -203,10 +274,18 @@ final class ServerGeneratorTest {
     assertFalse(generated.contains("IEventStreamServiceProtocol"));
     // Streaming endpoints delegate to the shared runtime path; only request-body streaming is
     // selected per operation.
-    assertTrue(generated.contains("WatchProtocol, handler.WatchAsync, false"), generated);
-    assertTrue(generated.contains("UploadProtocol, handler.UploadAsync, true"), generated);
-    assertTrue(generated.contains("ChatProtocol, handler.ChatAsync, true"), generated);
-    assertTrue(generated.contains("MapStreamingServiceGrpc"), generated);
+    assertTrue(generated.contains("WatchGrpcProtocol, handler.WatchAsync, false"), generated);
+    assertTrue(generated.contains("UploadGrpcProtocol, handler.UploadAsync, true"), generated);
+    assertTrue(generated.contains("ChatGrpcProtocol, handler.ChatAsync, true"), generated);
+    assertTrue(
+        generated.contains(
+            "public static IEndpointRouteBuilder MapStreamingService(this IEndpointRouteBuilder"
+                + " endpoints, StreamingServiceProtocols protocols ="
+                + " StreamingServiceProtocols.Grpc)"),
+        generated);
+    assertFalse(
+        generated.contains("public static IEndpointRouteBuilder MapStreamingServiceGrpc"),
+        generated);
   }
 
   @Test
@@ -232,11 +311,67 @@ final class ServerGeneratorTest {
             "example.reststreaming#StreamingService",
             "Example.RestStreaming");
 
-    assertTrue(generated.contains("MapStreamingServiceRestJson1"), generated);
+    assertTrue(generated.contains("public enum StreamingServiceProtocols"), generated);
+    assertTrue(generated.contains("RestJson1 = 1,"), generated);
+    assertTrue(generated.contains("All = RestJson1,"), generated);
+    assertTrue(
+        generated.contains(
+            "public static IEndpointRouteBuilder MapStreamingService(this IEndpointRouteBuilder"
+                + " endpoints, StreamingServiceProtocols protocols ="
+                + " StreamingServiceProtocols.RestJson1)"),
+        generated);
+    assertFalse(
+        generated.contains("public static IEndpointRouteBuilder MapStreamingServiceRestJson1"),
+        generated);
     assertTrue(generated.contains("endpoints.MapMethods(\"/watch\", [\"GET\"]"), generated);
-    assertTrue(generated.contains("WatchProtocol, handler.WatchAsync, false"), generated);
+    assertTrue(generated.contains("WatchRestJson1Protocol, handler.WatchAsync, false"), generated);
     assertTrue(generated.contains("endpoints.MapMethods(\"/upload\", [\"POST\"]"), generated);
-    assertTrue(generated.contains("UploadProtocol, handler.UploadAsync, true"), generated);
+    assertTrue(generated.contains("UploadRestJson1Protocol, handler.UploadAsync, true"), generated);
+  }
+
+  @Test
+  void multiProtocolServersGenerateSelectableMapperAndRouteConflictChecks() throws Exception {
+    String generated =
+        renderServer(
+            MULTI_PROTOCOL_TRAITS,
+            MULTI_PROTOCOL_MODEL,
+            "example.multi#MultiService",
+            "Example.Multi");
+
+    assertTrue(generated.contains("public enum MultiServiceProtocols"), generated);
+    assertTrue(generated.contains("RpcV2Cbor = 1,"), generated);
+    assertTrue(generated.contains("SimpleRestJson = 2,"), generated);
+    assertTrue(generated.contains("RestJson1 = 4,"), generated);
+    assertTrue(generated.contains("All = RpcV2Cbor | SimpleRestJson | RestJson1,"), generated);
+    assertTrue(
+        generated.contains(
+            "public static IEndpointRouteBuilder MapMultiService(this IEndpointRouteBuilder"
+                + " endpoints, MultiServiceProtocols protocols = MultiServiceProtocols.RpcV2Cbor)"),
+        generated);
+    assertTrue(generated.contains("if ((protocols & ~MultiServiceProtocols.All) != 0)"), generated);
+    assertTrue(
+        generated.contains("if ((protocols & MultiServiceProtocols.SimpleRestJson) != 0)"),
+        generated);
+    assertTrue(
+        generated.contains(
+            "EnsureRouteAvailable(mappedRoutes, \"GET\", \"/things/{id}\","
+                + " MultiServiceProtocols.SimpleRestJson);"),
+        generated);
+    assertTrue(
+        generated.contains(
+            "EnsureRouteAvailable(mappedRoutes, \"GET\", \"/things/{id}\","
+                + " MultiServiceProtocols.RestJson1);"),
+        generated);
+    assertTrue(
+        generated.contains(
+            "Map conflicting protocols on different endpoint route builders, hosts, or ports."),
+        generated);
+    assertFalse(
+        generated.contains("public static IEndpointRouteBuilder MapMultiServiceRestJson1"),
+        generated);
+    assertFalse(
+        generated.contains("public static IEndpointRouteBuilder MapMultiServiceRpcV2Cbor"),
+        generated);
   }
 
   private String renderServer() throws Exception {
@@ -251,12 +386,12 @@ final class ServerGeneratorTest {
   private String renderServer(
       String protocolTraits, String modelText, String serviceId, String writerNamespace)
       throws Exception {
-    Model model =
-        Model.assembler()
-            .addUnparsedModel("protocol-traits.smithy", protocolTraits)
-            .addUnparsedModel("model.smithy", modelText)
-            .assemble()
-            .unwrap();
+    var assembler = Model.assembler();
+    String[] protocolTraitModels = protocolTraits.split("(?m)^---$");
+    for (int i = 0; i < protocolTraitModels.length; i++) {
+      assembler.addUnparsedModel("protocol-traits-" + i + ".smithy", protocolTraitModels[i]);
+    }
+    Model model = assembler.addUnparsedModel("model.smithy", modelText).assemble().unwrap();
     CSharpSettings settings =
         CSharpSettings.fromNode(
             ObjectNode.builder()

--- a/designs/server-architecture.md
+++ b/designs/server-architecture.md
@@ -261,14 +261,14 @@ bolted-on feature:
 - Dispatch is parameterized by that binding, so the same handler delegate serves
   every protocol.
 
-Codegen emits one `Map{Service}{Protocol}` endpoint extension per protocol trait
-on the service, each building its own bindings and all resolving the same
-DI-registered handler:
+Codegen emits one `Map{Service}` endpoint extension with a generated
+`{Service}Protocols` flags enum. Each selected protocol builds its own bindings
+and resolves the same DI-registered handler:
 
 ```csharp
-app.MapWeatherRestJson();    // @http routes:      POST /forecast
-app.MapWeatherRpcV2Cbor();   // structured routes: /service/Weather/operation/GetForecast
-services.AddWeatherHandler<MyWeatherHandler>();   // one handler, both
+app.MapWeatherService(
+    WeatherServiceProtocols.RestJson1 | WeatherServiceProtocols.RpcV2Cbor);
+services.AddWeatherServiceHandler<MyWeatherHandler>();   // one handler, both
 ```
 
 Two rules keep the handler shared across protocols:
@@ -282,8 +282,8 @@ Two rules keep the handler shared across protocols:
 
 ### Listeners and Ports
 
-Generated `Map{Service}{Protocol}` extensions are port-agnostic — ports are a
-deployment concern, not a model concern, so codegen never binds one. Whether two
+Generated `Map{Service}` extensions are port-agnostic — ports are a deployment
+concern, not a model concern, so codegen never binds one. Whether two
 protocols can share a listener depends on their routes and transport:
 
 - **Disjoint routes share a port.** restJson1 (`@http` paths), rpcv2Cbor
@@ -301,7 +301,9 @@ The scoping mechanism is ASP.NET Core's `RequireHost`, applied by the app, not t
 generator:
 
 ```csharp
-app.MapWeatherGrpc().RequireHost("*:5002");   // gRPC on its own HTTP/2 port
+app.MapGroup("")
+    .RequireHost("*:5002")
+    .MapWeatherService(WeatherServiceProtocols.Grpc);   // gRPC on its own HTTP/2 port
 ```
 
 ## Streaming Type Naming

--- a/examples/grpc-streaming/server/Program.cs
+++ b/examples/grpc-streaming/server/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddSingleton<ChatRooms>();
 builder.Services.AddChatServiceHandler<ChatHandler>();
 
 var app = builder.Build();
-app.MapChatServiceGrpc();
+app.MapChatService();
 app.Run();
 
 internal sealed class ChatHandler(ChatRooms rooms) : IChatServiceHandler

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -13,7 +13,7 @@ numbers, `@protoNumType` (`uint32`, `fixed64`), `@sparse` maps,
 
 - `contracts`: the Smithy model, packaged as a contracts project.
 - `server`: ASP.NET Core server on Kestrel HTTP/2 that maps the generated gRPC
-  endpoints via `MapLibraryServiceGrpc()`.
+  endpoints via `MapLibraryService()`.
 - `client`: generated typed client that selects gRPC with
   `Protocol = new GrpcProtocol()`.
 

--- a/examples/grpc/server/Program.cs
+++ b/examples/grpc/server/Program.cs
@@ -15,7 +15,7 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.AddLibraryServiceHandler<LibraryHandler>();
 
 var app = builder.Build();
-app.MapLibraryServiceGrpc();
+app.MapLibraryService();
 app.Run();
 
 internal sealed class LibraryHandler : ILibraryServiceHandler

--- a/examples/rest-json1/server/Program.cs
+++ b/examples/rest-json1/server/Program.cs
@@ -19,7 +19,7 @@ builder
 var app = builder.Build();
 app.MapSmithyOpenApi();
 app.MapSmithyDocs();
-app.MapWeatherServiceRestJson1();
+app.MapWeatherService();
 app.Run();
 
 internal sealed class WeatherHandler : IWeatherServiceHandler

--- a/examples/restjson1-streaming/server/Program.cs
+++ b/examples/restjson1-streaming/server/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddSingleton<ChatRooms>();
 builder.Services.AddChatServiceHandler<ChatHandler>();
 
 var app = builder.Build();
-app.MapChatServiceRestJson1();
+app.MapChatService();
 app.Run();
 
 internal sealed class ChatHandler(ChatRooms rooms) : IChatServiceHandler

--- a/examples/rpcv2cbor-streaming/server/Program.cs
+++ b/examples/rpcv2cbor-streaming/server/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddSingleton<ChatRooms>();
 builder.Services.AddChatServiceHandler<ChatHandler>();
 
 var app = builder.Build();
-app.MapChatServiceRpcV2Cbor();
+app.MapChatService();
 app.Run();
 
 internal sealed class ChatHandler(ChatRooms rooms) : IChatServiceHandler

--- a/examples/rpcv2cbor/server/Program.cs
+++ b/examples/rpcv2cbor/server/Program.cs
@@ -7,7 +7,7 @@ builder.WebHost.UseUrls($"http://localhost:{port}");
 builder.Services.AddWeatherServiceHandler<WeatherHandler>();
 
 var app = builder.Build();
-app.MapWeatherServiceRpcV2Cbor();
+app.MapWeatherService();
 app.Run();
 
 internal sealed class WeatherHandler : IWeatherServiceHandler

--- a/examples/simple-rest-json/server/Program.cs
+++ b/examples/simple-rest-json/server/Program.cs
@@ -6,7 +6,7 @@ builder.Services.AddPizzaAdminServiceHandler<PizzaHandler>();
 
 var app = builder.Build();
 app.MapSmithyDocs();
-app.MapPizzaAdminServiceSimpleRestJson();
+app.MapPizzaAdminService();
 app.Run();
 
 internal sealed class PizzaHandler : IPizzaAdminServiceHandler

--- a/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
+++ b/templates/NSmithy.Templates/content/nsmithy-server/Program.cs
@@ -32,7 +32,7 @@ app.MapSmithyDocs();
 
 //#endif
 //#if (IsGrpc)
-app.MapHelloServiceGrpc();
+app.MapHelloService();
 
 //#else
 app.MapHelloServiceHttp();

--- a/tests/Conformance/RestJson1/Conformance/ServerConformanceSupport.cs
+++ b/tests/Conformance/RestJson1/Conformance/ServerConformanceSupport.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
@@ -51,7 +52,7 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
 
         var operationHandler = ResolveOperationHandlerInterface(operationName);
         var aggregateHandler = ResolveAggregateHandlerInterface(operationHandler);
-        var mapMethod = ResolveMapMethod(aggregateHandler);
+        var map = ResolveMapMethod(aggregateHandler);
         var handler = CreateProxy(aggregateHandler, invoker);
 
         builder.Services.AddSingleton(aggregateHandler, handler);
@@ -77,7 +78,7 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
                 }
             }
         );
-        mapMethod.Invoke(null, [app]);
+        map.MapMethod.Invoke(null, [app, map.Protocol]);
         await app.StartAsync(cancellationToken).ConfigureAwait(false);
 
         var address =
@@ -121,21 +122,30 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
             );
     }
 
-    private static MethodInfo ResolveMapMethod(Type aggregateHandler)
+    private static (MethodInfo MapMethod, object Protocol) ResolveMapMethod(Type aggregateHandler)
     {
         var serviceName = aggregateHandler.Name["I".Length..^"Handler".Length];
-        return aggregateHandler
+        var protocolType = aggregateHandler
+            .Assembly.GetTypes()
+            .Single(t =>
+                t.IsEnum
+                && string.Equals(t.Name, serviceName + "Protocols", StringComparison.Ordinal)
+            );
+        var protocol = Enum.Parse(protocolType, "RestJson1");
+        var endpointRouteBuilderType = typeof(IEndpointRouteBuilder);
+        var method = aggregateHandler
             .Assembly.GetTypes()
             .Where(t => t.IsSealed && t.IsAbstract)
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
             .Single(m =>
             {
                 var parameters = m.GetParameters();
-                return m.Name == $"Map{serviceName}RestJson1"
-                    && parameters.Length == 1
-                    && parameters[0].ParameterType.FullName
-                        == "Microsoft.AspNetCore.Routing.IEndpointRouteBuilder";
+                return m.Name == $"Map{serviceName}"
+                    && parameters.Length == 2
+                    && parameters[0].ParameterType == endpointRouteBuilderType
+                    && parameters[1].ParameterType == protocolType;
             });
+        return (method, protocol);
     }
 
     private static object CreateProxy(

--- a/tests/Conformance/RpcV2Cbor/Conformance/ServerConformanceSupport.cs
+++ b/tests/Conformance/RpcV2Cbor/Conformance/ServerConformanceSupport.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace RpcV2Cbor.Conformance;
@@ -43,7 +44,7 @@ internal sealed class RpcV2CborServerHost : IAsyncDisposable
 
         var operationHandler = ResolveOperationHandlerInterface(operationName);
         var aggregateHandler = ResolveAggregateHandlerInterface(operationHandler);
-        var mapMethod = ResolveMapMethod(aggregateHandler);
+        var map = ResolveMapMethod(aggregateHandler);
         var handler = CreateProxy(aggregateHandler, invoker);
 
         builder.Services.AddSingleton(aggregateHandler, handler);
@@ -53,7 +54,7 @@ internal sealed class RpcV2CborServerHost : IAsyncDisposable
         }
 
         var app = builder.Build();
-        mapMethod.Invoke(null, [app]);
+        map.MapMethod.Invoke(null, [app, map.Protocol]);
         await app.StartAsync(cancellationToken).ConfigureAwait(false);
 
         var address =
@@ -97,21 +98,30 @@ internal sealed class RpcV2CborServerHost : IAsyncDisposable
             );
     }
 
-    private static MethodInfo ResolveMapMethod(Type aggregateHandler)
+    private static (MethodInfo MapMethod, object Protocol) ResolveMapMethod(Type aggregateHandler)
     {
         var serviceName = aggregateHandler.Name["I".Length..^"Handler".Length];
-        return aggregateHandler
+        var protocolType = aggregateHandler
+            .Assembly.GetTypes()
+            .Single(t =>
+                t.IsEnum
+                && string.Equals(t.Name, serviceName + "Protocols", StringComparison.Ordinal)
+            );
+        var protocol = Enum.Parse(protocolType, "RpcV2Cbor");
+        var endpointRouteBuilderType = typeof(IEndpointRouteBuilder);
+        var method = aggregateHandler
             .Assembly.GetTypes()
             .Where(t => t.IsSealed && t.IsAbstract)
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
             .Single(m =>
             {
                 var parameters = m.GetParameters();
-                return m.Name == $"Map{serviceName}RpcV2Cbor"
-                    && parameters.Length == 1
-                    && parameters[0].ParameterType.FullName
-                        == "Microsoft.AspNetCore.Routing.IEndpointRouteBuilder";
+                return m.Name == $"Map{serviceName}"
+                    && parameters.Length == 2
+                    && parameters[0].ParameterType == endpointRouteBuilderType
+                    && parameters[1].ParameterType == protocolType;
             });
+        return (method, protocol);
     }
 
     private static object CreateProxy(

--- a/tests/Conformance/SimpleRestJson/Conformance/ServerConformanceSupport.cs
+++ b/tests/Conformance/SimpleRestJson/Conformance/ServerConformanceSupport.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
@@ -50,7 +51,7 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
 
         var operationHandler = ResolveOperationHandlerInterface(operationName);
         var aggregateHandler = ResolveAggregateHandlerInterface(operationHandler);
-        var mapMethod = ResolveMapMethod(aggregateHandler);
+        var map = ResolveMapMethod(aggregateHandler);
         var handler = CreateProxy(aggregateHandler, invoker);
 
         builder.Services.AddSingleton(aggregateHandler, handler);
@@ -76,7 +77,7 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
                 }
             }
         );
-        mapMethod.Invoke(null, [app]);
+        map.MapMethod.Invoke(null, [app, map.Protocol]);
         await app.StartAsync(cancellationToken).ConfigureAwait(false);
 
         var address =
@@ -120,21 +121,30 @@ internal sealed class RestJsonServerHost : IAsyncDisposable
             );
     }
 
-    private static MethodInfo ResolveMapMethod(Type aggregateHandler)
+    private static (MethodInfo MapMethod, object Protocol) ResolveMapMethod(Type aggregateHandler)
     {
         var serviceName = aggregateHandler.Name["I".Length..^"Handler".Length];
-        return aggregateHandler
+        var protocolType = aggregateHandler
+            .Assembly.GetTypes()
+            .Single(t =>
+                t.IsEnum
+                && string.Equals(t.Name, serviceName + "Protocols", StringComparison.Ordinal)
+            );
+        var protocol = Enum.Parse(protocolType, "SimpleRestJson");
+        var endpointRouteBuilderType = typeof(IEndpointRouteBuilder);
+        var method = aggregateHandler
             .Assembly.GetTypes()
             .Where(t => t.IsSealed && t.IsAbstract)
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
             .Single(m =>
             {
                 var parameters = m.GetParameters();
-                return m.Name == $"Map{serviceName}SimpleRestJson"
-                    && parameters.Length == 1
-                    && parameters[0].ParameterType.FullName
-                        == "Microsoft.AspNetCore.Routing.IEndpointRouteBuilder";
+                return m.Name == $"Map{serviceName}"
+                    && parameters.Length == 2
+                    && parameters[0].ParameterType == endpointRouteBuilderType
+                    && parameters[1].ParameterType == protocolType;
             });
+        return (method, protocol);
     }
 
     private static object CreateProxy(

--- a/website/src/components/landing/Walkthrough.astro
+++ b/website/src/components/landing/Walkthrough.astro
@@ -52,8 +52,8 @@ public class WeatherHandler : IWeatherHandler
 }
 
 // register the handler, map the routes + docs
-builder.Services.AddWeatherHandler<WeatherHandler>();
-app.MapWeatherHttp();     // REST routes -> /forecast/{city}
+builder.Services.AddWeatherServiceHandler<WeatherHandler>();
+app.MapWeatherService();  // REST routes -> /forecast/{city}
 app.MapSmithyOpenApi();   // Scalar UI   -> /openapi
 app.MapSmithyDocs();      // Sphinx docs -> /docs`,
   },
@@ -83,7 +83,7 @@ function hl(code: string, lang: 'smithy' | 'csharp'): string {
   const types =
     lang === 'smithy'
       ? ['String', 'Float', 'Integer', 'Boolean', 'Long', 'Double', 'Timestamp', 'Blob', 'Document']
-      : ['Task', 'CancellationToken', 'String', 'Float', 'Console', 'IWeatherClient', 'WeatherClient', 'GetForecastInput', 'GetForecastOutput', 'IWeatherHandler', 'WeatherHandler'];
+      : ['Task', 'CancellationToken', 'String', 'Float', 'Console', 'IWeatherClient', 'WeatherClient', 'GetForecastInput', 'GetForecastOutput', 'IWeatherHandler', 'WeatherHandler', 'AddWeatherServiceHandler', 'MapWeatherService'];
   const re = /(\/\/[^\n]*)|("(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`)|(@[A-Za-z][\w.#]*|\$[a-z]+)|\b([A-Za-z_][A-Za-z0-9_]*)\b/g;
   return esc(code).replace(re, (m, comment, str, ann, word) => {
     if (comment) return `<span style="color:#6b7280">${comment}</span>`;

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -60,17 +60,7 @@ Adding this would improve the IDE experience for consumers of generated code —
 hover documentation, parameter hints, and IntelliSense would reflect the
 model's documentation rather than being empty.
 
-### 4. Improve generator clarity and diagnostics
-
-- Keep generated output predictable and easy to inspect.
-- Improve unsupported-shape and unsupported-trait diagnostics.
-- Continue simplifying generator internals where semantics are harder to follow
-  than they need to be.
-- Revisit the generated server mapping API so service mapping can be
-  protocol-selectable, for example `MapFooService(protocols)`, while preserving
-  protocol-specific internals and handling route conflicts explicitly.
-
-### 5. Enforce constraint traits and modeled validation
+### 4. Enforce constraint traits and modeled validation
 
 Smithy's constraint traits — `@length`, `@pattern`, `@range`, `@uniqueItems`,
 and server-side enforcement of `@required` — are not yet enforced. `@required`
@@ -90,7 +80,7 @@ This work includes:
 - Covering server behavior with Smithy's malformed-request conformance suites.
 - Documenting the client-side non-goal as an explicit preview boundary.
 
-### 6. Improve CBOR and XML codec performance through schema-compiled codecs
+### 5. Improve CBOR and XML codec performance through schema-compiled codecs
 
 JSON already benefits from compiling codec state once from the schema so the
 runtime can cache structural decisions such as dispatch and boxing behavior.
@@ -107,7 +97,7 @@ This work includes:
 - Keeping the generated codec path explicit enough that performance work does
   not make diagnostics and debuggability worse.
 
-### 7. Harden streaming operations
+### 6. Harden streaming operations
 
 NSmithy has two experimental event-streaming surfaces: native gRPC (client,
 server, and bidirectional streaming) and `rpcv2Cbor` event streams over
@@ -123,7 +113,7 @@ This work includes:
 - Extending streaming support beyond event streams, especially streaming blob
   payloads.
 
-### 8. Expand to async protocols
+### 7. Expand to async protocols
 
 NSmithy's current protocol work is mostly request/response oriented. A separate
 near-term goal is to validate that the runtime and generator model can also
@@ -138,7 +128,7 @@ This work includes:
 - Using these protocols to pressure-test the existing transport, codec, and
   client/server seams beyond HTTP-centric assumptions.
 
-### 9. Support Smithy AI traits and MCP generation
+### 8. Support Smithy AI traits and MCP generation
 
 Support Smithy's AI-oriented traits so that .NET and protocol artifacts can be
 generated for tool-driven and agent-driven workflows, rather than treating the
@@ -152,7 +142,7 @@ This work includes:
 - Defining the runtime and generation boundaries needed so AI-trait-aware
   models remain inspectable, testable, and versionable.
 
-### 10. Honor protocol HTTP-version traits
+### 9. Honor protocol HTTP-version traits
 
 Protocol traits can declare the HTTP versions a service supports via their `http`
 and `eventStreamHttp` members — a list of ALPN protocol IDs in preference order

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -173,7 +173,7 @@ The generated server uses [ASP.NET Core minimal API](https://learn.microsoft.com
 ```csharp
 builder.Services.AddHelloServiceHandler<HelloHandler>();
 
-app.MapHelloServiceRestJson1();
+app.MapHelloService();
 ```
 
 `HelloHandler` (also generated as a starter) returns a greeting:

--- a/website/src/content/docs/guides/endpoint-documentation.md
+++ b/website/src/content/docs/guides/endpoint-documentation.md
@@ -71,7 +71,7 @@ using NSmithy.Server.AspNetCore.Docs;
 var app = builder.Build();
 app.MapSmithyOpenApi(); // mounts Scalar at /openapi (requires SmithyOpenApiProtocol)
 app.MapSmithyDocs();    // serves Sphinx HTML at /docs (requires SmithyGenerateDocs)
-app.MapMyServiceRestJson1();
+app.MapMyService();
 app.Run();
 ```
 

--- a/website/src/content/docs/protocols/grpc.md
+++ b/website/src/content/docs/protocols/grpc.md
@@ -114,7 +114,7 @@ itself works the same way — you implement one method per operation.
 
 Configure Kestrel to serve HTTP/2 on a dedicated port. Cleartext gRPC requires
 HTTP/2; mixing HTTP/1.1 REST and cleartext gRPC on the same port is unreliable
-without TLS/ALPN. There is no `AddGrpc()` call — the generated `MapWeatherServiceGrpc`
+without TLS/ALPN. There is no `AddGrpc()` call — the generated `MapWeatherService`
 maps the gRPC method routes itself:
 
 ```csharp
@@ -129,7 +129,7 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.AddWeatherServiceHandler<WeatherHandler>();
 
 var app = builder.Build();
-app.MapWeatherServiceGrpc();
+app.MapWeatherService();
 app.Run();
 
 internal sealed class WeatherHandler : IWeatherServiceHandler

--- a/website/src/content/docs/servers/hosting.md
+++ b/website/src/content/docs/servers/hosting.md
@@ -4,17 +4,18 @@ description: Expose one service over several protocols from a single handler set
 ---
 
 A service can declare more than one protocol trait. When it does, codegen emits
-a `Map{Service}{Protocol}` extension per protocol, and every one of them
-resolves the **same** handler you registered with `Add{Service}Handler`. The
-handler deals only in model types, so nothing about it is protocol-specific.
+a `Map{Service}` extension with a generated `{Service}Protocols` flags enum.
+Every selected protocol resolves the **same** handler you registered with
+`Add{Service}Handler`. The handler deals only in model types, so nothing about
+it is protocol-specific.
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddWeatherServiceHandler<WeatherHandler>();   // one handler
 
 var app = builder.Build();
-app.MapWeatherServiceRestJson1();    // POST /forecast
-app.MapWeatherServiceRpcV2Cbor();    // /service/Weather/operation/GetForecast
+app.MapWeatherService(
+    WeatherServiceProtocols.RestJson1 | WeatherServiceProtocols.RpcV2Cbor);
 app.Run();
 ```
 
@@ -24,7 +25,7 @@ lives entirely in each protocol's binding.
 ## What can share a port
 
 Endpoints are port-agnostic — ports are a deployment concern, so the generated
-`Map` extensions never bind one. Whether two protocols can share a listener
+`Map` extension never binds one. Whether two protocols can share a listener
 depends on their routes and transport:
 
 - **Disjoint routes share a port.** restJson1 (`@http` paths), rpcv2Cbor
@@ -51,8 +52,11 @@ builder.WebHost.ConfigureKestrel(options =>
 });
 
 var app = builder.Build();
-app.MapWeatherServiceRestJson1();
-app.MapWeatherServiceGrpc().RequireHost("*:5001");
+app.MapGroup("")
+    .MapWeatherService(WeatherServiceProtocols.RestJson1);
+app.MapGroup("")
+    .RequireHost("*:5001")
+    .MapWeatherService(WeatherServiceProtocols.Grpc);
 app.Run();
 ```
 

--- a/website/src/content/docs/servers/index.md
+++ b/website/src/content/docs/servers/index.md
@@ -62,21 +62,20 @@ served.
 
 ## Map the endpoints
 
-Each declared protocol generates a `Map{Service}{Protocol}` extension —
-`MapWeatherServiceRestJson1`, `MapWeatherServiceRpcV2Cbor`,
-`MapWeatherServiceGrpc`, and so on. Call the one for the protocol your service
-declares:
+Each server generates a `Map{Service}` extension. By default it maps the first
+declared server protocol; for multi-protocol services, pass the generated
+`{Service}Protocols` flags enum to select one or more protocols:
 
 ```csharp
 var app = builder.Build();
-app.MapWeatherServiceRestJson1();
+app.MapWeatherService();
 app.Run();
 ```
 
 The endpoint is thin: it binds the route to your handler method and the
 operation's bound protocol, and delegates to the runtime. A service that
-declares several protocols gets one `Map` per protocol and can serve them all
-from the same handler — see [Hosting &amp; Multiple Protocols](/smithy-dotnet/servers/hosting/).
+declares several protocols can serve selected protocols from the same handler —
+see [Hosting &amp; Multiple Protocols](/smithy-dotnet/servers/hosting/).
 
 ## Implement the handler
 


### PR DESCRIPTION
Closes #116.

- Replace protocol-specific server mapper methods with a protocol flags argument.
- Add route conflict checks for selected protocols.
- Update docs, examples, and roadmap.