### PR TITLE
Emit XML docs from Smithy documentation traits

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -14,7 +14,9 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport.Kind
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -28,6 +30,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -64,6 +67,7 @@ public final class ClientGenerator implements Runnable {
     String interfaceName = "I" + typeName;
 
     // Interface — IDisposable so a client that owns its HttpClient is released via `using` or DI.
+    writer.writeXmlDocs(service);
     writer.write("public interface $L : System.IDisposable", interfaceName);
     writer.openBlock(
         "{",
@@ -71,13 +75,19 @@ public final class ClientGenerator implements Runnable {
         () -> {
           writer.write("");
           for (OperationShape op : operations) {
+            writer.writeXmlDocs(op, operationParameterDocs(model, op));
             writer.write("$L;", operationSignature(sp, op));
             paginationInfo(op)
                 .ifPresent(
                     info -> {
+                      writer.writeXmlDocs(op, operationParameterDocs(model, op));
                       writer.write("$L;", paginatorPagesSignature(sp, op));
                       paginatorItemsSignature(sp, info)
-                          .ifPresent(signature -> writer.write("$L;", signature));
+                          .ifPresent(
+                              signature -> {
+                                writer.writeXmlDocs(op, operationParameterDocs(model, op));
+                                writer.write("$L;", signature);
+                              });
                     });
           }
         });
@@ -117,6 +127,7 @@ public final class ClientGenerator implements Runnable {
     boolean needsRuntime = operations.stream().anyMatch(op -> canBindOperation(op));
     boolean needsIdempotency =
         operations.stream().anyMatch(op -> operationCanDefaultIdempotencyToken(model, op));
+    writer.writeXmlDocs(service);
     writer.write("public sealed class $L : $L", typeName, interfaceName);
     writer.openBlock(
         "{",
@@ -439,6 +450,7 @@ public final class ClientGenerator implements Runnable {
   // ---------------- per-operation method ----------------
 
   private void writeOperationMethod(SymbolProvider sp, Model model, OperationShape op) {
+    writer.writeXmlDocs(op, operationParameterDocs(model, op));
     if (!canBindOperation(op)) {
       writer.write("public $L", operationSignature(sp, op));
       writer.openBlock(
@@ -589,6 +601,7 @@ public final class ClientGenerator implements Runnable {
     String tokenProperty = CSharpNaming.propertyName(info.getInputTokenMember().getMemberName());
     String outputTokenExpr = memberPathExpr("output", info.getOutputTokenMemberPath());
 
+    writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
     writer.write(
         "public async $L",
         paginatorPagesSignature(sp, op)
@@ -625,6 +638,7 @@ public final class ClientGenerator implements Runnable {
         .ifPresent(
             signature -> {
               String itemsExpr = memberPathExpr("page", info.getItemsMemberPath());
+              writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
               writer.write(
                   "public async $L",
                   signature.replace(
@@ -693,6 +707,18 @@ public final class ClientGenerator implements Runnable {
         + "("
         + params
         + "System.Threading.CancellationToken cancellationToken = default)";
+  }
+
+  private Map<String, String> operationParameterDocs(Model model, OperationShape op) {
+    if (ShapeSupport.isUnit(op.getInputShape())) {
+      return Map.of();
+    }
+    Map<String, String> docs = new LinkedHashMap<>();
+    model
+        .expectShape(op.getInputShape())
+        .getTrait(DocumentationTrait.class)
+        .ifPresent(trait -> docs.put("input", trait.getValue()));
+    return docs;
   }
 
   private boolean isEventStreamOperation(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -9,12 +9,15 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.RetryableTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -40,6 +43,7 @@ public final class ErrorGenerator implements Runnable {
     List<MemberShape> members = ShapeSupport.sortedMembers(shape);
 
     Optional<RetryableTrait> retryable = shape.getTrait(RetryableTrait.class);
+    writer.writeXmlDocs(shape);
     if (retryable.isPresent()) {
       writer.write(
           "public sealed partial class $L : System.Exception, NSmithy.Core.ISmithyRetryableError",
@@ -61,6 +65,7 @@ public final class ErrorGenerator implements Runnable {
           writeConstructor(typeName, messageMember.orElse(null));
           messageMember.ifPresent(
               mm -> {
+                writer.writeXmlDocs(mm);
                 writer.write("public override string Message => base.Message!;");
                 writer.write("");
               });
@@ -75,6 +80,21 @@ public final class ErrorGenerator implements Runnable {
     Model model = context.model();
     List<MemberShape> ctor = ShapeSupport.constructorMembers(shape, messageMember);
     boolean hasRequired = ctor.stream().anyMatch(m -> !ShapeSupport.isOptionalParameter(m));
+
+    Map<String, String> parameterDocs = new LinkedHashMap<>();
+    if (messageMember != null) {
+      messageMember
+          .getTrait(DocumentationTrait.class)
+          .ifPresent(trait -> parameterDocs.put("message", trait.getValue()));
+    }
+    for (MemberShape m : ctor) {
+      m.getTrait(DocumentationTrait.class)
+          .ifPresent(
+              trait ->
+                  parameterDocs.put(
+                      CSharpNaming.parameterName(m.getMemberName()), trait.getValue()));
+    }
+    writer.writeXmlDocs(shape, parameterDocs);
 
     StringBuilder sig = new StringBuilder("public ").append(typeName).append("(");
     sig.append("string? message");
@@ -119,6 +139,7 @@ public final class ErrorGenerator implements Runnable {
       String prop = CSharpNaming.propertyName(m.getMemberName());
       boolean nullable = ShapeSupport.isNullable(m);
       String type = ShapeSupport.memberTypeExpr(model, sp, m, nullable);
+      writer.writeXmlDocs(m);
       writer.write("public $L $L { get; }", type, prop);
     }
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
@@ -28,6 +28,7 @@ public final class IntEnumGenerator implements Runnable {
     writer.addImport(RuntimeTypes.NSMITHY_CORE);
     writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
     String typeName = CSharpNaming.typeName(shape.getId().getName());
+    writer.writeXmlDocs(shape);
     writer.write("public enum $L", typeName);
     writer.openBlock(
         "{",
@@ -37,6 +38,7 @@ public final class IntEnumGenerator implements Runnable {
             String prop = CSharpNaming.propertyName(m.getMemberName());
             Integer value =
                 m.getTrait(EnumValueTrait.class).flatMap(t -> t.getIntValue()).orElse(null);
+            writer.writeXmlDocs(m);
             if (value != null) {
               writer.write("$L = $L,", prop, value);
             } else {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -34,6 +34,7 @@ public final class ListGenerator implements Runnable {
     String memberType =
         CSharpSymbolProvider.qualified(member) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
+    writer.writeXmlDocs(shape);
     writer.write("public sealed partial record class $L", typeName);
     writer.openBlock(
         "{",
@@ -50,6 +51,7 @@ public final class ListGenerator implements Runnable {
                     "Values = System.Array.AsReadOnly(System.Linq.Enumerable.ToArray(values));");
               });
           writer.write("");
+          writer.writeXmlDocs(shape.getMember());
           writer.write(
               "public System.Collections.Generic.IReadOnlyList<$L> Values { get; }", memberType);
         });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -36,6 +36,7 @@ public final class MapGenerator implements Runnable {
     String valueType =
         CSharpSymbolProvider.qualified(value) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
+    writer.writeXmlDocs(shape);
     writer.write("public sealed partial record class $L", typeName);
     writer.openBlock(
         "{",
@@ -60,6 +61,7 @@ public final class MapGenerator implements Runnable {
                     valueType);
               });
           writer.write("");
+          writer.writeXmlDocs(shape.getValue());
           writer.write(
               "public System.Collections.Generic.IReadOnlyDictionary<$L, $L> Values { get; }",
               keyType,

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -21,13 +21,16 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport.Kind
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -92,8 +95,15 @@ public final class ServerGenerator implements Runnable {
 
     // Per-operation handler interfaces (streaming surface derived from the model).
     for (OperationShape op : ops) {
+      writer.writeXmlDocs(op, operationParameterDocs(op));
       writer.write("public interface $L", opHandlerName(op));
-      writer.openBlock("{", "}", () -> writer.write("$L;", serverOperationSignature(sp, op)));
+      writer.openBlock(
+          "{",
+          "}",
+          () -> {
+            writer.writeXmlDocs(op, operationParameterDocs(op));
+            writer.write("$L;", serverOperationSignature(sp, op));
+          });
       writer.write("");
     }
 
@@ -101,6 +111,7 @@ public final class ServerGenerator implements Runnable {
         ops.isEmpty()
             ? ""
             : " : " + ops.stream().map(this::opHandlerName).collect(Collectors.joining(", "));
+    writer.writeXmlDocs(service);
     writer.write("public interface $L$L { }", aggInterface, inherits);
     writer.write("");
 
@@ -498,6 +509,19 @@ public final class ServerGenerator implements Runnable {
         + "("
         + params
         + "System.Threading.CancellationToken cancellationToken = default)";
+  }
+
+  private Map<String, String> operationParameterDocs(OperationShape op) {
+    Model model = context.model();
+    if (ShapeSupport.isUnit(op.getInputShape())) {
+      return Map.of();
+    }
+    Map<String, String> docs = new LinkedHashMap<>();
+    model
+        .expectShape(op.getInputShape())
+        .getTrait(DocumentationTrait.class)
+        .ifPresent(trait -> docs.put("input", trait.getValue()));
+    return docs;
   }
 
   private boolean isEventStreamOperation(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
@@ -28,6 +28,7 @@ public final class StringEnumGenerator implements Runnable {
   public void run() {
     writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
     String typeName = CSharpNaming.typeName(shape.getId().getName());
+    writer.writeXmlDocs(shape);
     writer.write(
         "public readonly partial record struct $L(string Value) : IStringEnumValue<$L>",
         typeName,
@@ -45,6 +46,7 @@ public final class StringEnumGenerator implements Runnable {
                 m.getTrait(EnumValueTrait.class)
                     .flatMap(t -> t.getStringValue())
                     .orElse(m.getMemberName());
+            writer.writeXmlDocs(m);
             writer.write(
                 "public static $L $L { get; } = new($L);",
                 typeName,

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
@@ -9,10 +9,13 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -34,9 +37,29 @@ public final class StructureGenerator implements Runnable {
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     List<MemberShape> members = List.copyOf(shape.members());
 
+    Map<String, String> parameterDocs = parameterDocs(ShapeSupport.constructorMembers(shape));
+    if (shape.hasTrait(DocumentationTrait.class)) {
+      writer.writeXmlDocs(shape, parameterDocs);
+    } else if (!parameterDocs.isEmpty()) {
+      writer.writeXmlDocs("Represents the Smithy structure " + shape.getId() + ".", parameterDocs);
+    } else {
+      writer.writeXmlDocs(shape);
+    }
     writer.write("public sealed record class $L$L;", typeName, primaryConstructorParameters(sp));
     writer.write("");
     SchemaGenerator.writeStructureSchema(writer, context, shape, members);
+  }
+
+  private Map<String, String> parameterDocs(List<MemberShape> members) {
+    Map<String, String> docs = new LinkedHashMap<>();
+    for (MemberShape member : members) {
+      member
+          .getTrait(DocumentationTrait.class)
+          .ifPresent(
+              trait ->
+                  docs.put(CSharpNaming.propertyName(member.getMemberName()), trait.getValue()));
+    }
+    return docs;
   }
 
   private String primaryConstructorParameters(SymbolProvider sp) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -13,11 +13,14 @@
  */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
@@ -37,6 +40,68 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
   public CSharpWriter addImport(String csharpNamespace) {
     getImportContainer().importNamespace(csharpNamespace);
     return this;
+  }
+
+  /** Emits a C# XML documentation summary from a Smithy shape's documentation trait. */
+  public void writeXmlDocs(Shape shape) {
+    shape.getTrait(DocumentationTrait.class).ifPresent(trait -> writeXmlDocs(trait.getValue()));
+  }
+
+  /**
+   * Emits a C# XML documentation summary and parameter tags. Parameter names must match the
+   * generated C# declaration.
+   */
+  public void writeXmlDocs(Shape shape, Map<String, String> parameterDocs) {
+    shape
+        .getTrait(DocumentationTrait.class)
+        .ifPresentOrElse(
+            trait -> writeXmlDocs(trait.getValue(), parameterDocs),
+            () -> writeXmlDocs((String) null, parameterDocs));
+  }
+
+  /** Emits C# XML documentation parameter tags without a summary. */
+  public void writeXmlParamDocs(Map<String, String> parameterDocs) {
+    writeXmlDocs((String) null, parameterDocs);
+  }
+
+  private void writeXmlDocs(String summary) {
+    writeXmlDocs(summary, Map.of());
+  }
+
+  public void writeXmlDocs(String summary, Map<String, String> parameterDocs) {
+    boolean hasSummary = summary != null && !summary.isBlank();
+    if (hasSummary) {
+      write("/// <summary>");
+      writeXmlText(summary);
+      write("/// </summary>");
+    }
+    parameterDocs.forEach(
+        (name, documentation) -> {
+          if (documentation == null || documentation.isBlank()) {
+            return;
+          }
+          write("/// <param name=\"$L\">", escapeXml(name));
+          writeXmlText(documentation);
+          write("/// </param>");
+        });
+  }
+
+  private void writeXmlText(String text) {
+    for (String line : text.strip().split("\\R", -1)) {
+      if (line.isBlank()) {
+        write("///");
+      } else {
+        write("/// $L", escapeXml(line.strip()));
+      }
+    }
+  }
+
+  private static String escapeXml(String value) {
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;");
   }
 
   /** Factory used by WriterDelegator. */

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/DocumentationGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/DocumentationGeneratorTest.java
@@ -1,0 +1,246 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
+import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpDelegator;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+final class DocumentationGeneratorTest {
+
+  @TempDir java.nio.file.Path tempDir;
+
+  private static final String REST_PROTOCOL_TRAITS =
+      """
+      $version: "2"
+
+      namespace aws.protocols
+
+      use smithy.api#protocolDefinition
+      use smithy.api#trait
+
+      @trait(selector: "service")
+      @protocolDefinition
+      structure restJson1 {}
+      """;
+
+  private static final String MODEL =
+      """
+      $version: "2"
+
+      namespace example.weather
+
+      use aws.protocols#restJson1
+      use smithy.api#http
+
+      /// Weather service docs.
+      @restJson1
+      service Weather {
+          version: "1"
+          operations: [GetForecast]
+      }
+
+      /// Gets <forecast> & conditions.
+      @http(method: "POST", uri: "/forecast")
+      operation GetForecast {
+          input: GetForecastInput
+          output: GetForecastOutput
+          errors: [ForecastError]
+      }
+
+      /// Forecast input docs.
+      structure GetForecastInput {
+          /// City <name> & region.
+          @required
+          city: String
+      }
+
+      structure GetForecastOutput {}
+
+      structure ParamOnlyDocs {
+          /// Member-only docs.
+          value: String
+      }
+
+      /// Forecast error docs.
+      @error("client")
+      structure ForecastError {
+          /// Error message docs.
+          message: String
+      }
+
+      /// Weather condition docs.
+      enum Condition {
+          /// Sunny docs.
+          SUNNY
+      }
+
+      /// Alert level docs.
+      intEnum AlertLevel {
+          /// Low docs.
+          LOW = 1
+      }
+      """;
+
+  @Test
+  void structuresEmitSummaryAndConstructorParamDocs() throws Exception {
+    String generated = renderStructure("example.weather#GetForecastInput");
+
+    assertTrue(generated.contains("/// <summary>\n/// Forecast input docs.\n/// </summary>"));
+    assertTrue(
+        generated.contains("/// <param name=\"City\">\n/// City &lt;name&gt; &amp; region."));
+    assertTrue(
+        generated.contains("public sealed record class GetForecastInput(string City);"), generated);
+  }
+
+  @Test
+  void structuresUseFallbackSummaryForMemberDocsWithoutShapeDocs() throws Exception {
+    String generated = renderStructure("example.weather#ParamOnlyDocs");
+
+    assertTrue(
+        generated.contains("/// Represents the Smithy structure example.weather#ParamOnlyDocs."),
+        generated);
+    assertTrue(generated.contains("/// <param name=\"Value\">"), generated);
+    assertTrue(generated.contains("/// Member-only docs."), generated);
+    assertTrue(
+        generated.contains("public sealed record class ParamOnlyDocs(string? Value = null);"));
+  }
+
+  @Test
+  void enumsEmitTypeAndVariantDocs() throws Exception {
+    String stringEnum = renderStringEnum("example.weather#Condition");
+    String intEnum = renderIntEnum("example.weather#AlertLevel");
+
+    assertTrue(stringEnum.contains("/// Weather condition docs."), stringEnum);
+    assertTrue(stringEnum.contains("/// Sunny docs."), stringEnum);
+    assertTrue(intEnum.contains("/// Alert level docs."), intEnum);
+    assertTrue(intEnum.contains("/// Low docs."), intEnum);
+  }
+
+  @Test
+  void errorsEmitTypeConstructorAndMemberDocs() throws Exception {
+    String generated = renderError("example.weather#ForecastError");
+
+    assertTrue(generated.contains("/// Forecast error docs."), generated);
+    assertTrue(generated.contains("/// <param name=\"message\">"), generated);
+    assertTrue(generated.contains("/// Error message docs."), generated);
+    assertTrue(generated.contains("public override string Message"), generated);
+  }
+
+  @Test
+  void clientsAndServersEmitServiceAndOperationDocs() throws Exception {
+    String client = renderClient();
+    String server = renderServer();
+
+    assertTrue(
+        client.contains(
+            "/// Weather service docs.\n/// </summary>\npublic interface IWeatherClient"));
+    assertTrue(client.contains("/// Gets &lt;forecast&gt; &amp; conditions."));
+    assertTrue(client.contains("/// <param name=\"input\">"), client);
+    assertTrue(client.contains("/// Forecast input docs."), client);
+    assertTrue(
+        server.contains(
+            "/// Weather service docs.\n/// </summary>\npublic interface IWeatherServiceHandler"));
+    assertTrue(server.contains("/// Gets &lt;forecast&gt; &amp; conditions."));
+  }
+
+  private String renderStructure(String shapeId) throws Exception {
+    var model = model();
+    var context = context(model);
+    var writer = new CSharpWriter("Example.Weather");
+    new StructureGenerator(
+            context, writer, model.expectShape(ShapeId.from(shapeId), StructureShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private String renderStringEnum(String shapeId) throws Exception {
+    var model = model();
+    var writer = new CSharpWriter("Example.Weather");
+    new StringEnumGenerator(writer, model.expectShape(ShapeId.from(shapeId), EnumShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private String renderIntEnum(String shapeId) throws Exception {
+    var model = model();
+    var writer = new CSharpWriter("Example.Weather");
+    new IntEnumGenerator(writer, model.expectShape(ShapeId.from(shapeId), IntEnumShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private String renderError(String shapeId) throws Exception {
+    var model = model();
+    var context = context(model);
+    var writer = new CSharpWriter("Example.Weather");
+    new ErrorGenerator(
+            context, writer, model.expectShape(ShapeId.from(shapeId), StructureShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private String renderClient() throws Exception {
+    var model = model();
+    var context = context(model);
+    var writer = new CSharpWriter("Example.Weather");
+    new ClientGenerator(
+            context,
+            writer,
+            model.expectShape(ShapeId.from("example.weather#Weather"), ServiceShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private String renderServer() throws Exception {
+    var model = model();
+    var context = context(model);
+    var writer = new CSharpWriter("Example.Weather");
+    new ServerGenerator(
+            context,
+            writer,
+            model.expectShape(ShapeId.from("example.weather#Weather"), ServiceShape.class))
+        .run();
+    return writer.toString();
+  }
+
+  private Model model() {
+    return Model.assembler()
+        .addUnparsedModel("protocol-traits.smithy", REST_PROTOCOL_TRAITS)
+        .addUnparsedModel("model.smithy", MODEL)
+        .assemble()
+        .unwrap();
+  }
+
+  private GenerationContext context(Model model) throws Exception {
+    CSharpSettings settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder()
+                .withMember("service", Node.from("example.weather#Weather"))
+                .withMember("baseNamespace", Node.from("Example"))
+                .build());
+    var symbolProvider = new CSharpSymbolProvider(model, settings);
+    var manifest = FileManifest.create(Files.createTempDirectory(tempDir, "manifest"));
+    return GenerationContext.builder()
+        .model(model)
+        .settings(settings)
+        .symbolProvider(symbolProvider)
+        .fileManifest(manifest)
+        .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+        .build();
+  }
+}

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -52,15 +52,7 @@ The remaining work closes the gaps:
 - Continuing to harden named client interceptors and the typed per-call
   execution context.
 
-### 3. XML doc comments from Smithy documentation traits
-
-Smithy's `@documentation` trait and `///` doc comments are not yet emitted as
-C# XML doc comments (`/// <summary>…</summary>`) on generated types and members.
-Adding this would improve the IDE experience for consumers of generated code —
-hover documentation, parameter hints, and IntelliSense would reflect the
-model's documentation rather than being empty.
-
-### 4. Enforce constraint traits and modeled validation
+### 3. Enforce constraint traits and modeled validation
 
 Smithy's constraint traits — `@length`, `@pattern`, `@range`, `@uniqueItems`,
 and server-side enforcement of `@required` — are not yet enforced. `@required`
@@ -80,7 +72,7 @@ This work includes:
 - Covering server behavior with Smithy's malformed-request conformance suites.
 - Documenting the client-side non-goal as an explicit preview boundary.
 
-### 5. Improve CBOR and XML codec performance through schema-compiled codecs
+### 4. Improve CBOR and XML codec performance through schema-compiled codecs
 
 JSON already benefits from compiling codec state once from the schema so the
 runtime can cache structural decisions such as dispatch and boxing behavior.
@@ -97,7 +89,7 @@ This work includes:
 - Keeping the generated codec path explicit enough that performance work does
   not make diagnostics and debuggability worse.
 
-### 6. Harden streaming operations
+### 5. Harden streaming operations
 
 NSmithy has two experimental event-streaming surfaces: native gRPC (client,
 server, and bidirectional streaming) and `rpcv2Cbor` event streams over
@@ -113,7 +105,7 @@ This work includes:
 - Extending streaming support beyond event streams, especially streaming blob
   payloads.
 
-### 7. Expand to async protocols
+### 6. Expand to async protocols
 
 NSmithy's current protocol work is mostly request/response oriented. A separate
 near-term goal is to validate that the runtime and generator model can also
@@ -128,7 +120,7 @@ This work includes:
 - Using these protocols to pressure-test the existing transport, codec, and
   client/server seams beyond HTTP-centric assumptions.
 
-### 8. Support Smithy AI traits and MCP generation
+### 7. Support Smithy AI traits and MCP generation
 
 Support Smithy's AI-oriented traits so that .NET and protocol artifacts can be
 generated for tool-driven and agent-driven workflows, rather than treating the
@@ -142,7 +134,7 @@ This work includes:
 - Defining the runtime and generation boundaries needed so AI-trait-aware
   models remain inspectable, testable, and versionable.
 
-### 9. Honor protocol HTTP-version traits
+### 8. Honor protocol HTTP-version traits
 
 Protocol traits can declare the HTTP versions a service supports via their `http`
 and `eventStreamHttp` members — a list of ALPN protocol IDs in preference order


### PR DESCRIPTION
Closes #115.

- Emit XML documentation comments from Smithy documentation traits.
- Cover generated model, client, server, and error surfaces.
- Add focused codegen tests.