### PR TITLE
Answer a malformed request with the structured 4xx Smithy specifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Structured 4xx for a request the server cannot accept.** Input that never
+  becomes modeled input — a body that is not JSON, a non-numeric integer, an
+  out-of-range number, a timestamp in the wrong format, a blob that is not
+  base64, a dense list holding `null`, a union with two members set — is answered
+  with a 400 `SerializationException` instead of reaching the host as a 500. A
+  request body whose `Content-Type` is not the one the operation reads is
+  answered with 415 `UnsupportedMediaTypeException`, and an `Accept` that
+  excludes the response's media type with 406 `NotAcceptableException`. The
+  generated restJson1 server now passes all 655 cases of Smithy's
+  `httpMalformedRequestTests` suite.
+- **Legacy `@enum` validation.** A string shape carrying the deprecated `@enum`
+  trait has its value set enforced on the server, as an enum shape already did.
+  Values marked `@internal` are accepted but left out of the rejection message.
+
+### Changed
+
+- **BREAKING: `RestServiceProtocol` takes a codec factory per read mode.** Its
+  first constructor parameter is now `Func<WireReadMode, IRestBodyCodecFactory>`
+  rather than a single factory, so each call side compiles codecs that read by
+  its own rules. A server holds a caller to exactly what the model declares; a
+  client stays permissive with a peer it does not control.
+- **BREAKING: a map with an enum key generates a `string` key.** Smithy map keys
+  are object names, and the runtime's map schema is string-keyed; the enum's value
+  set now reaches the schema as key traits, so the key is still validated. A
+  string shape carrying `@enum` no longer generates an enum type — it was never
+  reachable as one, since every string shape maps to `string`.
+
 ## [0.7.0]
 
 This release brings event streaming to NSmithy: a standalone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,16 @@ and NSmithy aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
   rather than a single factory, so each call side compiles codecs that read by
   its own rules. A server holds a caller to exactly what the model declares; a
   client stays permissive with a peer it does not control.
-- **BREAKING: a map with an enum key generates a `string` key.** Smithy map keys
-  are object names, and the runtime's map schema is string-keyed; the enum's value
-  set now reaches the schema as key traits, so the key is still validated. A
-  string shape carrying `@enum` no longer generates an enum type — it was never
-  reachable as one, since every string shape maps to `string`.
+- **BREAKING: a map schema carries the shape its key targets.** `Schemas.Map`
+  takes a `key` schema (defaulting to `Schemas.String`), and
+  `IMapSchema.TypedKeyMember` is replaced by the untyped `IMapSchema.KeyMember`,
+  whose target is that shape rather than a flattened `Schemas.String`. This is
+  what lets a server hold an enum-keyed map's keys to the enum's value set. A map
+  with an enum key generates a `string` key, since a map key is an object name;
+  the enum still types the value.
+- **BREAKING: a string shape carrying `@enum` no longer generates an enum type.**
+  It was never reachable as one — every string shape maps to `string` — and
+  generating it produced a build error. Its value set is enforced from the trait.
 
 ## [0.7.0]
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/DirectedCSharpCodegen.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/DirectedCSharpCodegen.java
@@ -169,15 +169,16 @@ final class DirectedCSharpCodegen
   @Override
   public void generateEnumShape(
       GenerateEnumDirective<GenerationContext, CSharpSettings> directive) {
-    EnumShape enumShape =
-        directive
-            .shape()
-            .asEnumShape()
-            .or(() -> directive.shape().asStringShape().flatMap(EnumShape::fromStringShape))
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Expected enum shape for " + directive.shape().getId()));
+    // A string carrying the deprecated @enum trait reaches this directive too, but it stays a
+    // `string` in the generated API: the symbol provider maps every string shape to `string`, and
+    // an @enum entry is not even required to carry the name a C# type would need. Its value set
+    // still reaches the runtime — the trait is inlined onto every member targeting the shape — so a
+    // server rejects a value outside it just as it does for an enum shape.
+    if (directive.shape().asEnumShape().isEmpty()) {
+      return;
+    }
+
+    EnumShape enumShape = directive.shape().asEnumShape().get();
     directive
         .context()
         .writerDelegator()

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -30,9 +30,11 @@ public final class MapGenerator implements Runnable {
   public void run() {
     SymbolProvider sp = context.symbolProvider();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
-    Symbol key = sp.toSymbol(context.model().expectShape(shape.getKey().getTarget()));
     Symbol value = sp.toSymbol(context.model().expectShape(shape.getValue().getTarget()));
-    String keyType = CSharpSymbolProvider.qualified(key);
+    // Always a string, even when the key targets an enum shape: a map key is a JSON object name,
+    // and the runtime's map schema is string-keyed throughout. The enum's value set still reaches
+    // the schema as key traits, so the server holds the key to it.
+    String keyType = "string";
     String valueType =
         CSharpSymbolProvider.qualified(value) + (ShapeSupport.isSparse(shape) ? "?" : "");
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -32,8 +32,8 @@ public final class MapGenerator implements Runnable {
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     Symbol value = sp.toSymbol(context.model().expectShape(shape.getValue().getTarget()));
     // Always a string, even when the key targets an enum shape: a map key is a JSON object name,
-    // and the runtime's map schema is string-keyed throughout. The enum's value set still reaches
-    // the schema as key traits, so the server holds the key to it.
+    // which has no other form. What the key targets is not lost — the schema carries that shape, so
+    // a server holds the key to whatever it says — but it is not what the key is typed as.
     String keyType = "string";
     String valueType =
         CSharpSymbolProvider.qualified(value) + (ShapeSupport.isSparse(shape) ? "?" : "");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.InternalTrait;
@@ -320,10 +319,12 @@ public final class SchemaGenerator {
           writer.write("static (builder, key, value) => builder[key] = value,");
           writer.write("static builder => new $L(builder),", typeName);
           writer.write(
-              "$L, keyTraits: $L, valueTraits: $L);",
+              "$L, keyTraits: $L, valueTraits: $L, key: $L);",
               traitsExpr(shape.getAllTraits().values()),
-              mapKeyTraitsExpr(context, shape.getKey()),
-              memberTraitsExpr(context, shape.getValue()));
+              memberTraitsExpr(context, shape.getKey()),
+              memberTraitsExpr(context, shape.getValue()),
+              shapeSchemaAccessor(
+                  context, context.model().expectShape(shape.getKey().getTarget())));
           writer.dedent();
           writer.dedent();
           writer.write("");
@@ -512,38 +513,6 @@ public final class SchemaGenerator {
         }
       }
     }
-    return traitsExpr(traits);
-  }
-
-  /**
-   * A map key is a string in the generated API even when it targets an enum shape, because the
-   * runtime's map schema is string-keyed: a key is a JSON object name, not a value with a type.
-   * That loses the enum's value set, which the server still has to hold the key to, so it is
-   * restated here as the {@code @enum} trait — the same shape the runtime already reads for a
-   * string whose value set comes from a trait rather than from an enum shape.
-   */
-  private static String mapKeyTraitsExpr(GenerationContext context, MemberShape key) {
-    Shape target = context.model().expectShape(key.getTarget());
-    if (!target.isEnumShape()) {
-      return memberTraitsExpr(context, key);
-    }
-
-    List<Node> entries = new ArrayList<>();
-    for (MemberShape member : target.getAllMembers().values()) {
-      ObjectNode.Builder entry =
-          Node.objectNodeBuilder()
-              .withMember("value", member.expectTrait(EnumValueTrait.class).expectStringValue());
-      if (member.hasTrait(InternalTrait.class)) {
-        entry.withMember("tags", Node.fromStrings("internal"));
-      }
-      entries.add(entry.build());
-    }
-
-    List<Trait> traits = new ArrayList<>(key.getAllTraits().values());
-    traits.removeIf(t -> t.toShapeId().equals(EnumTrait.ID));
-    traits.add(
-        new EnumTrait.Provider()
-            .createTrait(EnumTrait.ID, new ArrayNode(entries, key.getSourceLocation())));
     return traitsExpr(traits);
   }
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -28,7 +28,10 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.InternalTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -319,7 +322,7 @@ public final class SchemaGenerator {
           writer.write(
               "$L, keyTraits: $L, valueTraits: $L);",
               traitsExpr(shape.getAllTraits().values()),
-              memberTraitsExpr(context, shape.getKey()),
+              mapKeyTraitsExpr(context, shape.getKey()),
               memberTraitsExpr(context, shape.getValue()));
           writer.dedent();
           writer.dedent();
@@ -338,12 +341,14 @@ public final class SchemaGenerator {
             String typeName = CSharpNaming.typeName(shape.getId().getName());
             writer.write(
                 "public static Schema<$L> Schema { get; } ="
-                    + " Schemas.StringEnum<$L>($L, values: $L, traits: $L);",
+                    + " Schemas.StringEnum<$L>($L, values: $L, traits: $L,"
+                    + " internalValues: $L);",
                 typeName,
                 typeName,
                 shapeIdExpr(shape.getId()),
                 stringEnumValuesExpr(shape),
-                traitsExpr(shape.getAllTraits().values()));
+                traitsExpr(shape.getAllTraits().values()),
+                stringEnumInternalValuesExpr(shape));
             writer.write("");
             return;
           }
@@ -510,6 +515,38 @@ public final class SchemaGenerator {
     return traitsExpr(traits);
   }
 
+  /**
+   * A map key is a string in the generated API even when it targets an enum shape, because the
+   * runtime's map schema is string-keyed: a key is a JSON object name, not a value with a type.
+   * That loses the enum's value set, which the server still has to hold the key to, so it is
+   * restated here as the {@code @enum} trait — the same shape the runtime already reads for a
+   * string whose value set comes from a trait rather than from an enum shape.
+   */
+  private static String mapKeyTraitsExpr(GenerationContext context, MemberShape key) {
+    Shape target = context.model().expectShape(key.getTarget());
+    if (!target.isEnumShape()) {
+      return memberTraitsExpr(context, key);
+    }
+
+    List<Node> entries = new ArrayList<>();
+    for (MemberShape member : target.getAllMembers().values()) {
+      ObjectNode.Builder entry =
+          Node.objectNodeBuilder()
+              .withMember("value", member.expectTrait(EnumValueTrait.class).expectStringValue());
+      if (member.hasTrait(InternalTrait.class)) {
+        entry.withMember("tags", Node.fromStrings("internal"));
+      }
+      entries.add(entry.build());
+    }
+
+    List<Trait> traits = new ArrayList<>(key.getAllTraits().values());
+    traits.removeIf(t -> t.toShapeId().equals(EnumTrait.ID));
+    traits.add(
+        new EnumTrait.Provider()
+            .createTrait(EnumTrait.ID, new ArrayNode(entries, key.getSourceLocation())));
+    return traitsExpr(traits);
+  }
+
   private static boolean shouldInlineTargetTraits(Shape target) {
     if ("smithy.api".equals(target.getId().getNamespace())) {
       return false;
@@ -587,6 +624,27 @@ public final class SchemaGenerator {
                 e.getEnumValues().values().stream()
                     .map(CSharpNaming::formatString)
                     .collect(Collectors.joining(", ", "[", "]")))
+        .orElse("null");
+  }
+
+  /**
+   * The values an enum shape marks {@code @internal}. They are valid on the wire like any other,
+   * but a server leaves them out of the message it sends back when it rejects a value, so the
+   * schema has to record which ones they are.
+   */
+  public static String stringEnumInternalValuesExpr(Shape shape) {
+    return shape
+        .asEnumShape()
+        .map(
+            e ->
+                e.getAllMembers().values().stream()
+                    .filter(m -> m.hasTrait(InternalTrait.class))
+                    .map(m -> m.expectTrait(EnumValueTrait.class).expectStringValue())
+                    .map(CSharpNaming::formatString)
+                    .collect(Collectors.toList()))
+        .filter(values -> !values.isEmpty())
+        .map(values -> String.join(", ", values))
+        .map(values -> "[" + values + "]")
         .orElse("null");
   }
 

--- a/packages/NSmithy.Codecs.Json/CompiledJsonCodec.cs
+++ b/packages/NSmithy.Codecs.Json/CompiledJsonCodec.cs
@@ -3,14 +3,17 @@ using NSmithy.Core.Serde;
 
 namespace NSmithy.Codecs.Json;
 
-internal sealed class CompiledJsonCodec<T>(Schema<T> schema, bool materializeTopLevelDefaults)
-    : IJsonCodec<T>
+internal sealed class CompiledJsonCodec<T>(
+    Schema<T> schema,
+    bool materializeTopLevelDefaults,
+    WireReadMode readMode
+) : IJsonCodec<T>
 {
     private readonly IJsonValueWriter<T> valueWriter = JsonWriterCompiler.Compile(
         schema,
         materializeTopLevelDefaults
     );
-    private readonly IJsonValueReader<T> valueReader = JsonReaderCompiler.Compile(schema);
+    private readonly IJsonValueReader<T> valueReader = JsonReaderCompiler.Compile(schema, readMode);
 
     public byte[] Serialize(T value)
     {
@@ -26,14 +29,37 @@ internal sealed class CompiledJsonCodec<T>(Schema<T> schema, bool materializeTop
     public T Deserialize(byte[] payload)
     {
         ArgumentNullException.ThrowIfNull(payload);
-        using var document = JsonDocument.Parse(payload);
+        using var document = JsonBody.Parse(payload);
         return valueReader.Read(document.RootElement);
+    }
+}
+
+/// <summary>
+/// The outermost step of reading a JSON payload: turning bytes into a document at all. A body that
+/// is not JSON — unbalanced braces, a comment, a trailing comma, anything after the closing brace —
+/// fails here, before a single member is read, and is the caller's mistake rather than a fault.
+/// </summary>
+internal static class JsonBody
+{
+    public static JsonDocument Parse(byte[] payload)
+    {
+        try
+        {
+            return JsonDocument.Parse(payload);
+        }
+        catch (JsonException exception)
+        {
+            throw MalformedRequestException.Serialization(
+                $"Request body is not valid JSON: {exception.Message}"
+            );
+        }
     }
 }
 
 internal sealed class CompiledJsonProjectionCodec<T, TBuilder>(
     StructProjection<T, TBuilder> projection,
-    bool materializeTopLevelDefaults
+    bool materializeTopLevelDefaults,
+    WireReadMode readMode
 ) : IProjectionCodec<T, TBuilder>
 {
     private readonly StructureJsonValueWriter<T> valueWriter = JsonWriterCompiler.Compile(
@@ -41,7 +67,7 @@ internal sealed class CompiledJsonProjectionCodec<T, TBuilder>(
         materializeTopLevelDefaults
     );
     private readonly StructureJsonProjectionReader<TBuilder> valueReader =
-        JsonReaderCompiler.Compile(projection);
+        JsonReaderCompiler.Compile(projection, readMode);
 
     public byte[] Serialize(T value)
     {
@@ -59,7 +85,7 @@ internal sealed class CompiledJsonProjectionCodec<T, TBuilder>(
         ArgumentNullException.ThrowIfNull(payload);
         ArgumentNullException.ThrowIfNull(builder);
 
-        using var document = JsonDocument.Parse(payload);
+        using var document = JsonBody.Parse(payload);
         valueReader.ReadInto(builder, document.RootElement);
     }
 }

--- a/packages/NSmithy.Codecs.Json/JsonCodec.cs
+++ b/packages/NSmithy.Codecs.Json/JsonCodec.cs
@@ -8,22 +8,25 @@ public static class JsonCodec
 {
     public static IJsonCodec<T> FromSchema<T>(
         Schema<T> schema,
-        bool materializeTopLevelDefaults = true
+        bool materializeTopLevelDefaults = true,
+        WireReadMode readMode = WireReadMode.Lenient
     )
     {
         ArgumentNullException.ThrowIfNull(schema);
-        return new CompiledJsonCodec<T>(schema, materializeTopLevelDefaults);
+        return new CompiledJsonCodec<T>(schema, materializeTopLevelDefaults, readMode);
     }
 
     public static IProjectionCodec<T, TBuilder> FromProjection<T, TBuilder>(
         StructProjection<T, TBuilder> projection,
-        bool materializeTopLevelDefaults = true
+        bool materializeTopLevelDefaults = true,
+        WireReadMode readMode = WireReadMode.Lenient
     )
     {
         ArgumentNullException.ThrowIfNull(projection);
         return new CompiledJsonProjectionCodec<T, TBuilder>(
             projection,
-            materializeTopLevelDefaults
+            materializeTopLevelDefaults,
+            readMode
         );
     }
 }

--- a/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
@@ -30,22 +30,25 @@ internal interface IJsonUnionCaseReader<out TUnion>
     TUnion Read(JsonElement value);
 }
 
-internal sealed class JsonReaderCompiler : ISchemaVisitor<object>
+internal sealed class JsonReaderCompiler(WireReadMode readMode) : ISchemaVisitor<object>
 {
     private readonly SchemaCompilationCache cache = new();
 
-    public static IJsonValueReader<T> Compile<T>(Schema<T> schema)
+    public WireReadMode ReadMode => readMode;
+
+    public static IJsonValueReader<T> Compile<T>(Schema<T> schema, WireReadMode readMode)
     {
         ArgumentNullException.ThrowIfNull(schema);
-        return new JsonReaderCompiler().CompileValue(schema);
+        return new JsonReaderCompiler(readMode).CompileValue(schema);
     }
 
     public static StructureJsonProjectionReader<TBuilder> Compile<T, TBuilder>(
-        StructProjection<T, TBuilder> projection
+        StructProjection<T, TBuilder> projection,
+        WireReadMode readMode
     )
     {
         ArgumentNullException.ThrowIfNull(projection);
-        var compiler = new JsonReaderCompiler();
+        var compiler = new JsonReaderCompiler(readMode);
         var visitor = new JsonMemberReaderCompiler<T, TBuilder>(compiler);
         projection.VisitMembers(visitor);
         return new StructureJsonProjectionReader<TBuilder>(visitor.Readers);
@@ -102,7 +105,7 @@ internal sealed class JsonReaderCompiler : ISchemaVisitor<object>
     public object VisitBlob(Schema<byte[]> schema) => new BlobJsonValueReader();
 
     public object VisitTimestamp(Schema<DateTimeOffset> schema) =>
-        new TimestampJsonValueReader(TimestampFormat.Resolve(null, schema));
+        new TimestampJsonValueReader(TimestampFormat.Resolve(null, schema), readMode);
 
     public object VisitDocument(Schema<Document> schema) => new DocumentJsonValueReader();
 
@@ -237,7 +240,7 @@ internal sealed class MemberTraitJsonReaderCompiler(
 ) : ISchemaVisitor<object>
 {
     public object VisitTimestamp(Schema<DateTimeOffset> schema) =>
-        new TimestampJsonValueReader(TimestampFormat.Resolve(memberTraits, schema));
+        new TimestampJsonValueReader(TimestampFormat.Resolve(memberTraits, schema), inner.ReadMode);
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
@@ -349,9 +352,7 @@ internal sealed class StructureJsonValueReader<T, TBuilder>(
     {
         if (value.ValueKind != JsonValueKind.Object)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON object but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON object");
         }
 
         var builder = createBuilder();
@@ -404,9 +405,7 @@ internal sealed class StructureJsonProjectionReader<TBuilder>(
     {
         if (value.ValueKind != JsonValueKind.Object)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON object but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON object");
         }
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -553,9 +552,7 @@ internal sealed class UnionJsonValueReader<T> : IJsonValueReader<T>
     {
         if (value.ValueKind != JsonValueKind.Object)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON object but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON object");
         }
 
         var properties = value
@@ -564,16 +561,17 @@ internal sealed class UnionJsonValueReader<T> : IJsonValueReader<T>
             .ToArray();
         if (properties.Length != 1)
         {
-            throw new InvalidOperationException(
-                "Expected union value to contain exactly one member but found "
-                    + $"{properties.Length}."
+            throw MalformedRequestException.Serialization(
+                $"Expected a union with exactly one member set but found {properties.Length}."
             );
         }
 
         var property = properties[0];
         if (!readersByName.TryGetValue(property.Name, out var reader))
         {
-            throw new InvalidOperationException($"Unknown union member '{property.Name}'.");
+            throw MalformedRequestException.Serialization(
+                $"Unknown union member '{property.Name}'."
+            );
         }
 
         return reader.Read(property.Value);
@@ -601,9 +599,7 @@ internal sealed class OpenUnionJsonValueReader<T> : IJsonValueReader<T>
     {
         if (value.ValueKind != JsonValueKind.Object)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON object but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON object");
         }
 
         return discriminatorName.Length == 0
@@ -619,8 +615,8 @@ internal sealed class OpenUnionJsonValueReader<T> : IJsonValueReader<T>
             .ToArray();
         if (properties.Length != 1)
         {
-            throw new InvalidOperationException(
-                $"Expected union value to contain exactly one member but found {properties.Length}."
+            throw MalformedRequestException.Serialization(
+                $"Expected a union with exactly one member set but found {properties.Length}."
             );
         }
 
@@ -632,7 +628,9 @@ internal sealed class OpenUnionJsonValueReader<T> : IJsonValueReader<T>
 
         return unknownReader is not null
             ? unknownReader.ReadUnknown(value)
-            : throw new InvalidOperationException($"Unknown union member '{property.Name}'.");
+            : throw MalformedRequestException.Serialization(
+                $"Unknown union member '{property.Name}'."
+            );
     }
 
     private T ReadDiscriminated(JsonElement value)
@@ -680,9 +678,7 @@ internal sealed class ListJsonValueReader<TCollection, TElement, TBuilder>(
     {
         if (value.ValueKind != JsonValueKind.Array)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON array but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON array");
         }
 
         var builder = schema.CreateTypedBuilder();
@@ -693,8 +689,8 @@ internal sealed class ListJsonValueReader<TCollection, TElement, TBuilder>(
             {
                 if (!sparse)
                 {
-                    throw new InvalidOperationException(
-                        "Non-sparse JSON list cannot contain null."
+                    throw MalformedRequestException.Serialization(
+                        "A list that is not @sparse cannot contain null."
                     );
                 }
 
@@ -731,9 +727,7 @@ internal sealed class MapJsonValueReader<TDictionary, TValue, TBuilder>(
     {
         if (value.ValueKind != JsonValueKind.Object)
         {
-            throw new InvalidOperationException(
-                $"Expected JSON object but found {value.ValueKind}."
-            );
+            throw Malformed(value, "a JSON object");
         }
 
         var builder = schema.CreateTypedBuilder();
@@ -743,7 +737,9 @@ internal sealed class MapJsonValueReader<TDictionary, TValue, TBuilder>(
             {
                 if (!sparse)
                 {
-                    throw new InvalidOperationException("Non-sparse JSON map cannot contain null.");
+                    throw MalformedRequestException.Serialization(
+                        "A map that is not @sparse cannot contain null."
+                    );
                 }
 
                 schema.Add(builder, property.Name, default!);
@@ -774,48 +770,58 @@ internal sealed class NullableJsonValueReader<T>(IJsonValueReader<T> inner) : IJ
 
 internal sealed class BooleanJsonValueReader : IJsonValueReader<bool>
 {
-    public bool Read(JsonElement value) => value.GetBoolean();
+    public bool Read(JsonElement value) =>
+        ReadValue(value, "a boolean", static element => element.GetBoolean());
 }
 
 internal sealed class ByteJsonValueReader : IJsonValueReader<sbyte>
 {
-    public sbyte Read(JsonElement value) => value.GetSByte();
+    public sbyte Read(JsonElement value) =>
+        ReadValue(value, "a byte", static element => element.GetSByte());
 }
 
 internal sealed class ShortJsonValueReader : IJsonValueReader<short>
 {
-    public short Read(JsonElement value) => value.GetInt16();
+    public short Read(JsonElement value) =>
+        ReadValue(value, "a short", static element => element.GetInt16());
 }
 
 internal sealed class IntegerJsonValueReader : IJsonValueReader<int>
 {
-    public int Read(JsonElement value) => value.GetInt32();
+    public int Read(JsonElement value) =>
+        ReadValue(value, "an integer", static element => element.GetInt32());
 }
 
 internal sealed class LongJsonValueReader : IJsonValueReader<long>
 {
-    public long Read(JsonElement value) => value.GetInt64();
+    public long Read(JsonElement value) =>
+        ReadValue(value, "a long", static element => element.GetInt64());
 }
 
 internal sealed class FloatJsonValueReader : IJsonValueReader<float>
 {
-    public float Read(JsonElement value) => ReadFloat(value);
+    public float Read(JsonElement value) => ReadValue(value, "a float", ReadFloat);
 }
 
 internal sealed class DoubleJsonValueReader : IJsonValueReader<double>
 {
-    public double Read(JsonElement value) => ReadDouble(value);
+    public double Read(JsonElement value) => ReadValue(value, "a double", ReadDouble);
 }
 
 internal sealed class BigIntegerJsonValueReader : IJsonValueReader<BigInteger>
 {
     public BigInteger Read(JsonElement value) =>
-        BigInteger.Parse(value.GetRawText(), CultureInfo.InvariantCulture);
+        ReadValue(
+            value,
+            "a bigInteger",
+            static element => BigInteger.Parse(element.GetRawText(), CultureInfo.InvariantCulture)
+        );
 }
 
 internal sealed class BigDecimalJsonValueReader : IJsonValueReader<decimal>
 {
-    public decimal Read(JsonElement value) => value.GetDecimal();
+    public decimal Read(JsonElement value) =>
+        ReadValue(value, "a bigDecimal", static element => element.GetDecimal());
 }
 
 internal sealed class StringJsonValueReader : IJsonValueReader<string>
@@ -823,29 +829,39 @@ internal sealed class StringJsonValueReader : IJsonValueReader<string>
     public string Read(JsonElement value) =>
         value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined
             ? null!
-            : value.GetString()!;
+            : ReadValue(value, "a string", static element => element.GetString()!);
 }
 
 internal sealed class StringEnumJsonValueReader<T>(StringEnumSchema<T> schema) : IJsonValueReader<T>
     where T : IStringEnumValue<T>
 {
-    public T Read(JsonElement value) => schema.Create(value.GetString()!);
+    // An unmodeled value is not rejected here: enums stay open on the wire, and it is the
+    // constraint validator that closes them on the server. Only a non-string is malformed.
+    public T Read(JsonElement value) =>
+        schema.Create(ReadValue(value, "a string", static element => element.GetString()!));
 }
 
 internal sealed class IntEnumJsonValueReader<T>(IntEnumSchema<T> schema) : IJsonValueReader<T>
     where T : struct, Enum
 {
-    public T Read(JsonElement value) => schema.Create(value.GetInt32());
+    public T Read(JsonElement value) =>
+        schema.Create(ReadValue(value, "an integer", static element => element.GetInt32()));
 }
 
 internal sealed class BlobJsonValueReader : IJsonValueReader<byte[]>
 {
-    public byte[] Read(JsonElement value) => value.GetBytesFromBase64();
+    public byte[] Read(JsonElement value) =>
+        ReadValue(value, "a base64-encoded blob", static element => element.GetBytesFromBase64());
 }
 
-internal sealed class TimestampJsonValueReader(string format) : IJsonValueReader<DateTimeOffset>
+internal sealed class TimestampJsonValueReader(string format, WireReadMode readMode)
+    : IJsonValueReader<DateTimeOffset>
 {
-    public DateTimeOffset Read(JsonElement value) => TimestampFormat.Read(value, format);
+    private readonly string expected = $"a {format} timestamp";
+    private readonly Func<JsonElement, DateTimeOffset> read = element =>
+        TimestampFormat.Read(element, format, readMode);
+
+    public DateTimeOffset Read(JsonElement value) => ReadValue(value, expected, read);
 }
 
 internal sealed class DocumentJsonValueReader : IJsonValueReader<Document>

--- a/packages/NSmithy.Codecs.Json/JsonWire.cs
+++ b/packages/NSmithy.Codecs.Json/JsonWire.cs
@@ -195,25 +195,24 @@ internal static class JsonWire
         }
     }
 
-    internal static MalformedRequestException Malformed(JsonElement value, string expected) =>
-        MalformedRequestException.Serialization(
-            $"Expected {expected} but found {Describe(value)}."
-        );
-
-    /// <summary>
-    /// The offending value, echoed back so a caller can see which one it was. Truncated because the
-    /// payload is untrusted and a message is not a place to copy an arbitrary amount of it.
-    /// </summary>
-    private static string Describe(JsonElement value)
+    internal static MalformedRequestException Malformed(JsonElement value, string expected)
     {
+        // The offending value is echoed back so a caller can see which one it was — truncated,
+        // because the payload is untrusted and a message is not a place to copy an arbitrary
+        // amount of it, and summarized for the two kinds whose raw text says nothing useful.
         const int limit = 64;
-        var text = value.ValueKind switch
+        var found = value.ValueKind switch
         {
             JsonValueKind.Object => "an object",
             JsonValueKind.Array => "an array",
             _ => value.GetRawText(),
         };
-        return text.Length <= limit ? text : string.Concat(text.AsSpan(0, limit), "…");
+        if (found.Length > limit)
+        {
+            found = string.Concat(found.AsSpan(0, limit), "…");
+        }
+
+        return MalformedRequestException.Serialization($"Expected {expected} but found {found}.");
     }
 
     // A JSON string is a float only for the three values JSON cannot represent as a number. Parsing

--- a/packages/NSmithy.Codecs.Json/JsonWire.cs
+++ b/packages/NSmithy.Codecs.Json/JsonWire.cs
@@ -170,6 +170,54 @@ internal static class JsonWire
         }
     }
 
+    /// <summary>
+    /// Runs one of <see cref="JsonElement"/>'s accessors and reports what it rejects as a malformed
+    /// request. The accessors say "these bytes are not that type" by throwing — a wrong value kind,
+    /// a number outside the target's range, text that is not base64 — and every one of those is the
+    /// payload's fault, not the server's, so they all become the same fault the runtime answers with
+    /// a structured 400.
+    /// </summary>
+    internal static T ReadValue<T>(JsonElement value, string expected, Func<JsonElement, T> read)
+    {
+        try
+        {
+            return read(value);
+        }
+        catch (Exception exception)
+            when (exception
+                    is FormatException
+                        or InvalidOperationException
+                        or OverflowException
+                        or ArgumentException
+            )
+        {
+            throw Malformed(value, expected);
+        }
+    }
+
+    internal static MalformedRequestException Malformed(JsonElement value, string expected) =>
+        MalformedRequestException.Serialization(
+            $"Expected {expected} but found {Describe(value)}."
+        );
+
+    /// <summary>
+    /// The offending value, echoed back so a caller can see which one it was. Truncated because the
+    /// payload is untrusted and a message is not a place to copy an arbitrary amount of it.
+    /// </summary>
+    private static string Describe(JsonElement value)
+    {
+        const int limit = 64;
+        var text = value.ValueKind switch
+        {
+            JsonValueKind.Object => "an object",
+            JsonValueKind.Array => "an array",
+            _ => value.GetRawText(),
+        };
+        return text.Length <= limit ? text : string.Concat(text.AsSpan(0, limit), "…");
+    }
+
+    // A JSON string is a float only for the three values JSON cannot represent as a number. Parsing
+    // any other string would coerce "123" into a number the caller never sent as one.
     internal static float ReadFloat(JsonElement value) =>
         value.ValueKind == JsonValueKind.String
             ? value.GetString() switch
@@ -177,7 +225,7 @@ internal static class JsonWire
                 "NaN" => float.NaN,
                 "Infinity" => float.PositiveInfinity,
                 "-Infinity" => float.NegativeInfinity,
-                var s => float.Parse(s!, CultureInfo.InvariantCulture),
+                var s => throw new FormatException($"'{s}' is not a float."),
             }
             : value.GetSingle();
 
@@ -188,7 +236,7 @@ internal static class JsonWire
                 "NaN" => double.NaN,
                 "Infinity" => double.PositiveInfinity,
                 "-Infinity" => double.NegativeInfinity,
-                var s => double.Parse(s!, CultureInfo.InvariantCulture),
+                var s => throw new FormatException($"'{s}' is not a double."),
             }
             : value.GetDouble();
 }

--- a/packages/NSmithy.Codecs.Json/TimestampFormat.cs
+++ b/packages/NSmithy.Codecs.Json/TimestampFormat.cs
@@ -67,7 +67,7 @@ internal static class TimestampFormat
         }
     }
 
-    public static DateTimeOffset Read(JsonElement value, string format) =>
+    public static DateTimeOffset Read(JsonElement value, string format, WireReadMode readMode) =>
         format switch
         {
             "epoch-seconds" => DateTimeOffset.FromUnixTimeMilliseconds(
@@ -79,10 +79,6 @@ internal static class TimestampFormat
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.None
             ),
-            _ => DateTimeOffset.Parse(
-                value.GetString()!,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind
-            ),
+            _ => Rfc3339.Parse(value.GetString()!, readMode),
         };
 }

--- a/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
@@ -446,13 +446,15 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
             return;
         }
 
+        var fieldNumber = ProtoWire.FieldNumber(member.Id, member.MemberTraits, readers.Count);
         readers.Add(
             target switch
             {
-                IListSchema list => CreateListReader(member, (dynamic)list),
-                IMapSchema map => CreateMapReader(member, (dynamic)map),
+                IListSchema list => CreateListReader(member, (dynamic)list, fieldNumber),
+                IMapSchema map => CreateMapReader(member, (dynamic)map, fieldNumber),
                 _ => new ValueProtoFieldReader<TContainer, TBuilder, TValue>(
                     member,
+                    fieldNumber,
                     compiler.CompileValue(member.TargetSchema, member.MemberTraits)
                 ),
             }
@@ -480,11 +482,13 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
         TCollectionBuilder
     > CreateListReader<TValue, TElement, TCollectionBuilder>(
         IMemberSchema<TContainer, TBuilder, TValue> member,
-        IListSchema<TValue, TElement, TCollectionBuilder> list
+        IListSchema<TValue, TElement, TCollectionBuilder> list,
+        int fieldNumber
     ) =>
         new(
             member,
             list,
+            fieldNumber,
             compiler.CompileValue(
                 list.TypedElementMember.TargetSchema,
                 list.TypedElementMember.MemberTraits
@@ -499,11 +503,13 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
         TMapBuilder
     > CreateMapReader<TValue, TMapValue, TMapBuilder>(
         IMemberSchema<TContainer, TBuilder, TValue> member,
-        IMapSchema<TValue, TMapValue, TMapBuilder> map
+        IMapSchema<TValue, TMapValue, TMapBuilder> map,
+        int fieldNumber
     ) =>
         new(
             member,
             map,
+            fieldNumber,
             ProtoWire.IsSparse((Schema)map),
             compiler.CompileValue(
                 map.TypedValueMember.TargetSchema,
@@ -514,10 +520,11 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
 
 internal sealed class ValueProtoFieldReader<TContainer, TBuilder, TValue>(
     IMemberSchema<TContainer, TBuilder, TValue> member,
+    int fieldNumber,
     IProtoValueReader<TValue> valueReader
 ) : IProtoFieldReader<TBuilder>
 {
-    public int FieldNumber { get; } = ProtoWire.ProtoIndex(member.MemberTraits);
+    public int FieldNumber { get; } = fieldNumber;
 
     public void ReadInto(
         TBuilder builder,
@@ -549,10 +556,11 @@ internal sealed class ListProtoFieldReader<
 >(
     IMemberSchema<TContainer, TBuilder, TCollection> member,
     IListSchema<TCollection, TElement, TCollectionBuilder> list,
+    int fieldNumber,
     IProtoValueReader<TElement> elementReader
 ) : IProtoFieldReader<TBuilder>
 {
-    public int FieldNumber { get; } = ProtoWire.ProtoIndex(member.MemberTraits);
+    public int FieldNumber { get; } = fieldNumber;
 
     public void ReadInto(
         TBuilder builder,
@@ -594,11 +602,12 @@ internal sealed class ListProtoFieldReader<
 internal sealed class MapProtoFieldReader<TContainer, TBuilder, TDictionary, TValue, TMapBuilder>(
     IMemberSchema<TContainer, TBuilder, TDictionary> member,
     IMapSchema<TDictionary, TValue, TMapBuilder> map,
+    int fieldNumber,
     bool sparse,
     IProtoValueReader<TValue> valueReader
 ) : IProtoFieldReader<TBuilder>
 {
-    public int FieldNumber { get; } = ProtoWire.ProtoIndex(member.MemberTraits);
+    public int FieldNumber { get; } = fieldNumber;
 
     private readonly SparseScalarValueReader<TValue> sparseReader = new(
         map.TypedValueMember.TargetSchema
@@ -668,6 +677,7 @@ internal sealed class InlinedProtoUnionCaseReaderCompiler<TContainer, TBuilder, 
             new InlinedProtoUnionCaseReader<TContainer, TBuilder, TUnion, TValue>(
                 member,
                 unionCase,
+                ProtoWire.FieldNumber(unionCase.Id, unionCase.Traits, readers.Count),
                 compiler.CompileValue(unionCase.TargetSchema, unionCase.Traits)
             )
         );
@@ -676,10 +686,11 @@ internal sealed class InlinedProtoUnionCaseReaderCompiler<TContainer, TBuilder, 
 internal sealed class InlinedProtoUnionCaseReader<TContainer, TBuilder, TUnion, TValue>(
     IMemberSchema<TContainer, TBuilder, TUnion> member,
     IUnionCaseSchema<TUnion, TValue> unionCase,
+    int fieldNumber,
     IProtoValueReader<TValue> valueReader
 ) : IProtoFieldReader<TBuilder>
 {
-    public int FieldNumber { get; } = ProtoWire.ProtoIndex(unionCase.Traits);
+    public int FieldNumber { get; } = fieldNumber;
 
     public void ReadInto(
         TBuilder builder,
@@ -741,6 +752,7 @@ internal sealed class ProtoUnionCaseReaderCompiler<TUnion>(ProtoValueReaderCompi
         readers.Add(
             new ProtoUnionCaseReader<TUnion, TValue>(
                 unionCase,
+                ProtoWire.FieldNumber(unionCase.Id, unionCase.Traits, readers.Count),
                 compiler.CompileValue(unionCase.TargetSchema, unionCase.Traits)
             )
         );
@@ -748,10 +760,11 @@ internal sealed class ProtoUnionCaseReaderCompiler<TUnion>(ProtoValueReaderCompi
 
 internal sealed class ProtoUnionCaseReader<TUnion, TValue>(
     IUnionCaseSchema<TUnion, TValue> unionCase,
+    int fieldNumber,
     IProtoValueReader<TValue> valueReader
 ) : IProtoUnionCaseReader<TUnion>
 {
-    public int FieldNumber { get; } = ProtoWire.ProtoIndex(unionCase.Traits);
+    public int FieldNumber { get; } = fieldNumber;
 
     public TUnion Read(ref ProtoReader reader, WireType wireType) =>
         unionCase.Create(valueReader.ReadBody(ref reader, wireType));

--- a/packages/NSmithy.Codecs.Proto/ProtoWire.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWire.cs
@@ -208,6 +208,9 @@ internal static class ProtoWire
     );
     private static readonly ShapeId SparseTrait = new("smithy.api", "sparse");
 
+    /// <summary>The namespace of the shapes the runtime owns rather than reads from a model.</summary>
+    private const string FrameworkNamespace = "smithy.framework";
+
     // String enums map to proto enums; the declared values (in declaration order) come from the
     // synthetic trait the codegen attaches, matching ProtoGenerator's UNSPECIFIED=0, then 1,2,3…
     private static readonly ShapeId SyntheticEnumTrait = new("smithy.synthetic", "enum");
@@ -739,7 +742,22 @@ internal static class ProtoWire
         return Document.From(items);
     }
 
-    internal static int ProtoIndex(IReadOnlyDictionary<ShapeId, Trait> traits)
+    /// <summary>
+    /// The proto field number for a member: its <c>@protoIndex</c>, which a model has to state
+    /// because proto's compatibility rules hang on it — reordering members must not move a field.
+    /// </summary>
+    /// <remarks>
+    /// A framework shape is the one exception. The server runtime can return
+    /// <c>smithy.framework#ValidationException</c> from any operation, so every codec has to be able
+    /// to put it on the wire, but it comes from the runtime rather than a model file and so has no
+    /// trait to carry. Its numbers come from declaration order instead, which is this codec's rule
+    /// to make: nothing outside it should have to know that proto wants a number per member.
+    /// </remarks>
+    internal static int FieldNumber(
+        ShapeId memberId,
+        IReadOnlyDictionary<ShapeId, Trait> traits,
+        int ordinal
+    )
     {
         if (
             traits.TryGetValue(ProtoIndexTrait, out var trait)
@@ -749,8 +767,13 @@ internal static class ProtoWire
             return (int)trait.Value.AsNumber();
         }
 
+        if (memberId.Namespace == FrameworkNamespace)
+        {
+            return ordinal + 1;
+        }
+
         throw new InvalidOperationException(
-            "Proto codec requires every member to carry an @protoIndex trait."
+            $"Proto codec requires every member to carry an @protoIndex trait; '{memberId}' has none."
         );
     }
 

--- a/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
@@ -457,13 +457,15 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
             return;
         }
 
+        var fieldNumber = ProtoWire.FieldNumber(member.Id, member.MemberTraits, writers.Count);
         writers.Add(
             target switch
             {
-                IListSchema list => CreateListWriter(member, (dynamic)list),
-                IMapSchema map => CreateMapWriter(member, (dynamic)map),
+                IListSchema list => CreateListWriter(member, (dynamic)list, fieldNumber),
+                IMapSchema map => CreateMapWriter(member, (dynamic)map, fieldNumber),
                 _ => new ValueProtoMemberWriter<TContainer, TValue>(
                     member,
+                    fieldNumber,
                     compiler.CompileValue(member.TargetSchema, member.MemberTraits)
                 ),
             }
@@ -482,11 +484,13 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
 
     private ListProtoMemberWriter<TContainer, TValue, TElement> CreateListWriter<TValue, TElement>(
         IMemberSchema<TContainer, TValue> member,
-        IListSchema<TValue, TElement> list
+        IListSchema<TValue, TElement> list,
+        int fieldNumber
     ) =>
         new(
             member,
             list,
+            fieldNumber,
             compiler.CompileValue(
                 list.TypedElementMember.TargetSchema,
                 list.TypedElementMember.MemberTraits
@@ -495,11 +499,13 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
 
     private MapProtoMemberWriter<TContainer, TValue, TMapValue> CreateMapWriter<TValue, TMapValue>(
         IMemberSchema<TContainer, TValue> member,
-        IMapSchema<TValue, TMapValue> map
+        IMapSchema<TValue, TMapValue> map,
+        int fieldNumber
     ) =>
         new(
             member,
             map,
+            fieldNumber,
             ProtoWire.IsSparse((Schema)map),
             compiler.CompileValue(
                 map.TypedValueMember.TargetSchema,
@@ -510,11 +516,10 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
 
 internal sealed class ValueProtoMemberWriter<TContainer, TValue>(
     IMemberSchema<TContainer, TValue> member,
+    int fieldNumber,
     IProtoValueWriter<TValue> valueWriter
 ) : IProtoMemberWriter<TContainer>
 {
-    private readonly int fieldNumber = ProtoWire.ProtoIndex(member.MemberTraits);
-
     public void Write(ProtoWriter writer, TContainer value)
     {
         var memberValue = member.GetValue(value);
@@ -531,10 +536,10 @@ internal sealed class ValueProtoMemberWriter<TContainer, TValue>(
 internal sealed class ListProtoMemberWriter<TContainer, TCollection, TElement>(
     IMemberSchema<TContainer, TCollection> member,
     IListSchema<TCollection, TElement> list,
+    int fieldNumber,
     IProtoValueWriter<TElement> elementWriter
 ) : IProtoMemberWriter<TContainer>
 {
-    private readonly int fieldNumber = ProtoWire.ProtoIndex(member.MemberTraits);
     private readonly bool packable = ProtoWire.IsPackableScalar(
         ProtoWire.Unwrap(list.ElementSchema).Kind
     );
@@ -575,11 +580,11 @@ internal sealed class ListProtoMemberWriter<TContainer, TCollection, TElement>(
 internal sealed class MapProtoMemberWriter<TContainer, TDictionary, TValue>(
     IMemberSchema<TContainer, TDictionary> member,
     IMapSchema<TDictionary, TValue> map,
+    int fieldNumber,
     bool sparse,
     IProtoValueWriter<TValue> valueWriter
 ) : IProtoMemberWriter<TContainer>
 {
-    private readonly int fieldNumber = ProtoWire.ProtoIndex(member.MemberTraits);
     private readonly SparseScalarValueWriter<TValue> sparseWriter = new(
         map.TypedValueMember.TargetSchema
     );
@@ -637,6 +642,7 @@ internal sealed class InlinedProtoUnionMemberWriterCompiler<TContainer, TUnion>(
         writers.Add(
             new ProtoUnionCaseWriter<TUnion, TValue>(
                 unionCase,
+                ProtoWire.FieldNumber(unionCase.Id, unionCase.Traits, writers.Count),
                 compiler.CompileValue(unionCase.TargetSchema, unionCase.Traits)
             )
         );
@@ -691,6 +697,7 @@ internal sealed class ProtoUnionCaseWriterCompiler<TUnion>(ProtoValueWriterCompi
         writers.Add(
             new ProtoUnionCaseWriter<TUnion, TValue>(
                 unionCase,
+                ProtoWire.FieldNumber(unionCase.Id, unionCase.Traits, writers.Count),
                 compiler.CompileValue(unionCase.TargetSchema, unionCase.Traits)
             )
         );
@@ -698,11 +705,10 @@ internal sealed class ProtoUnionCaseWriterCompiler<TUnion>(ProtoValueWriterCompi
 
 internal sealed class ProtoUnionCaseWriter<TUnion, TValue>(
     IUnionCaseSchema<TUnion, TValue> unionCase,
+    int fieldNumber,
     IProtoValueWriter<TValue> valueWriter
 ) : IProtoUnionCaseWriter<TUnion>
 {
-    private readonly int fieldNumber = ProtoWire.ProtoIndex(unionCase.Traits);
-
     public bool TryWrite(ProtoWriter writer, TUnion value)
     {
         if (!unionCase.Matches(value))

--- a/packages/NSmithy.Core/Serde/MalformedRequestException.cs
+++ b/packages/NSmithy.Core/Serde/MalformedRequestException.cs
@@ -1,0 +1,107 @@
+namespace NSmithy.Core.Serde;
+
+/// <summary>
+/// What a server could not do with a request whose bytes never became modeled input. Each kind maps
+/// to a different HTTP status, but the mapping belongs to the protocol, not here: this says what
+/// went wrong, and the protocol says how that looks on the wire.
+/// </summary>
+public enum MalformedRequestKind
+{
+    /// <summary>The request could not be read as the shape the model declares.</summary>
+    Serialization,
+
+    /// <summary>The request's <c>Content-Type</c> is not the one the operation's input is bound to.</summary>
+    UnsupportedMediaType,
+
+    /// <summary>The request's <c>Accept</c> excludes the media type the operation's output uses.</summary>
+    NotAcceptable,
+}
+
+/// <summary>
+/// Thrown while a server reads a request that never becomes modeled input at all: a body that is not
+/// valid JSON, a non-numeric integer, a timestamp in the wrong format, a content type the operation
+/// does not accept. It is the counterpart of
+/// <see cref="NSmithy.Core.Validation.ValidationException"/>, which answers input that parsed but
+/// broke a constraint — and like it, a caller mistake rather than a server fault, so the runtime
+/// answers with a structured 4xx instead of letting it reach the host as a 500.
+/// </summary>
+public sealed class MalformedRequestException(MalformedRequestKind kind, string message)
+    : Exception(message)
+{
+    public MalformedRequestKind Kind { get; } = kind;
+
+    public static MalformedRequestException Serialization(string message) =>
+        new(MalformedRequestKind.Serialization, message);
+
+    public static MalformedRequestException UnsupportedMediaType(string message) =>
+        new(MalformedRequestKind.UnsupportedMediaType, message);
+
+    public static MalformedRequestException NotAcceptable(string message) =>
+        new(MalformedRequestKind.NotAcceptable, message);
+}
+
+/// <summary>
+/// The body a <see cref="MalformedRequestException"/> serializes to. Smithy models no shape for
+/// these faults — the status and the protocol's error discriminator are the whole contract the
+/// malformed-request suite asserts — but a response a caller cannot read is a poor one, so the
+/// runtime carries the same single <c>message</c> member every Smithy error has.
+/// </summary>
+public static class MalformedRequestSchema
+{
+    public static readonly ShapeId Id = ShapeId.Parse("smithy.framework#MalformedRequest");
+
+    public sealed class Builder
+    {
+        public string? Message { get; set; }
+    }
+
+    public static Schema<MalformedRequestException> Schema { get; } =
+        Schemas
+            .Structure<MalformedRequestException, Builder>(
+                Id,
+                [new Trait(ShapeId.Parse("smithy.api#error"), Document.From("client"))]
+            )
+            .Required(
+                "message",
+                static value => value.Message,
+                static (builder, value) => builder.Message = value,
+                Schemas.NullableReference(Schemas.String),
+                [FrameworkTraits.ProtoIndex(1)]
+            )
+            .Build(
+                static () => new Builder(),
+                static builder =>
+                    MalformedRequestException.Serialization(
+                        builder.Message ?? throw new MissingRequiredMemberException("message")
+                    )
+            );
+
+    /// <summary>
+    /// The wire name a protocol puts in its error discriminator, and the status that goes with it.
+    /// These are the names AWS's REST protocols use and the malformed-request suite asserts.
+    /// </summary>
+    public static (string ErrorType, int StatusCode) Wire(MalformedRequestKind kind) =>
+        kind switch
+        {
+            MalformedRequestKind.Serialization => ("SerializationException", 400),
+            MalformedRequestKind.UnsupportedMediaType => ("UnsupportedMediaTypeException", 415),
+            MalformedRequestKind.NotAcceptable => ("NotAcceptableException", 406),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+}
+
+/// <summary>
+/// Traits a framework shape declares for itself. A modeled shape gets its traits from a model file;
+/// a shape the runtime owns has none, so anything a codec requires has to be stated here.
+/// </summary>
+internal static class FrameworkTraits
+{
+    private static readonly ShapeId ProtoIndexTrait = ShapeId.Parse("alloy.proto#protoIndex");
+
+    /// <summary>
+    /// Every protocol has to be able to put a framework shape on the wire, because the server
+    /// runtime can return one from any operation. The proto codec requires a field number on every
+    /// member, and unlike a modeled shape there is no model file to carry one.
+    /// </summary>
+    public static Trait ProtoIndex(int index) => new(ProtoIndexTrait, Document.From(index));
+}

--- a/packages/NSmithy.Core/Serde/MalformedRequestException.cs
+++ b/packages/NSmithy.Core/Serde/MalformedRequestException.cs
@@ -46,6 +46,10 @@ public sealed class MalformedRequestException(MalformedRequestKind kind, string 
 /// malformed-request suite asserts — but a response a caller cannot read is a poor one, so the
 /// runtime carries the same single <c>message</c> member every Smithy error has.
 /// </summary>
+/// <remarks>
+/// Like every shape the runtime owns rather than reads from a model, it declares only what the
+/// model would: what a particular codec needs on top of that is that codec's problem to solve.
+/// </remarks>
 public static class MalformedRequestSchema
 {
     public static readonly ShapeId Id = ShapeId.Parse("smithy.framework#MalformedRequest");
@@ -65,8 +69,7 @@ public static class MalformedRequestSchema
                 "message",
                 static value => value.Message,
                 static (builder, value) => builder.Message = value,
-                Schemas.NullableReference(Schemas.String),
-                [FrameworkTraits.ProtoIndex(1)]
+                Schemas.NullableReference(Schemas.String)
             )
             .Build(
                 static () => new Builder(),
@@ -88,20 +91,4 @@ public static class MalformedRequestSchema
             MalformedRequestKind.NotAcceptable => ("NotAcceptableException", 406),
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
-}
-
-/// <summary>
-/// Traits a framework shape declares for itself. A modeled shape gets its traits from a model file;
-/// a shape the runtime owns has none, so anything a codec requires has to be stated here.
-/// </summary>
-internal static class FrameworkTraits
-{
-    private static readonly ShapeId ProtoIndexTrait = ShapeId.Parse("alloy.proto#protoIndex");
-
-    /// <summary>
-    /// Every protocol has to be able to put a framework shape on the wire, because the server
-    /// runtime can return one from any operation. The proto codec requires a field number on every
-    /// member, and unlike a modeled shape there is no model file to carry one.
-    /// </summary>
-    public static Trait ProtoIndex(int index) => new(ProtoIndexTrait, Document.From(index));
 }

--- a/packages/NSmithy.Core/Serde/Rfc3339.cs
+++ b/packages/NSmithy.Core/Serde/Rfc3339.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace NSmithy.Core.Serde;
+
+/// <summary>
+/// Smithy's <c>date-time</c> timestamp format: the <c>date-time</c> production of
+/// <see href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC 3339 section 5.6</see>.
+/// </summary>
+/// <remarks>
+/// <see cref="DateTimeOffset.Parse(string, IFormatProvider?, DateTimeStyles)"/> is far more
+/// permissive than that production — it also accepts IMF-fixdate, which is a different Smithy format
+/// — so a server using it would silently accept a timestamp the model says is wrong. The shape is
+/// checked first and only then handed to the framework parser, which is the part that knows about
+/// leap years and offsets.
+/// </remarks>
+public static partial class Rfc3339
+{
+    /// <summary>
+    /// Reads a <c>date-time</c>. Smithy's production carries no UTC offset — every conforming peer
+    /// writes <c>Z</c> — so a <see cref="WireReadMode.Strict"/> read rejects one and a
+    /// <see cref="WireReadMode.Lenient"/> read honors it.
+    /// </summary>
+    public static DateTimeOffset Parse(string value, WireReadMode readMode = WireReadMode.Lenient)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var match = Pattern().Match(value);
+        if (!match.Success)
+        {
+            throw new FormatException($"'{value}' is not an RFC 3339 date-time.");
+        }
+
+        if (readMode == WireReadMode.Strict && match.Groups["offset"].Value is not ("Z" or "z"))
+        {
+            throw new FormatException(
+                $"'{value}' carries a UTC offset, which a date-time timestamp does not."
+            );
+        }
+
+        return DateTimeOffset.Parse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind
+        );
+    }
+
+    [GeneratedRegex(
+        @"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?(?<offset>[Zz]|[+-]\d{2}:\d{2})$",
+        RegexOptions.CultureInvariant
+    )]
+    private static partial Regex Pattern();
+}

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -331,19 +331,31 @@ public sealed class StringEnumSchema<T> : Schema<T>, IStringEnumSchema
     internal StringEnumSchema(
         ShapeId id,
         IEnumerable<string>? values = null,
-        IEnumerable<Trait>? traits = null
+        IEnumerable<Trait>? traits = null,
+        IEnumerable<string>? internalValues = null
     )
         : base(id, ShapeKind.Enum, traits)
     {
         Values = values is null ? [] : [.. values];
         lookup = Values.ToFrozenSet(StringComparer.Ordinal);
+        var hidden = internalValues is null
+            ? []
+            : internalValues.ToFrozenSet(StringComparer.Ordinal);
+        PublishedValues = hidden.Count == 0 ? Values : [.. Values.Where(v => !hidden.Contains(v))];
     }
 
     private readonly FrozenSet<string> lookup;
 
     public bool Contains(string value) => lookup.Contains(value);
 
+    /// <summary>Every value the model declares, which is what membership is decided against.</summary>
     public IReadOnlyList<string> Values { get; }
+
+    /// <summary>
+    /// The values without <c>@internal</c>. A caller sees these listed when a value is rejected: an
+    /// internal member is still accepted on the wire, but naming it back would advertise it.
+    /// </summary>
+    public IReadOnlyList<string> PublishedValues { get; }
 
     public T Create(string value) => T.FromValue(value);
 
@@ -1582,6 +1594,27 @@ public static class Schemas
 {
     private const string PreludeNamespace = "smithy.api";
 
+    private static readonly ShapeId SyntheticOriginalShapeId = new(
+        "smithy.synthetic",
+        "originalShapeId"
+    );
+
+    private const string UnitShapeId = "smithy.api#Unit";
+
+    /// <summary>
+    /// Whether a schema is the empty structure Smithy synthesizes for an operation whose input or
+    /// output is <c>smithy.api#Unit</c>. The synthetic shape carries
+    /// <c>smithy.synthetic#originalShapeId</c> pointing back at the unit, which is the only thing
+    /// telling it apart from a structure the model really declares with no members — a distinction
+    /// protocols need, because one has no body and the other has an empty one.
+    /// </summary>
+    public static bool IsSyntheticUnit(Schema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        return schema.GetTrait(SyntheticOriginalShapeId)?.Value is { Kind: DocumentKind.String } id
+            && id.AsString() == UnitShapeId;
+    }
+
     public static Schema<bool> Boolean { get; } =
         new BooleanSchema(new ShapeId(PreludeNamespace, "Boolean"));
 
@@ -1650,9 +1683,10 @@ public static class Schemas
     public static StringEnumSchema<T> StringEnum<T>(
         ShapeId id,
         IEnumerable<string>? values = null,
-        IEnumerable<Trait>? traits = null
+        IEnumerable<Trait>? traits = null,
+        IEnumerable<string>? internalValues = null
     )
-        where T : IStringEnumValue<T> => new(id, values, traits);
+        where T : IStringEnumValue<T> => new(id, values, traits, internalValues);
 
     public static IntEnumSchema<T> IntEnum<T>(
         ShapeId id,

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -312,6 +312,15 @@ public sealed class NullableSchema<T> : Schema<T?>, INullableSchema
 public interface IStringEnumSchema
 {
     object CreateObject(string value);
+
+    /// <summary>Whether the value is one the model declares.</summary>
+    bool Contains(string value);
+
+    /// <summary>
+    /// The values without <c>@internal</c> — what a caller is told when a value is rejected. See
+    /// <see cref="StringEnumSchema{T}.PublishedValues"/>.
+    /// </summary>
+    IReadOnlyList<string> PublishedValues { get; }
 }
 
 public interface IStringEnumValue
@@ -529,6 +538,14 @@ public interface IListSchema<TCollection, TElement, TBuilder> : IListSchema<TCol
 
 public interface IMapSchema
 {
+    /// <summary>
+    /// The key as the model declares it. A map key is always a string on the wire — that is what a
+    /// JSON object name is — but the shape it targets can still say more about which strings are
+    /// allowed, and an enum shape says exactly that. Keeping the shape rather than flattening it to
+    /// <see cref="Schemas.String"/> is what lets a server hold a key to it.
+    /// </summary>
+    IMemberSchema KeyMember { get; }
+
     Schema Value { get; }
 
     IEnumerable<KeyValuePair<string, object?>> GetEntriesObject(object value);
@@ -542,8 +559,6 @@ public interface IMapSchema
 
 public interface IMapSchema<TDictionary, TValue> : IMapSchema
 {
-    ITargetedMemberSchema<string> TypedKeyMember { get; }
-
     ITargetedMemberSchema<TValue> TypedValueMember { get; }
 
     Schema<TValue> ValueSchema { get; }
@@ -696,6 +711,49 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
 
     public Trait? GetTrait(ShapeId id) =>
         MemberTraits.TryGetValue(id, out var trait) ? trait : TargetSchema.GetTrait(id);
+
+    public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
+}
+
+/// <summary>
+/// A map's key member. Untyped, unlike every other member, because a key's CLR type and its modeled
+/// shape need not agree: the key of a map is a <see cref="string"/> whatever it targets — a JSON
+/// object name has no other form — while the shape it targets may be an enum, whose own CLR type is
+/// the generated enum. Carrying the shape is what lets a server hold the key to it.
+/// </summary>
+public sealed class MapKeyMemberSchema : IMemberSchema
+{
+    private readonly IReadOnlyDictionary<ShapeId, Trait> memberTraits;
+
+    internal MapKeyMemberSchema(ShapeId id, Schema target, IEnumerable<Trait>? traits = null)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (!id.IsMember)
+        {
+            throw new ArgumentException(
+                $"Member schema id must include a member name; got '{id}'.",
+                nameof(id)
+            );
+        }
+
+        Id = id;
+        Target = target;
+        memberTraits = Schema.BuildTraits(traits);
+    }
+
+    public ShapeId Id { get; }
+
+    public string Name => Id.MemberName!;
+
+    public IReadOnlyDictionary<ShapeId, Trait> MemberTraits => memberTraits;
+
+    public Schema Target { get; }
+
+    // An entry's key is always present when the map holds the entry.
+    public bool IsRequired => true;
+
+    public Trait? GetTrait(ShapeId id) =>
+        MemberTraits.TryGetValue(id, out var trait) ? trait : Target.GetTrait(id);
 
     public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
@@ -907,16 +965,13 @@ public sealed class MapSchema<TValue>
         Schema<TValue> value,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? keyTraits = null,
-        IEnumerable<Trait>? valueTraits = null
+        IEnumerable<Trait>? valueTraits = null,
+        Schema? key = null
     )
         : base(id, ShapeKind.Map, traits)
     {
         ArgumentNullException.ThrowIfNull(value);
-        TypedKeyMember = new CollectionMemberSchema<string>(
-            id.WithMember("key"),
-            Schemas.String,
-            keyTraits
-        );
+        KeyMember = new MapKeyMemberSchema(id.WithMember("key"), key ?? Schemas.String, keyTraits);
         TypedValueMember = new CollectionMemberSchema<TValue>(
             id.WithMember("value"),
             value,
@@ -925,7 +980,7 @@ public sealed class MapSchema<TValue>
         ValueSchema = value;
     }
 
-    public ITargetedMemberSchema<string> TypedKeyMember { get; }
+    public IMemberSchema KeyMember { get; }
 
     public ITargetedMemberSchema<TValue> TypedValueMember { get; }
 
@@ -985,7 +1040,8 @@ public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
         Func<TBuilder, TDictionary> build,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? keyTraits = null,
-        IEnumerable<Trait>? valueTraits = null
+        IEnumerable<Trait>? valueTraits = null,
+        Schema? key = null
     )
         : base(id, ShapeKind.Map, traits)
     {
@@ -995,11 +1051,7 @@ public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
         ArgumentNullException.ThrowIfNull(add);
         ArgumentNullException.ThrowIfNull(build);
 
-        TypedKeyMember = new CollectionMemberSchema<string>(
-            id.WithMember("key"),
-            Schemas.String,
-            keyTraits
-        );
+        KeyMember = new MapKeyMemberSchema(id.WithMember("key"), key ?? Schemas.String, keyTraits);
         TypedValueMember = new CollectionMemberSchema<TValue>(
             id.WithMember("value"),
             value,
@@ -1012,7 +1064,7 @@ public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
         this.build = build;
     }
 
-    public ITargetedMemberSchema<string> TypedKeyMember { get; }
+    public IMemberSchema KeyMember { get; }
 
     public ITargetedMemberSchema<TValue> TypedValueMember { get; }
 
@@ -1769,13 +1821,19 @@ public static class Schemas
             elementTraits
         );
 
+    /// <param name="key">
+    /// The shape the key targets. Defaults to <see cref="String"/>, which is what a map key with no
+    /// shape of its own is; pass the modeled shape when the model gives it one, so a server can hold
+    /// the key to what that shape says.
+    /// </param>
     public static MapSchema<TValue> Map<TValue>(
         ShapeId id,
         Schema<TValue> value,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? keyTraits = null,
-        IEnumerable<Trait>? valueTraits = null
-    ) => new(id, value, traits, keyTraits, valueTraits);
+        IEnumerable<Trait>? valueTraits = null,
+        Schema? key = null
+    ) => new(id, value, traits, keyTraits, valueTraits, key);
 
     public static DictionarySchema<TDictionary, TValue, TBuilder> Map<
         TDictionary,
@@ -1790,8 +1848,9 @@ public static class Schemas
         Func<TBuilder, TDictionary> build,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? keyTraits = null,
-        IEnumerable<Trait>? valueTraits = null
-    ) => new(id, value, getEntries, createBuilder, add, build, traits, keyTraits, valueTraits);
+        IEnumerable<Trait>? valueTraits = null,
+        Schema? key = null
+    ) => new(id, value, getEntries, createBuilder, add, build, traits, keyTraits, valueTraits, key);
 
     public static OperationSchema<TInput, TOutput> Operation<TInput, TOutput>(
         ShapeId id,

--- a/packages/NSmithy.Core/Serde/WireReadMode.cs
+++ b/packages/NSmithy.Core/Serde/WireReadMode.cs
@@ -1,0 +1,21 @@
+namespace NSmithy.Core.Serde;
+
+/// <summary>
+/// How closely a codec holds the wire to the model when reading.
+/// </summary>
+/// <remarks>
+/// A server reads what a caller sent and owes a structured 400 for anything the model does not
+/// allow, so it reads <see cref="Strict"/>. A client reads a peer it does not control — a real
+/// service that predates a rule, or is simply looser than the spec — and refusing a response it can
+/// understand helps nobody, so it reads <see cref="Lenient"/>. Only one rule currently differs: the
+/// UTC offset on a <c>date-time</c> timestamp, which Smithy's own protocol tests require a server to
+/// reject and a client to accept.
+/// </remarks>
+public enum WireReadMode
+{
+    /// <summary>Accept what can be understood. The default, and what a client uses.</summary>
+    Lenient,
+
+    /// <summary>Accept only what the model declares. What a server uses.</summary>
+    Strict,
+}

--- a/packages/NSmithy.Core/Validation/SmithyValidator.cs
+++ b/packages/NSmithy.Core/Validation/SmithyValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Numerics;
@@ -130,6 +131,7 @@ internal static class ConstraintTraits
             || traits.ContainsKey(Range)
             || traits.ContainsKey(Pattern)
             || traits.ContainsKey(UniqueItems)
+            || traits.ContainsKey(Enum)
         );
 }
 
@@ -648,6 +650,7 @@ internal sealed class ConstraintValidator<T> : IValueValidator<T>
         AddLengthConstraint(traits, shapeId, kind, target, constraints);
         AddRangeConstraint(traits, shapeId, kind, constraints);
         AddPatternConstraint(traits, shapeId, kind, constraints);
+        AddEnumTraitConstraint(traits, shapeId, kind, constraints);
         return constraints.Count == 0
             ? NoOpValidator<T>.Instance
             : new ConstraintValidator<T>(constraints);
@@ -768,6 +771,70 @@ internal sealed class ConstraintValidator<T> : IValueValidator<T>
     }
 
     /// <summary>
+    /// The deprecated <c>@enum</c> trait on a string shape. An enum shape carries its value set on
+    /// the schema and is checked by <see cref="StringEnumValidator{T}"/>; a string that predates enum
+    /// shapes carries its set in this trait instead, and generates a plain <c>string</c>, so the set
+    /// is read from the trait here. Both close the same openness at the same place.
+    /// </summary>
+    private static void AddEnumTraitConstraint(
+        IReadOnlyDictionary<ShapeId, Trait> traits,
+        ShapeId shapeId,
+        ShapeKind kind,
+        List<IConstraint<T>> constraints
+    )
+    {
+        if (
+            kind != ShapeKind.String
+            || !traits.TryGetValue(ConstraintTraits.Enum, out var trait)
+            || trait.Value.Kind != DocumentKind.Array
+        )
+        {
+            return;
+        }
+
+        if (typeof(T) != typeof(string))
+        {
+            throw Unenforceable(ConstraintTraits.Enum, shapeId);
+        }
+
+        List<string> values = [];
+        List<string> published = [];
+        foreach (var entry in trait.Value.AsArray())
+        {
+            if (
+                entry.Kind != DocumentKind.Object
+                || !entry.AsObject().TryGetValue("value", out var value)
+                || value.Kind != DocumentKind.String
+            )
+            {
+                continue;
+            }
+
+            values.Add(value.AsString());
+            if (!IsInternal(entry))
+            {
+                published.Add(value.AsString());
+            }
+        }
+
+        if (values.Count > 0)
+        {
+            constraints.Add(new EnumTraitConstraint<T>(shapeId, values, published));
+        }
+    }
+
+    /// <summary>
+    /// A value the model keeps but does not publish. The trait predates <c>@internal</c>, so it says
+    /// so with a tag; either way such a value is accepted on the wire but left out of the message,
+    /// which is what a caller sees.
+    /// </summary>
+    private static bool IsInternal(Document entry) =>
+        entry.AsObject().TryGetValue("tags", out var tags)
+        && tags.Kind == DocumentKind.Array
+        && tags.AsArray()
+            .Any(tag => tag.Kind == DocumentKind.String && tag.AsString() == "internal");
+
+    /// <summary>
     /// Prefers the non-backtracking engine, which has no catastrophic-backtracking failure mode, so
     /// a hostile input cannot stall a request thread. Patterns using constructs it does not support
     /// (backreferences, lookaround) fall back to the backtracking engine under a timeout.
@@ -823,7 +890,7 @@ internal sealed class StringEnumValidator<T>(StringEnumSchema<T> schema) : IValu
                 ConstraintTraits.Enum,
                 ConstraintMessages.Failed(
                     path,
-                    $"Member must satisfy enum value set: [{string.Join(", ", schema.Values)}]"
+                    $"Member must satisfy enum value set: [{string.Join(", ", schema.PublishedValues)}]"
                 )
             )
         );
@@ -973,6 +1040,40 @@ internal sealed class RangeConstraint<T>(
                 )
             );
         }
+    }
+}
+
+/// <summary>
+/// The value set of a deprecated <c>@enum</c> trait. <paramref name="published"/> is what the
+/// message lists — a value the model marks internal is still accepted, but naming it back to a
+/// caller would advertise it.
+/// </summary>
+internal sealed class EnumTraitConstraint<T>(
+    ShapeId shapeId,
+    IReadOnlyList<string> values,
+    IReadOnlyList<string> published
+) : IConstraint<T>
+{
+    private readonly FrozenSet<string> lookup = values.ToFrozenSet(StringComparer.Ordinal);
+
+    public void Validate(T value, string path, List<SmithyValidationError> errors)
+    {
+        if (value is not string text || lookup.Contains(text))
+        {
+            return;
+        }
+
+        errors.Add(
+            new SmithyValidationError(
+                path,
+                shapeId,
+                ConstraintTraits.Enum,
+                ConstraintMessages.Failed(
+                    path,
+                    $"Member must satisfy enum value set: [{string.Join(", ", published)}]"
+                )
+            )
+        );
     }
 }
 

--- a/packages/NSmithy.Core/Validation/SmithyValidator.cs
+++ b/packages/NSmithy.Core/Validation/SmithyValidator.cs
@@ -187,7 +187,7 @@ internal static class ValidatorCompiler
         IMapSchema<TDictionary, TValue> map,
         HashSet<Schema> visited
     ) =>
-        RequiresMemberValidation(map.TypedKeyMember, visited)
+        RequiresMemberValidation(map.KeyMember, visited)
         || RequiresMemberValidation(map.TypedValueMember, visited);
 
     private sealed class StructuralCompiler : ISchemaVisitor<object>
@@ -338,6 +338,20 @@ internal static class ValidatorCompiler
     /// One compilation path for every kind of member — structure members, list elements, map keys
     /// and map values are the same thing here: an edge with its own traits onto a target schema.
     /// </summary>
+    /// <summary>
+    /// A map key is a string whatever it targets, so it cannot be compiled like a typed member: its
+    /// traits constrain the string, while the shape it targets may close the set of strings allowed.
+    /// An enum key is the case that matters — the value set lives on the enum schema, and there is
+    /// nowhere else for it to be.
+    /// </summary>
+    internal static MemberValueValidator<string> CompileMapKey(IMemberSchema key) =>
+        new(
+            ConstraintValidator<string>.FromTraits(key.MemberTraits, key.Id, Schemas.String),
+            key.Target.Resolved is IStringEnumSchema @enum
+                ? new StringKeyEnumValidator(key.Target.Id, @enum)
+                : NoOpValidator<string>.Instance
+        );
+
     internal static MemberValueValidator<TValue> CompileMember<TValue>(
         ITargetedMemberSchema<TValue> member
     ) =>
@@ -528,8 +542,8 @@ internal sealed class ListValidator<TCollection, TElement> : IValueValidator<TCo
 internal sealed class MapValidator<TDictionary, TValue>(IMapSchema<TDictionary, TValue> schema)
     : IValueValidator<TDictionary>
 {
-    private readonly MemberValueValidator<string> keyValidator = ValidatorCompiler.CompileMember(
-        schema.TypedKeyMember
+    private readonly MemberValueValidator<string> keyValidator = ValidatorCompiler.CompileMapKey(
+        schema.KeyMember
     );
     private readonly MemberValueValidator<TValue> valueValidator = ValidatorCompiler.CompileMember(
         schema.TypedValueMember
@@ -883,18 +897,49 @@ internal sealed class StringEnumValidator<T>(StringEnumSchema<T> schema) : IValu
             return;
         }
 
-        errors.Add(
-            new SmithyValidationError(
+        errors.Add(EnumMembership.Error(path, schema.Id, schema.PublishedValues));
+    }
+}
+
+/// <summary>
+/// <inheritdoc cref="StringEnumValidator{T}" path="/summary"/> A key reaches the validator as a
+/// string rather than as the enum's own type, because that is what a map key is, so it is checked
+/// against the enum schema directly.
+/// </summary>
+internal sealed class StringKeyEnumValidator(ShapeId shapeId, IStringEnumSchema schema)
+    : IValueValidator<string>
+{
+    public void Validate(string value, string path, List<SmithyValidationError> errors)
+    {
+        if (value is null || schema.Contains(value))
+        {
+            return;
+        }
+
+        errors.Add(EnumMembership.Error(path, shapeId, schema.PublishedValues));
+    }
+}
+
+/// <summary>
+/// The one place a rejected enum value is worded, so the enum shape, the enum-keyed map, and the
+/// deprecated <c>@enum</c> trait cannot drift from each other.
+/// </summary>
+internal static class EnumMembership
+{
+    public static SmithyValidationError Error(
+        string path,
+        ShapeId shapeId,
+        IReadOnlyList<string> published
+    ) =>
+        new(
+            path,
+            shapeId,
+            ConstraintTraits.Enum,
+            ConstraintMessages.Failed(
                 path,
-                schema.Id,
-                ConstraintTraits.Enum,
-                ConstraintMessages.Failed(
-                    path,
-                    $"Member must satisfy enum value set: [{string.Join(", ", schema.PublishedValues)}]"
-                )
+                $"Member must satisfy enum value set: [{string.Join(", ", published)}]"
             )
         );
-    }
 }
 
 /// <inheritdoc cref="StringEnumValidator{T}" />
@@ -1063,17 +1108,7 @@ internal sealed class EnumTraitConstraint<T>(
             return;
         }
 
-        errors.Add(
-            new SmithyValidationError(
-                path,
-                shapeId,
-                ConstraintTraits.Enum,
-                ConstraintMessages.Failed(
-                    path,
-                    $"Member must satisfy enum value set: [{string.Join(", ", published)}]"
-                )
-            )
-        );
+        errors.Add(EnumMembership.Error(path, shapeId, published));
     }
 }
 

--- a/packages/NSmithy.Core/Validation/ValidationException.cs
+++ b/packages/NSmithy.Core/Validation/ValidationException.cs
@@ -96,19 +96,6 @@ public static class ValidationExceptionFieldSchema
             );
 }
 
-internal static class FrameworkTraits
-{
-    private static readonly ShapeId ProtoIndexTrait = ShapeId.Parse("alloy.proto#protoIndex");
-
-    /// <summary>
-    /// Every protocol has to be able to put this shape on the wire, because the server runtime can
-    /// return it from any operation. The proto codec requires a field number on every member, and
-    /// unlike a modeled shape there is no model file to carry one, so the framework shape declares
-    /// its own.
-    /// </summary>
-    public static Trait ProtoIndex(int index) => new(ProtoIndexTrait, Document.From(index));
-}
-
 public static class ValidationExceptionSchema
 {
     public static readonly ShapeId Id = ShapeId.Parse("smithy.framework#ValidationException");

--- a/packages/NSmithy.Core/Validation/ValidationException.cs
+++ b/packages/NSmithy.Core/Validation/ValidationException.cs
@@ -77,15 +77,13 @@ public static class ValidationExceptionFieldSchema
                 "path",
                 static value => value.Path,
                 static (builder, value) => builder.Path = value,
-                Schemas.NullableReference(Schemas.String),
-                [FrameworkTraits.ProtoIndex(1)]
+                Schemas.NullableReference(Schemas.String)
             )
             .Required(
                 "message",
                 static value => value.Message,
                 static (builder, value) => builder.Message = value,
-                Schemas.NullableReference(Schemas.String),
-                [FrameworkTraits.ProtoIndex(2)]
+                Schemas.NullableReference(Schemas.String)
             )
             .Build(
                 static () => new Builder(),
@@ -117,8 +115,7 @@ public static class ValidationExceptionSchema
                 "message",
                 static value => value.Message,
                 static (builder, value) => builder.Message = value,
-                Schemas.NullableReference(Schemas.String),
-                [FrameworkTraits.ProtoIndex(1)]
+                Schemas.NullableReference(Schemas.String)
             )
             .Optional(
                 "fieldList",
@@ -129,8 +126,7 @@ public static class ValidationExceptionSchema
                         ShapeId.Parse("smithy.framework#ValidationExceptionFieldList"),
                         ValidationExceptionFieldSchema.Schema
                     )
-                ),
-                [FrameworkTraits.ProtoIndex(2)]
+                )
             )
             .Build(
                 static () => new Builder(),

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -20,21 +20,11 @@ public sealed class AwsJson11Protocol : AwsJsonProtocol
 
 public abstract class AwsJsonProtocol(string contentType) : IProtocol
 {
-    private static readonly ShapeId SyntheticOriginalShapeId = new(
-        "smithy.synthetic",
-        "originalShapeId"
-    );
-
     public IServiceProtocol ForService(ServiceSchema service)
     {
         ArgumentNullException.ThrowIfNull(service);
         return new ServiceProtocol(service, contentType);
     }
-
-    private static bool IsUnitSchema(Schema schema) =>
-        schema.HasTrait(SyntheticOriginalShapeId)
-        && schema.GetTrait(SyntheticOriginalShapeId)?.Value.Kind == DocumentKind.String
-        && schema.GetTrait(SyntheticOriginalShapeId)?.Value.AsString() == "smithy.api#Unit";
 
     private sealed class ServiceProtocol(ServiceSchema service, string contentType)
         : IServiceProtocol
@@ -75,7 +65,7 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
             this.contentType = contentType;
             target = $"{service.Id.Name}.{operation.Id.Name}";
             outputIsSmithyUnit = typeof(TOutput) == typeof(SmithyUnit);
-            outputIsUnit = outputIsSmithyUnit || IsUnitSchema(operation.Output);
+            outputIsUnit = outputIsSmithyUnit || Schemas.IsSyntheticUnit(operation.Output);
             outputSchema = operation.Output;
             requestCodec = JsonCodec.FromSchema(operation.Input);
             responseCodec = JsonCodec.FromSchema(operation.Output);

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -35,11 +35,6 @@ public sealed class GrpcProtocol : IProtocol
     // standard Smithy↔gRPC error binding.
     internal const string ErrorShapeHeader = "x-smithy-grpc-error";
 
-    private static readonly ShapeId SyntheticOriginalShapeId = new(
-        "smithy.synthetic",
-        "originalShapeId"
-    );
-
     public IServiceProtocol ForService(ServiceSchema service)
     {
         ArgumentNullException.ThrowIfNull(service);
@@ -757,11 +752,7 @@ public sealed class GrpcProtocol : IProtocol
         body is SmithyHttpBody.Bytes bytes ? bytes.Content : [];
 
     private static bool IsUnit<T>(Schema schema) =>
-        typeof(T) == typeof(SmithyUnit)
-        || (
-            schema.GetTrait(SyntheticOriginalShapeId)?.Value.Kind == DocumentKind.String
-            && schema.GetTrait(SyntheticOriginalShapeId)?.Value.AsString() == "smithy.api#Unit"
-        );
+        typeof(T) == typeof(SmithyUnit) || Schemas.IsSyntheticUnit(schema);
 
     private static Schema? FindEventStreamEventSchema(Schema schema) =>
         schema.Resolved is IStructSchema structure

--- a/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
@@ -34,6 +34,28 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
     /// <summary>Pre-resolved value for the request's <c>Accept</c> header.</summary>
     public required string AcceptType { get; init; }
 
+    /// <summary>
+    /// The <c>Content-Type</c> a request body must carry, or null when the operation models no
+    /// request body at all — in which case a request that sends one is rejected rather than ignored.
+    /// </summary>
+    public required string? RequestContentType { get; init; }
+
+    /// <summary>
+    /// True when the request body is an opaque blob payload, whose <c>Content-Type</c> the protocol
+    /// therefore does not constrain. See <see cref="RestProtocol.IsOpaquePayload"/>.
+    /// </summary>
+    public required bool RequestMediaTypeIsOpaque { get; init; }
+
+    /// <summary>The same for the response, which is what an <c>Accept</c> header is matched against.</summary>
+    public required bool ResponseMediaTypeIsOpaque { get; init; }
+
+    /// <summary>
+    /// Whether a request that sends a body must say what media type it is. AWS's REST protocols
+    /// require it and answer an omission with a 415; alloy's <c>simpleRestJson</c> does not, and its
+    /// own protocol tests send JSON bodies with no <c>Content-Type</c> at all.
+    /// </summary>
+    public required bool RequiresDeclaredContentType { get; init; }
+
     /// <summary>True when the response payload is a streaming blob and must not be buffered.</summary>
     public required bool OutputHasStreamingPayload { get; init; }
 
@@ -75,7 +97,8 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
         IStructSchema<TInput, TInputBuilder> inputSchema,
         IStructSchema<TOutput, TOutputBuilder> outputSchema,
         IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads
+        bool rawStringPayloads,
+        bool requiresDeclaredContentType
     )
     {
         ArgumentNullException.ThrowIfNull(operation);
@@ -97,6 +120,13 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
         var outputIsUnit =
             typeof(TOutput) == typeof(SmithyUnit) || operation.Output.Resolved is UnitSchema;
 
+        // A synthetic unit is an input that models no body at all, which is not the same as a
+        // structure the model declares with no members: that one still has a body, an empty object.
+        var inputIsUnit =
+            typeof(TInput) == typeof(SmithyUnit)
+            || operation.Input.Resolved is UnitSchema
+            || Schemas.IsSyntheticUnit(operation.Input);
+
         // Partition input members in a single pass
         var labelMembers = new List<IStructMemberSchema>();
         var queryMembers = new List<QueryMemberBinding>();
@@ -106,9 +136,11 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
         IMemberSchema<TInput>? inputPayloadMember = null;
         var inputBodyMembers = new List<IMemberSchema<TInput>>();
         var boundQueryNames = new HashSet<string>(StringComparer.Ordinal);
+        var inputMemberCount = 0;
 
         foreach (var member in Schemas.GetMembers(inputSchema))
         {
+            inputMemberCount++;
             if (member.MemberTraits.ContainsKey(RestTraits.HttpLabel))
             {
                 labelMembers.Add(member);
@@ -147,6 +179,14 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
                 inputBodyMembers.Add(member);
             }
         }
+
+        // A structure the model declares still has a body when every member is bound elsewhere —
+        // an empty object — but a synthetic unit has none, and an input whose members are all bound
+        // to the URI or headers leaves nothing for the body to carry.
+        var inputHasBody =
+            inputPayloadMember is null
+            && !inputIsUnit
+            && (inputBodyMembers.Count > 0 || inputMemberCount == 0);
 
         // Request bodies don't materialize top-level defaults (the client sends only what was set).
         IProjectionCodec<TInput, TInputBuilder>? inputBodyCodec =
@@ -222,6 +262,29 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
                     codecFactory,
                     rawStringPayloads
                 ),
+            RequestContentType =
+                inputPayloadMember is not null
+                    ? RestProtocol.PayloadContentType(
+                        inputPayloadMember.Target,
+                        inputPayloadMember.MemberTraits,
+                        codecFactory,
+                        rawStringPayloads
+                    )
+                : inputHasBody ? codecFactory.ContentType
+                : null,
+            RequestMediaTypeIsOpaque =
+                inputPayloadMember is not null
+                && RestProtocol.IsOpaquePayload(
+                    inputPayloadMember.Target,
+                    inputPayloadMember.MemberTraits
+                ),
+            ResponseMediaTypeIsOpaque =
+                outputPayloadMember is not null
+                && RestProtocol.IsOpaquePayload(
+                    outputPayloadMember.Target,
+                    outputPayloadMember.MemberTraits
+                ),
+            RequiresDeclaredContentType = requiresDeclaredContentType,
             OutputHasStreamingPayload =
                 outputPayloadMember is not null
                 && (
@@ -305,7 +368,8 @@ public static class RestOperationBinding
         IStructSchema<TInput, TInputBuilder> inputSchema,
         IStructSchema<TOutput, TOutputBuilder> outputSchema,
         IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads
+        bool rawStringPayloads,
+        bool requiresDeclaredContentType = true
     )
         where TInputBuilder : notnull
         where TOutputBuilder : notnull =>
@@ -314,13 +378,15 @@ public static class RestOperationBinding
             inputSchema,
             outputSchema,
             codecFactory,
-            rawStringPayloads
+            rawStringPayloads,
+            requiresDeclaredContentType
         );
 
     public static dynamic From<TInput, TOutput>(
         OperationSchema<TInput, TOutput> operation,
         IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads
+        bool rawStringPayloads,
+        bool requiresDeclaredContentType = true
     )
     {
         ArgumentNullException.ThrowIfNull(operation);
@@ -340,7 +406,8 @@ public static class RestOperationBinding
             (dynamic)inputSchema,
             (dynamic)outputSchema,
             codecFactory,
-            rawStringPayloads
+            rawStringPayloads,
+            requiresDeclaredContentType
         );
     }
 }

--- a/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
@@ -6,43 +6,50 @@ namespace NSmithy.Protocols.Rest;
 
 /// <summary>
 /// REST <see cref="IServiceProtocol"/> shared by restJson1 / simpleRestJson / restXml. A protocol is
-/// described by three things: its body wire format (<see cref="IRestBodyCodecFactory"/>, JSON vs
-/// XML), whether string/enum payloads are raw <c>text/plain</c> (<paramref name="rawStringPayloads"/>
-/// — true for restJson1/restXml, false for simpleRestJson), and the modeled-error discriminator
-/// header (<paramref name="errorTypeHeader"/>; <c>null</c> for protocols that don't serialize errors
-/// via a header, such as restXml). Unlike rpcv2Cbor, REST's per-operation path is authored
-/// <c>@http</c> data on the operation schema, so the service schema is not consulted here.
+/// described by three things: its body wire format (<paramref name="codecFactoryFor"/> hands out the
+/// <see cref="IRestBodyCodecFactory"/> — JSON vs XML — for a read mode), whether string/enum payloads
+/// are raw <c>text/plain</c> (<paramref name="rawStringPayloads"/> — true for restJson1/restXml,
+/// false for simpleRestJson), and the modeled-error discriminator header
+/// (<paramref name="errorTypeHeader"/>; <c>null</c> for protocols that don't serialize errors via a
+/// header, such as restXml). Unlike rpcv2Cbor, REST's per-operation path is authored <c>@http</c>
+/// data on the operation schema, so the service schema is not consulted here.
 /// </summary>
 public sealed class RestServiceProtocol(
-    IRestBodyCodecFactory codecFactory,
+    Func<WireReadMode, IRestBodyCodecFactory> codecFactoryFor,
     Func<SmithyHttpClientResponse, string?> errorDiscriminator,
     bool rawStringPayloads,
-    string? errorTypeHeader
+    string? errorTypeHeader,
+    bool requiresDeclaredContentType = true
 ) : IServiceProtocol
 {
     public IClientOperationProtocol<TInput, TOutput> ForClientOperation<TInput, TOutput>(
         OperationSchema<TInput, TOutput> operation
-    ) => CreateOperation(operation, validateInput: false);
+    ) => CreateOperation(operation, server: false);
 
     public IServerOperationProtocol<TInput, TOutput> ForServerOperation<TInput, TOutput>(
         OperationSchema<TInput, TOutput> operation
-    ) => CreateOperation(operation, validateInput: true);
+    ) => CreateOperation(operation, server: true);
 
     private IOperationProtocol<TInput, TOutput> CreateOperation<TInput, TOutput>(
         OperationSchema<TInput, TOutput> operation,
-        bool validateInput
+        bool server
     )
     {
         ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(codecFactoryFor);
+
+        // Each side gets its own binding, so each side's codecs read by its own rules and only the
+        // server compiles a validator.
         return CreateOperation(
             operation,
             operation.Errors,
-            codecFactory,
+            codecFactoryFor(server ? WireReadMode.Strict : WireReadMode.Lenient),
             errorDiscriminator,
             rawStringPayloads,
             errorTypeHeader,
             SmithyRequestModifiers.Compile(operation),
-            validateInput ? SmithyValidator.FromSchema(operation.Input) : null
+            server ? SmithyValidator.FromSchema(operation.Input) : null,
+            requiresDeclaredContentType
         );
     }
 
@@ -54,7 +61,8 @@ public sealed class RestServiceProtocol(
         bool rawStringPayloads,
         string? errorTypeHeader,
         Action<SmithyHttpRequest>? requestTransform,
-        ISmithyValidator<TInput>? inputValidator
+        ISmithyValidator<TInput>? inputValidator,
+        bool requiresDeclaredContentType
     )
     {
         var inputSchema =
@@ -78,7 +86,8 @@ public sealed class RestServiceProtocol(
             rawStringPayloads,
             errorTypeHeader,
             requestTransform,
-            inputValidator
+            inputValidator,
+            requiresDeclaredContentType
         );
     }
 
@@ -97,7 +106,8 @@ public sealed class RestServiceProtocol(
         bool rawStringPayloads,
         string? errorTypeHeader,
         Action<SmithyHttpRequest>? requestTransform,
-        ISmithyValidator<TInput>? inputValidator
+        ISmithyValidator<TInput>? inputValidator,
+        bool requiresDeclaredContentType
     )
         where TInputBuilder : notnull
         where TOutputBuilder : notnull =>
@@ -107,7 +117,8 @@ public sealed class RestServiceProtocol(
                 inputSchema,
                 outputSchema,
                 codecFactory,
-                rawStringPayloads
+                rawStringPayloads,
+                requiresDeclaredContentType
             ),
             modeledErrors,
             codecFactory,
@@ -196,8 +207,27 @@ public sealed class RestOperationProtocol<TInput, TOutput, TInputBuilder, TOutpu
             )
         );
 
-    public bool TrySerializeError(Exception exception, out SmithyHttpServerResponse response) =>
-        serverErrors.TrySerialize(exception, out response);
+    public bool TrySerializeError(Exception exception, out SmithyHttpServerResponse response)
+    {
+        // A framework fault is not one of the operation's modeled errors — no model declares it —
+        // so it is answered here rather than through the compiled matcher.
+        if (exception is MalformedRequestException malformed && errorTypeHeader is not null)
+        {
+            var (errorType, statusCode) = MalformedRequestSchema.Wire(malformed.Kind);
+            response = RestProtocol.SerializeError(
+                MalformedRequestSchema.Schema,
+                malformed,
+                errorType,
+                statusCode,
+                codecFactory,
+                rawStringPayloads,
+                errorTypeHeader
+            );
+            return true;
+        }
+
+        return serverErrors.TrySerialize(exception, out response);
+    }
 
     private static (Type, Func<Exception, SmithyHttpServerResponse>) CompileServerError<TError>(
         OperationErrorSchema<TError> error,

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -114,6 +114,9 @@ public static class RestProtocol
         ArgumentNullException.ThrowIfNull(binding);
         ArgumentNullException.ThrowIfNull(request);
 
+        CheckContentType(binding, request);
+        CheckAccept(binding, request);
+
         var builder = binding.InputSchema.CreateTypedBuilder();
         var labels = ExtractLabels(binding.UriTemplate, request.RequestUri);
         var query = ParseQuery(request.RequestUri);
@@ -1486,9 +1489,37 @@ public static class RestProtocol
     )
     {
         schema = UnwrapNullable(schema);
+        try
+        {
+            return ParseHttpValueCore(schema, traits, value);
+        }
+        catch (Exception exception)
+            when (exception is FormatException or OverflowException or ArgumentException)
+        {
+            // A label, query parameter, or header the model types but the caller did not: on a
+            // server the caller's mistake, answered with a structured 400 rather than a fault.
+            throw MalformedRequestException.Serialization(
+                $"Value '{value}' is not a valid {schema.Kind.ToString().ToLowerInvariant()}."
+            );
+        }
+    }
+
+    private static object? ParseHttpValueCore(
+        Schema schema,
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        string value
+    )
+    {
         return schema.Kind switch
         {
-            ShapeKind.Boolean => bool.Parse(value),
+            // Only the two literals the model means. bool.Parse also accepts "True" and " TRUE ",
+            // which would let a caller coerce a string into a boolean the model never declared.
+            ShapeKind.Boolean => value switch
+            {
+                "true" => true,
+                "false" => false,
+                _ => throw new FormatException($"'{value}' is not a boolean."),
+            },
             ShapeKind.Byte => sbyte.Parse(value, CultureInfo.InvariantCulture),
             ShapeKind.Short => short.Parse(value, CultureInfo.InvariantCulture),
             ShapeKind.Integer => int.Parse(value, CultureInfo.InvariantCulture),
@@ -1696,11 +1727,9 @@ public static class RestProtocol
         {
             "epoch-seconds" => ParseEpochSeconds(value),
             "http-date" => DateTimeOffset.ParseExact(value, "r", CultureInfo.InvariantCulture),
-            "date-time" => DateTimeOffset.Parse(
-                value,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind
-            ),
+            // A label, query parameter, or header is only ever read from a request, so there is no
+            // looser peer to accommodate here the way there is in a response body.
+            "date-time" => Rfc3339.Parse(value, WireReadMode.Strict),
             var format => throw new NotSupportedException(
                 $"Timestamp format '{format}' is not supported."
             ),
@@ -1731,6 +1760,20 @@ public static class RestProtocol
             ? trait.Value.AsString()
             : null;
     }
+
+    /// <summary>
+    /// Whether an <c>@httpPayload</c> member carries bytes the protocol assigns no meaning to: a blob
+    /// the model does not give a <c>@mediaType</c>. <c>application/octet-stream</c> is what such a
+    /// payload is written as, not what it has to be read as, so a caller may label those bytes
+    /// however it likes and a caller's <c>Accept</c> constrains nothing.
+    /// </summary>
+    internal static bool IsOpaquePayload(
+        Schema target,
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    ) =>
+        GetMediaType(target, traits) is null
+        && target.Resolved is not IEventStreamSchema
+        && UnwrapNullable(target).Kind == ShapeKind.Blob;
 
     private static DateTimeOffset ParseEpochSeconds(string value)
     {
@@ -1953,6 +1996,140 @@ public static class RestProtocol
             entry => (IReadOnlyList<string>)entry.Value,
             StringComparer.Ordinal
         );
+    }
+
+    /// <summary>
+    /// Rejects a request body the operation cannot read. The model fixes exactly one media type per
+    /// operation — the body codec's for a structured body, the <c>@mediaType</c> or implied type for
+    /// an <c>@httpPayload</c> — so anything else is a 415 rather than something to guess at, and so
+    /// is a body sent to an operation that reads none.
+    /// </summary>
+    private static void CheckContentType<TInput, TOutput, TInputBuilder, TOutputBuilder>(
+        RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
+        SmithyHttpRequest request
+    )
+        where TInputBuilder : notnull
+        where TOutputBuilder : notnull
+    {
+        var declared = TryGetFirstHeader(request.Headers, "Content-Type", out var header)
+            ? header
+            : request.ContentType;
+
+        if (binding.RequestContentType is not { } expected)
+        {
+            // No media type is the right one for an operation that reads no body, so a caller that
+            // announces one is describing a body the server has nowhere to put. Both halves matter:
+            // a Content-Type with no body is a stray header, and a body with no Content-Type
+            // announces nothing — neither is a media type the server would have to reject.
+            if (declared is not null && HasRequestContent(request))
+            {
+                throw MalformedRequestException.UnsupportedMediaType(
+                    $"Operation reads no request body, but one arrived as '{declared}'."
+                );
+            }
+
+            return;
+        }
+
+        if (binding.RequestMediaTypeIsOpaque)
+        {
+            return;
+        }
+
+        // An absent Content-Type is only an omission once there is something to describe: a request
+        // that sends no body at all leaves an optional payload unset, which the model allows.
+        if (declared is null)
+        {
+            if (binding.RequiresDeclaredContentType && HasRequestContent(request))
+            {
+                throw MalformedRequestException.UnsupportedMediaType(
+                    $"Request body requires Content-Type '{expected}' but none was set."
+                );
+            }
+
+            return;
+        }
+
+        if (!MediaTypeEquals(MediaTypeOf(declared), expected))
+        {
+            throw MalformedRequestException.UnsupportedMediaType(
+                $"Expected Content-Type '{expected}' but found '{declared}'."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Rejects a request whose <c>Accept</c> excludes the only media type the operation's response
+    /// can use. An operation with no modeled output has no response media type to negotiate over.
+    /// </summary>
+    private static void CheckAccept<TInput, TOutput, TInputBuilder, TOutputBuilder>(
+        RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
+        SmithyHttpRequest request
+    )
+        where TInputBuilder : notnull
+        where TOutputBuilder : notnull
+    {
+        if (
+            binding.OutputIsUnit
+            || binding.ResponseMediaTypeIsOpaque
+            || !TryGetFirstHeader(request.Headers, "Accept", out var accept)
+            || accept.Length == 0
+        )
+        {
+            return;
+        }
+
+        foreach (var range in accept.Split(','))
+        {
+            if (MediaRangeAccepts(MediaTypeOf(range), binding.AcceptType))
+            {
+                return;
+            }
+        }
+
+        throw MalformedRequestException.NotAcceptable(
+            $"Response is '{binding.AcceptType}', which Accept '{accept}' excludes."
+        );
+    }
+
+    private static bool HasRequestContent(SmithyHttpRequest request) =>
+        request.Body switch
+        {
+            SmithyHttpBody.Bytes bytes => bytes.Content.Length > 0,
+            // A streaming body is not read here, so its length is all there is to go on. An unknown
+            // length (a chunked request) counts as content: the caller is sending something.
+            SmithyHttpBody.Streaming streaming => streaming.ContentLength is null or > 0,
+            SmithyHttpBody.EventStreaming => true,
+            _ => false,
+        };
+
+    /// <summary>The media type without its parameters — <c>application/json; charset=utf-8</c> is JSON.</summary>
+    private static ReadOnlySpan<char> MediaTypeOf(string headerValue)
+    {
+        var span = headerValue.AsSpan();
+        var separator = span.IndexOf(';');
+        return (separator < 0 ? span : span[..separator]).Trim();
+    }
+
+    private static bool MediaTypeEquals(ReadOnlySpan<char> declared, string expected) =>
+        declared.Equals(expected, StringComparison.OrdinalIgnoreCase);
+
+    private static bool MediaRangeAccepts(ReadOnlySpan<char> range, string mediaType)
+    {
+        if (range.Equals("*/*", StringComparison.Ordinal) || range.IsEmpty)
+        {
+            return true;
+        }
+
+        if (range.EndsWith("/*", StringComparison.Ordinal))
+        {
+            var type = range[..^2];
+            var slash = mediaType.IndexOf('/', StringComparison.Ordinal);
+            return slash > 0
+                && type.Equals(mediaType.AsSpan(0, slash), StringComparison.OrdinalIgnoreCase);
+        }
+
+        return MediaTypeEquals(range, mediaType);
     }
 
     private static bool TryGetFirstHeader(

--- a/packages/NSmithy.Protocols.RestJson/JsonRestBodyCodecFactory.cs
+++ b/packages/NSmithy.Protocols.RestJson/JsonRestBodyCodecFactory.cs
@@ -10,18 +10,24 @@ namespace NSmithy.Protocols.RestJson;
 /// error discriminator, which live on the protocol (not the format), so a single instance serves
 /// both.
 /// </summary>
-internal sealed class JsonRestBodyCodecFactory : IRestBodyCodecFactory
+internal sealed class JsonRestBodyCodecFactory(WireReadMode readMode) : IRestBodyCodecFactory
 {
-    public static JsonRestBodyCodecFactory Instance { get; } = new();
+    private static readonly JsonRestBodyCodecFactory Lenient = new(WireReadMode.Lenient);
+    private static readonly JsonRestBodyCodecFactory Strict = new(WireReadMode.Strict);
+
+    /// <summary>The instance whose codecs read by the given rules; see <see cref="WireReadMode"/>.</summary>
+    public static IRestBodyCodecFactory For(WireReadMode readMode) =>
+        readMode == WireReadMode.Strict ? Strict : Lenient;
 
     public string ContentType => "application/json";
 
     public string BlobContentType => "application/octet-stream";
 
-    public ICodec<T> CodecFor<T>(Schema<T> schema) => JsonCodec.FromSchema(schema);
+    public ICodec<T> CodecFor<T>(Schema<T> schema) =>
+        JsonCodec.FromSchema(schema, readMode: readMode);
 
     public IProjectionCodec<T, TBuilder> CodecFor<T, TBuilder>(
         StructProjection<T, TBuilder> projection,
         bool materializeTopLevelDefaults
-    ) => JsonCodec.FromProjection(projection, materializeTopLevelDefaults);
+    ) => JsonCodec.FromProjection(projection, materializeTopLevelDefaults, readMode);
 }

--- a/packages/NSmithy.Protocols.RestJson/RestJson1Protocol.cs
+++ b/packages/NSmithy.Protocols.RestJson/RestJson1Protocol.cs
@@ -15,7 +15,7 @@ public sealed class RestJson1Protocol : IProtocol
     /// </summary>
     public IServiceProtocol ForService(ServiceSchema service) =>
         new RestServiceProtocol(
-            JsonRestBodyCodecFactory.Instance,
+            JsonRestBodyCodecFactory.For,
             DeserializeErrorType,
             rawStringPayloads: true,
             errorTypeHeader: "X-Amzn-Errortype"

--- a/packages/NSmithy.Protocols.RestJson/SimpleRestJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.RestJson/SimpleRestJsonProtocol.cs
@@ -17,10 +17,13 @@ public sealed class SimpleRestJsonProtocol : IProtocol
 
     public IServiceProtocol ForService(ServiceSchema service) =>
         new RestServiceProtocol(
-            JsonRestBodyCodecFactory.Instance,
+            JsonRestBodyCodecFactory.For,
             DeserializeErrorType,
             rawStringPayloads: false,
-            errorTypeHeader: ErrorTypeHeader
+            errorTypeHeader: ErrorTypeHeader,
+            // alloy's own protocol tests send JSON bodies with no Content-Type, so simpleRestJson
+            // reads a body whose media type the caller did not declare.
+            requiresDeclaredContentType: false
         );
 
     public static string? DeserializeErrorType(SmithyHttpClientResponse response)

--- a/packages/NSmithy.Protocols.RestXml/RestXmlProtocol.cs
+++ b/packages/NSmithy.Protocols.RestXml/RestXmlProtocol.cs
@@ -20,7 +20,7 @@ public sealed class RestXmlProtocol : IProtocol
     /// </summary>
     public IServiceProtocol ForService(ServiceSchema service) =>
         new RestServiceProtocol(
-            BodyCodecFactory,
+            _ => BodyCodecFactory,
             DeserializeErrorType,
             rawStringPayloads: true,
             errorTypeHeader: null

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -17,20 +17,6 @@ public sealed class RpcV2CborProtocol : IProtocol
     private const string InitialRequestEventType = "initial-request";
     private const string InitialResponseEventType = "initial-response";
 
-    // Smithy 2.0 wraps `input: Unit` / `output: Unit` in synthetic structures that carry
-    // this trait pointing back to the original `smithy.api#Unit` shape id.
-    private static readonly ShapeId SyntheticOriginalShapeId = new(
-        "smithy.synthetic",
-        "originalShapeId"
-    );
-    private static readonly string UnitShapeIdString = "smithy.api#Unit";
-
-    /// <summary>Returns true for synthetic unit-derived schemas that carry no members.</summary>
-    private static bool IsUnitSchema(Schema schema) =>
-        schema.HasTrait(SyntheticOriginalShapeId)
-        && schema.GetTrait(SyntheticOriginalShapeId)?.Value.Kind == DocumentKind.String
-        && schema.GetTrait(SyntheticOriginalShapeId)?.Value.AsString() == UnitShapeIdString;
-
     /// <summary>
     /// Binds the protocol to a service, yielding per-operation protocols. The service schema
     /// supplies the service shape name used to derive each operation's request path.
@@ -926,7 +912,7 @@ public sealed class RpcV2CborProtocol : IProtocol
         );
 
     private static bool IsUnit<T>(Schema schema) =>
-        typeof(T) == typeof(SmithyUnit) || IsUnitSchema(schema);
+        typeof(T) == typeof(SmithyUnit) || Schemas.IsSyntheticUnit(schema);
 
     private static Schema? FindEventStreamEventSchema(Schema schema) =>
         schema.Resolved is IStructSchema structure

--- a/packages/NSmithy.Server/SmithyServerRuntime.cs
+++ b/packages/NSmithy.Server/SmithyServerRuntime.cs
@@ -43,10 +43,16 @@ public sealed class SmithyServerRuntime
             // A required member absent from the payload fails in the codec, before the compiled
             // validator ever sees the input. It is still a constraint violation, so it gets the
             // same modeled response rather than surfacing as a server fault.
-            return SerializeValidationFailure(
+            return SerializeRequestFailure(
                 protocol,
                 ValidationException.FromMissingRequiredMember(exception)
             );
+        }
+        catch (MalformedRequestException exception)
+        {
+            // Bytes that never became modeled input at all: an unreadable body, a media type the
+            // operation does not accept. Also the caller's mistake, so also a structured 4xx.
+            return SerializeRequestFailure(protocol, exception);
         }
 
         if (protocol.InputValidator is { } validator)
@@ -54,7 +60,7 @@ public sealed class SmithyServerRuntime
             var validationErrors = validator.GetErrors(input);
             if (validationErrors.Count > 0)
             {
-                return SerializeValidationFailure(
+                return SerializeRequestFailure(
                     protocol,
                     ValidationException.FromErrors(validationErrors)
                 );
@@ -78,12 +84,12 @@ public sealed class SmithyServerRuntime
     }
 
     /// <summary>
-    /// Serialized like any modeled error, since every operation implicitly carries
-    /// smithy.framework#ValidationException. A protocol that cannot serialize server errors
-    /// rethrows, surfaced as a 500 by the host.
+    /// Serialized through the same path as a modeled error: every operation implicitly carries
+    /// smithy.framework#ValidationException, and a protocol answers a framework fault itself. A
+    /// protocol that cannot serialize server errors rethrows, surfaced as a 500 by the host.
     /// </summary>
-    private static SmithyHttpServerResponse SerializeValidationFailure<TInput, TOutput>(
+    private static SmithyHttpServerResponse SerializeRequestFailure<TInput, TOutput>(
         IServerOperationProtocol<TInput, TOutput> protocol,
-        ValidationException exception
+        Exception exception
     ) => protocol.TrySerializeError(exception, out var response) ? response : throw exception;
 }

--- a/tests/Conformance/RestJson1/Conformance/RestJson1Allowlist.cs
+++ b/tests/Conformance/RestJson1/Conformance/RestJson1Allowlist.cs
@@ -10,15 +10,11 @@ internal static class RestJson1Allowlist
     public const string Protocol = "aws.protocols#restJson1";
 
     /// <summary>
-    /// Malformed-request cases the generated server is expected to satisfy: the ones asserting
-    /// <c>smithy.framework#ValidationException</c>, i.e. constraint enforcement. The rest of the
-    /// suite asserts that unparseable input (a bad timestamp, a non-numeric integer, an
-    /// unsupported content type) is rejected with a structured 400 rather than a 500 — a separate
-    /// feature from constraint validation, which the server does not implement yet.
+    /// Malformed-request cases the generated server is expected to satisfy — every case whose
+    /// operation the generated service exposes. Nothing is filtered out: constraint violations,
+    /// unreadable input, and content negotiation are all answered.
     /// </summary>
-    internal static bool RunsMalformedCase(HttpMalformedRequestTestCase testCase) =>
-        testCase.ExpectedHeaders.TryGetValue("x-amzn-errortype", out var type)
-        && type == "ValidationException";
+    internal static bool RunsMalformedCase(HttpMalformedRequestTestCase testCase) => true;
 
     public static readonly IReadOnlySet<string> ExecutableRequestCases = new HashSet<string>(
         StringComparer.Ordinal

--- a/tests/Conformance/RestJson1/Conformance/ServerConformanceSupport.cs
+++ b/tests/Conformance/RestJson1/Conformance/ServerConformanceSupport.cs
@@ -318,7 +318,16 @@ internal static class ServerConformanceRequestFactory
             request.Headers.TryAddWithoutValidation(name, value);
         }
 
-        if (testCase.BodyMediaType is not null && content is not null)
+        // `bodyMediaType` only says how to compare the body. It stands in for a Content-Type when the
+        // case declares none, but must not be added alongside one the case does declare — two
+        // Content-Type values on one request is itself a malformed request.
+        if (
+            testCase.BodyMediaType is not null
+            && content is not null
+            && !testCase.Headers.Keys.Any(name =>
+                string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase)
+            )
+        )
         {
             content.Headers.TryAddWithoutValidation("Content-Type", testCase.BodyMediaType);
         }

--- a/tests/Conformance/RestJson1/Conformance/ServerHttpRequestRunner.cs
+++ b/tests/Conformance/RestJson1/Conformance/ServerHttpRequestRunner.cs
@@ -27,16 +27,19 @@ internal static class ServerHttpRequestRunner
             host.Client.BaseAddress!
         );
         using var response = await host.Client.SendAsync(request).ConfigureAwait(false);
-        var responseBody =
-            (int)response.StatusCode >= 500
-                ? await response.Content.ReadAsStringAsync().ConfigureAwait(false)
-                : "";
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         Assert.True(
             (int)response.StatusCode < 500,
             $"Server returned {(int)response.StatusCode} for {testCase.Id}.\n{responseBody}"
         );
 
-        Assert.NotNull(capturedMethod);
+        // A request the server rejected before dispatch never reaches the handler, so report what it
+        // was rejected with rather than a bare null.
+        Assert.True(
+            capturedMethod is not null,
+            $"Handler was not reached for {testCase.Id}; server answered "
+                + $"{(int)response.StatusCode}.\n{responseBody}"
+        );
         Assert.Equal(testCase.OperationName + "Async", capturedMethod!.Name);
         if (testCase.Params is not null)
         {

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -80,12 +80,6 @@
               "aws.protocoltests.restjson.validation#RestJsonValidation"
             ]
           }
-        },
-        {
-          "name": "excludeShapesBySelector",
-          "args": {
-            "selector": "[id|namespace='aws.protocoltests.restjson.validation'][id|name^='MalformedEnum']"
-          }
         }
       ],
       "plugins": {

--- a/tests/Conformance/SimpleRestJson/Conformance/ServerConformanceSupport.cs
+++ b/tests/Conformance/SimpleRestJson/Conformance/ServerConformanceSupport.cs
@@ -352,7 +352,16 @@ internal static class ServerConformanceRequestFactory
             request.Headers.TryAddWithoutValidation(name, value);
         }
 
-        if (testCase.BodyMediaType is not null && content is not null)
+        // `bodyMediaType` only says how to compare the body. It stands in for a Content-Type when the
+        // case declares none, but must not be added alongside one the case does declare — two
+        // Content-Type values on one request is itself a malformed request.
+        if (
+            testCase.BodyMediaType is not null
+            && content is not null
+            && !testCase.Headers.Keys.Any(name =>
+                string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase)
+            )
+        )
         {
             content.Headers.TryAddWithoutValidation("Content-Type", testCase.BodyMediaType);
         }

--- a/tests/Conformance/SimpleRestJson/Conformance/ServerHttpRequestRunner.cs
+++ b/tests/Conformance/SimpleRestJson/Conformance/ServerHttpRequestRunner.cs
@@ -27,16 +27,19 @@ internal static class ServerHttpRequestRunner
             host.Client.BaseAddress!
         );
         using var response = await host.Client.SendAsync(request).ConfigureAwait(false);
-        var responseBody =
-            (int)response.StatusCode >= 500
-                ? await response.Content.ReadAsStringAsync().ConfigureAwait(false)
-                : "";
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         Assert.True(
             (int)response.StatusCode < 500,
             $"Server returned {(int)response.StatusCode} for {testCase.Id}.\n{responseBody}"
         );
 
-        Assert.NotNull(capturedMethod);
+        // A request the server rejected before dispatch never reaches the handler, so report what it
+        // was rejected with rather than a bare null.
+        Assert.True(
+            capturedMethod is not null,
+            $"Handler was not reached for {testCase.Id}; server answered "
+                + $"{(int)response.StatusCode}.\n{responseBody}"
+        );
         Assert.Equal(testCase.OperationName + "Async", capturedMethod!.Name);
         if (testCase.Params is not null)
         {

--- a/tests/NSmithy.Tests/Codecs/Proto/ProtoCodecTests.cs
+++ b/tests/NSmithy.Tests/Codecs/Proto/ProtoCodecTests.cs
@@ -1,6 +1,7 @@
 using NSmithy.Codecs.Proto;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
+using NSmithy.Core.Validation;
 
 namespace NSmithy.Tests.Codecs.Proto;
 
@@ -653,5 +654,47 @@ public sealed class ProtoCodecTests
         Assert.Equal(36m, result["age"].AsNumber());
         Assert.True(result["admin"].AsBoolean());
         Assert.Equal("y", result["tags"].AsArray()[1].AsString());
+    }
+
+    /// <summary>
+    /// A framework shape carries no <c>@protoIndex</c> — it comes from the runtime, not a model file
+    /// — so the codec numbers its members by declaration order instead. The server runtime can
+    /// return one from any operation, so a gRPC service has to be able to put it on the wire.
+    /// </summary>
+    [Fact]
+    public void NumbersFrameworkShapeMembersByDeclarationOrder()
+    {
+        var codec = ProtoCodec.FromSchema(ValidationExceptionSchema.Schema);
+
+        var bytes = codec.Serialize(
+            new ValidationException("nope", [new ValidationExceptionField("/a", "bad")])
+        );
+
+        // 0A 04 'n' 'o' 'p' 'e'                  (message = field 1, LEN)
+        // 12 09 0A 02 '/' 'a' 12 03 'b' 'a' 'd'  (fieldList = field 2, holding path=1, message=2)
+        Assert.Equal(
+            "0A046E6F706512090A022F611203626164",
+            Convert.ToHexString(bytes),
+            StringComparer.Ordinal
+        );
+
+        var round = codec.Deserialize(bytes);
+        Assert.Equal("nope", round.Message);
+        Assert.Equal("/a", Assert.Single(round.FieldList).Path);
+    }
+
+    /// <summary>A modeled shape still has to say so: order is not a number a model may omit.</summary>
+    [Fact]
+    public void RejectsAModeledMemberWithNoProtoIndex()
+    {
+        var schema = Schemas
+            .Structure<Simple, SimpleBuilder>(ShapeId.Parse("test#Unnumbered"))
+            .Required("name", x => x.Name, (b, v) => b.Name = v, Schemas.String)
+            .Required("value", x => x.Value, (b, v) => b.Value = v, Schemas.Integer, Field(2))
+            .Build(() => new SimpleBuilder(), b => new Simple(b.Name!, b.Value));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => ProtoCodec.FromSchema(schema));
+
+        Assert.Contains("test#Unnumbered$name", ex.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/NSmithy.Tests/Core/SchemaTests.cs
+++ b/tests/NSmithy.Tests/Core/SchemaTests.cs
@@ -424,10 +424,13 @@ public sealed class SchemaTests
             .Build();
         var codec = JsonCodec.FromSchema(choiceSchema);
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        // A payload that does not match the schema is the caller's mistake, not a fault: on a server
+        // the runtime turns this into a structured 400.
+        var ex = Assert.Throws<MalformedRequestException>(() =>
             codec.DeserializeText("{\"missing\":\"hello\"}")
         );
 
+        Assert.Equal(MalformedRequestKind.Serialization, ex.Kind);
         Assert.Equal("Unknown union member 'missing'.", ex.Message);
     }
 

--- a/tests/NSmithy.Tests/Core/SmithyValidatorTests.cs
+++ b/tests/NSmithy.Tests/Core/SmithyValidatorTests.cs
@@ -483,6 +483,41 @@ public sealed class SmithyValidatorTests
     }
 
     [Fact]
+    public void ValidateRejectsMapKeyOutsideItsEnum()
+    {
+        // A map key is a string whatever it targets, so the value set can only come from the shape
+        // the key member targets — there is nowhere on a string for it to live.
+        var validator = SmithyValidator.FromSchema(
+            Schemas.Map(
+                new ShapeId("example", "Palette"),
+                Schemas.String,
+                key: Schemas.StringEnum<Colour>(
+                    new ShapeId("example", "Colour"),
+                    values: ["RED", "GREEN", "PUCE"],
+                    internalValues: ["PUCE"]
+                )
+            )
+        )!;
+
+        Assert.Empty(
+            validator.GetErrors(new Dictionary<string, string> { ["RED"] = "a", ["PUCE"] = "b" })
+        );
+
+        var error = Assert.Single(
+            validator.GetErrors(new Dictionary<string, string> { ["MAUVE"] = "a" })
+        );
+        // Reported at the map, not the entry: the key is not a value sitting at the entry's pointer.
+        Assert.Equal("", error.Path);
+        Assert.Equal(new ShapeId("smithy.api", "enum"), error.ConstraintId);
+        // PUCE is accepted above but withheld here — an @internal value is not advertised.
+        Assert.EndsWith(
+            "Member must satisfy enum value set: [RED, GREEN]",
+            error.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
     public void FromSchemaSkipsEnumsWithoutDeclaredValues()
     {
         // A schema built without them cannot tell a modeled value from an invented one, so it must

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -52,24 +52,7 @@ The remaining work closes the gaps:
 - Continuing to harden named client interceptors and the typed per-call
   execution context.
 
-### 3. Reject unparseable input with a structured 400
-
-Constraint traits are enforced and answered with
-`smithy.framework#ValidationException`, covered by Smithy's malformed-request
-conformance suite. Input the codec cannot parse at all is still surfaced as a
-500: a non-numeric integer, an unparseable timestamp, a body that is not JSON, or
-an unsupported content type. Smithy specifies a structured 400 for each.
-
-This work includes:
-
-- Turning deserialization failures into modeled error responses rather than
-  letting them reach the host as unhandled exceptions.
-- Running the remainder of the malformed-request conformance suite, which covers
-  exactly these cases.
-- Validating the legacy `@enum` trait on string shapes, which needs the value set
-  to reach the schema the way enum shapes' values already do.
-
-### 4. Harden streaming operations
+### 3. Harden streaming operations
 
 NSmithy has two experimental event-streaming surfaces: native gRPC (client,
 server, and bidirectional streaming) and `rpcv2Cbor` event streams over
@@ -85,7 +68,7 @@ This work includes:
 - Extending streaming support beyond event streams, especially streaming blob
   payloads.
 
-### 5. Expand to async protocols
+### 4. Expand to async protocols
 
 NSmithy's current protocol work is mostly request/response oriented. A separate
 near-term goal is to validate that the runtime and generator model can also
@@ -100,7 +83,7 @@ This work includes:
 - Using these protocols to pressure-test the existing transport, codec, and
   client/server seams beyond HTTP-centric assumptions.
 
-### 6. Support Smithy AI traits and MCP generation
+### 5. Support Smithy AI traits and MCP generation
 
 Support Smithy's AI-oriented traits so that .NET and protocol artifacts can be
 generated for tool-driven and agent-driven workflows, rather than treating the
@@ -114,7 +97,7 @@ This work includes:
 - Defining the runtime and generation boundaries needed so AI-trait-aware
   models remain inspectable, testable, and versionable.
 
-### 7. Honor protocol HTTP-version traits
+### 6. Honor protocol HTTP-version traits
 
 Protocol traits can declare the HTTP versions a service supports via their `http`
 and `eventStreamHttp` members — a list of ALPN protocol IDs in preference order

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -38,6 +38,9 @@ Notes:
   server, cases whose operation has no generated handler (auxiliary services like
   Glacier that ship fixtures but aren't part of the `RestJson` service) are out
   of scope rather than counted as failures.
+- restJson1's server additionally runs all 655 of Smithy's
+  `httpMalformedRequestTests` cases, which assert what a server owes for a request
+  it cannot accept. See [Validation](/smithy-dotnet/servers/validation/).
 - AWS JSON support is client-only. The current conformance project targets
   `aws.protocols#awsJson1_1`; the runtime also exposes `AwsJson10Protocol` for
   `aws.protocols#awsJson1_0`, but there is not yet a separate `awsJson1_0`

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -79,27 +79,16 @@ The `http` / `eventStreamHttp` members on protocol traits (for example
 `HttpClient`'s default HTTP version (HTTP/1.1 unless configured), and HTTP/2 is
 forced only for native gRPC. See the [Roadmap](/smithy-dotnet/contributing/roadmap/).
 
-## Malformed Input Is Rejected As A 500, Not A 400
+## Request Rejection Has Two Remaining Gaps
 
-Constraint violations are enforced and answered with
-`smithy.framework#ValidationException` (see [Servers](/smithy-dotnet/servers/)),
-covered by Smithy's malformed-request conformance suite.
+A malformed request is answered with a structured 4xx (see
+[Validation](/smithy-dotnet/servers/validation/)), and the whole of Smithy's
+restJson1 malformed-request conformance suite runs against the generated server.
+Two things the model states are still not enforced:
 
-Input the codec cannot parse at all is a different matter: a non-numeric integer,
-an unparseable timestamp, a body that is not JSON, or an unsupported content type
-currently surfaces as a 500 rather than the structured 400 Smithy specifies. The
-remainder of the malformed-request suite covers exactly those cases and is not
-run yet.
-
-Constraint enforcement itself has three gaps:
-
-- The legacy `@enum` trait on a string is not validated — only enum *shapes* are.
-  A string shape carrying `@enum` is generated as a plain `string`, so the schema
-  carries no value set.
-- `@length` on a `@streaming` blob is not enforced. The stream reaches the handler
-  unread, so its length is not knowable without buffering the whole request.
-- Traits outside the constraint set — `@idRef` reference resolution, for example —
-  are not enforced.
+- `@length` on a `@streaming` blob. The stream reaches the handler unread, so its
+  length is not knowable without buffering the whole request.
+- Traits outside the constraint set — `@idRef` reference resolution, for example.
 
 ## Extra Smithy Maven Dependencies Are External
 

--- a/website/src/content/docs/servers/validation.md
+++ b/website/src/content/docs/servers/validation.md
@@ -1,13 +1,26 @@
 ---
 title: Validation
-description: The server enforces the model's constraint traits before the handler runs and answers a violation with smithy.framework#ValidationException.
+description: The server rejects a request the model does not allow before the handler runs, with the status and body Smithy specifies.
 ---
 
-The server checks a deserialized request against the model's constraint traits
-before calling the handler. A handler only sees input the model permits, so it
-does not need to re-check what the model already states.
+A handler only sees input the model permits. Everything that could make a request
+something else is answered before the handler runs, and each kind of problem has
+its own answer:
 
-## What is checked
+| What is wrong | Status | Error type |
+| --- | --- | --- |
+| A value breaks a constraint trait | 400 | `ValidationException` |
+| The bytes are not the shape the model declares | 400 | `SerializationException` |
+| The `Content-Type` is not the one the operation reads | 415 | `UnsupportedMediaTypeException` |
+| The `Accept` excludes the response's media type | 406 | `NotAcceptableException` |
+
+The rest of this page covers each in turn. The generated server is run against
+Smithy's `httpMalformedRequestTests` suite for restJson1, which asserts every one
+of these; see [Protocol Status](/smithy-dotnet/protocols/status/).
+
+## Constraint traits
+
+### What is checked
 
 | Trait | Applies to |
 | --- | --- |
@@ -19,13 +32,17 @@ does not need to re-check what the model already states.
 
 Enum membership is checked as well. Generated enum types stay open on the wire so
 a client is not broken by a server that adds a member; the server is where that
-openness stops, and a value outside the modeled set is rejected.
+openness stops, and a value outside the modeled set is rejected. This covers both
+an enum shape and a string carrying the deprecated `@enum` trait — the latter
+generates a plain `string`, and its value set is read from the trait. A value the
+model marks `@internal` is accepted but left out of the message, so rejecting a
+request does not advertise it.
 
 Constraints are enforced wherever they sit — on a member, on the shape a member
 targets, on a list's elements, or on a map's keys or values — and validation
 recurses through structures, lists, maps, and unions.
 
-## The response
+### The response
 
 A violation produces `smithy.framework#ValidationException` with HTTP 400.
 Every operation carries this error implicitly, so a generated client
@@ -57,7 +74,7 @@ Validation reports every violation it finds rather than stopping at the first,
 and a member that breaks two constraints produces two entries: `@length` and
 `@pattern` on the same string are separate checks with separate messages.
 
-## Paths
+### Paths
 
 `path` is a [JSONPointer](https://www.rfc-editor.org/rfc/rfc6901) into the input.
 The root is the empty string, and `~` and `/` inside a name are escaped as `~0`
@@ -75,7 +92,7 @@ and `~1`.
 A map key is reported at the map because the key is not a value sitting at the
 entry's pointer; the entry's value is.
 
-## Missing members
+### Missing members
 
 A `@required` member that arrives as null fails validation like any other
 constraint. A member missing from the payload entirely never reaches the
@@ -87,7 +104,7 @@ same wording:
 Value at '/name' failed to satisfy constraint: Member must not be null
 ```
 
-## Event streams
+### Event streams
 
 For a streaming operation the initial request is validated exactly as a unary
 input is: an event stream changes how the body is framed, not what the input
@@ -95,7 +112,7 @@ structure has to satisfy. The events themselves are not validated — rejecting
 one mid-stream would mean reporting a violation after the response has already
 begun.
 
-## Cost
+### Cost
 
 A validator is compiled once per operation from the schema, when the service
 starts, and reused for every request. An operation whose input carries no
@@ -104,6 +121,47 @@ entirely.
 
 Only servers build one. Clients take their half of the protocol from a separate
 factory, so a client never compiles a validator it would not run.
+
+## Unreadable input
+
+A constraint violation is a value the model does not allow. A request can also
+fail earlier than that, on bytes that never become a value at all: a body that is
+not JSON, a non-numeric integer, a number outside its type's range, a timestamp in
+a format the member does not use, a blob that is not base64, a dense list holding
+`null`, a union with two members set. None of these reach the validator, because
+there is nothing to validate.
+
+They are still the caller's mistake rather than a server fault, so they are
+answered with a 400 carrying `SerializationException`:
+
+```json
+{ "message": "Expected an integer but found \"10\"." }
+```
+
+A server reads by exactly what the model declares. A client is more forgiving of
+the same wire — a real service may be looser than the spec, and a response it can
+understand is worth reading — so the two sides compile their codecs separately.
+The one rule that currently differs is the UTC offset on a `date-time` timestamp,
+which Smithy's own protocol tests require a server to reject and a client to
+accept.
+
+## Content negotiation
+
+The model fixes one media type per operation: the body codec's for a structured
+body, the `@mediaType` or the implied type for an `@httpPayload` member. A request
+body that arrives as anything else is answered with 415
+`UnsupportedMediaTypeException`, and so is a body sent to an operation that reads
+none.
+
+Two cases are deliberately unconstrained. A blob payload with no `@mediaType`
+carries bytes the protocol assigns no meaning to, so any `Content-Type` is
+accepted. And alloy's `simpleRestJson` does not require a body to declare its
+media type at all, because its own protocol tests send JSON bodies without one;
+AWS's REST protocols do.
+
+An `Accept` header that excludes the response's media type is answered with 406
+`NotAcceptableException`. `*/*` and `type/*` match, an absent header constrains
+nothing, and an operation with no modeled output has no media type to negotiate.
 
 ## Clients do not validate
 
@@ -115,10 +173,6 @@ generated client sends what it is given and surfaces the server's
 
 ## Not covered
 
-- Input the codec cannot parse at all — a non-numeric integer, an unparseable
-  timestamp, a body that is not JSON — surfaces as a 500 rather than the
-  structured 400 Smithy specifies.
-- The legacy `@enum` trait on a string is not validated; only enum *shapes* are.
 - `@length` on a `@streaming` blob is not enforced, since the stream reaches the
   handler unread.
 - Traits outside the constraint set, such as `@idRef` reference resolution.


### PR DESCRIPTION
Input that never becomes modeled input is answered with a 400 `SerializationException` instead of reaching the host as a 500, a request body whose `Content-Type` the operation does not read with 415, and an `Accept` that excludes the response's media type with 406. The legacy `@enum` trait on a string is validated like an enum shape. The generated restJson1 server now passes all 655 of Smithy's `httpMalformedRequestTests` cases, up from 113. Closes #117.