### PR TITLE
Speed up the JSON codec and apply modelled defaults on explicit null

### DIFF
--- a/packages/NSmithy.Codecs.Json/CompiledJsonCodec.cs
+++ b/packages/NSmithy.Codecs.Json/CompiledJsonCodec.cs
@@ -15,15 +15,26 @@ internal sealed class CompiledJsonCodec<T>(
     );
     private readonly IJsonValueReader<T> valueReader = JsonReaderCompiler.Compile(schema, readMode);
 
+    // Size hint carried between calls: a codec instance serializes the same shape
+    // repeatedly, so the previous payload size is a good guess at the next one and
+    // usually avoids growing the scratch buffer at all.
+    private int sizeHint = 256;
+
     public byte[] Serialize(T value)
     {
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
+        using var buffer = new PooledByteBufferWriter(sizeHint);
+        var writer = JsonWriterCache.Rent(buffer);
+        try
         {
             valueWriter.Write(writer, value);
+            writer.Flush();
+            sizeHint = buffer.WrittenCount;
+            return buffer.WrittenSpan.ToArray();
         }
-
-        return stream.ToArray();
+        finally
+        {
+            JsonWriterCache.Return(writer);
+        }
     }
 
     public T Deserialize(byte[] payload)
@@ -69,15 +80,23 @@ internal sealed class CompiledJsonProjectionCodec<T, TBuilder>(
     private readonly StructureJsonProjectionReader<TBuilder> valueReader =
         JsonReaderCompiler.Compile(projection, readMode);
 
+    private int sizeHint = 256;
+
     public byte[] Serialize(T value)
     {
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
+        using var buffer = new PooledByteBufferWriter(sizeHint);
+        var writer = JsonWriterCache.Rent(buffer);
+        try
         {
             valueWriter.Write(writer, value);
+            writer.Flush();
+            sizeHint = buffer.WrittenCount;
+            return buffer.WrittenSpan.ToArray();
         }
-
-        return stream.ToArray();
+        finally
+        {
+            JsonWriterCache.Return(writer);
+        }
     }
 
     public void ReadInto(byte[] payload, TBuilder builder)

--- a/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
@@ -348,6 +348,13 @@ internal sealed class StructureJsonValueReader<T, TBuilder>(
     IReadOnlyList<IJsonMemberReader<TBuilder>> memberReaders
 ) : IJsonValueReader<T>
 {
+    // Member names as UTF-8, encoded once. Matching a property against these never
+    // transcodes and never allocates a name string.
+    private readonly byte[][] utf8Names =
+    [
+        .. memberReaders.Select(reader => System.Text.Encoding.UTF8.GetBytes(reader.Name)),
+    ];
+
     public T Read(JsonElement value)
     {
         if (value.ValueKind != JsonValueKind.Object)
@@ -356,32 +363,45 @@ internal sealed class StructureJsonValueReader<T, TBuilder>(
         }
 
         var builder = createBuilder();
-        foreach (var memberReader in memberReaders)
+
+        // One pass over the payload, rather than one pass per member. The previous
+        // shape called TryGetProperty for each member, and each of those calls
+        // scanned the object again — so a structure with N members over an object
+        // with M properties walked the document N times.
+        Span<bool> seen =
+            memberReaders.Count <= 64 ? stackalloc bool[64] : new bool[memberReaders.Count];
+
+        foreach (var property in value.EnumerateObject())
         {
-            if (!value.TryGetProperty(memberReader.Name, out var memberValue))
+            var index = IndexOf(property);
+            if (index < 0)
             {
-                if (memberReader.IsRequired)
-                {
-                    throw new MissingRequiredMemberException(memberReader.Name);
-                }
-
-                memberReader.ReadMissing(builder);
                 continue;
             }
 
-            if (memberValue.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            // First occurrence wins, which is what TryGetProperty did for a payload
+            // carrying a duplicate key.
+            if (seen[index])
             {
-                if (memberReader.IsRequired)
-                {
-                    throw new MissingRequiredMemberException(memberReader.Name);
-                }
-
                 continue;
             }
+
+            var memberReader = memberReaders[index];
+
+            if (property.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            {
+                // Left unseen so the trailing loop applies the modelled default, the
+                // same as an absent member. A member carrying @default always has a
+                // value in Smithy, so an explicit null must not leave it unset — and
+                // the trailing loop raises the same error for a required member.
+                continue;
+            }
+
+            seen[index] = true;
 
             try
             {
-                memberReader.ReadInto(builder, memberValue);
+                memberReader.ReadInto(builder, property.Value);
             }
             catch (MissingRequiredMemberException exception)
             {
@@ -390,7 +410,36 @@ internal sealed class StructureJsonValueReader<T, TBuilder>(
             }
         }
 
+        for (var i = 0; i < memberReaders.Count; i++)
+        {
+            if (seen[i])
+            {
+                continue;
+            }
+
+            var memberReader = memberReaders[i];
+            if (memberReader.IsRequired)
+            {
+                throw new MissingRequiredMemberException(memberReader.Name);
+            }
+
+            memberReader.ReadMissing(builder);
+        }
+
         return build(builder);
+    }
+
+    private int IndexOf(JsonProperty property)
+    {
+        for (var i = 0; i < utf8Names.Length; i++)
+        {
+            if (property.NameEquals(utf8Names[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 }
 

--- a/packages/NSmithy.Codecs.Json/JsonWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonWriterCompiler.cs
@@ -329,6 +329,15 @@ internal sealed class JsonMemberWriter<TContainer, TValue>(
     bool materializeDefault
 ) : IJsonMemberWriter<TContainer>
 {
+    // Resolved once at compile time rather than per write. Previously each member
+    // of each object cost a ShapeId-keyed trait lookup to find any @jsonName, then
+    // handed a string to WritePropertyName, which re-transcoded and re-escaped it
+    // every time. The wire name is constant per member, so all of that is
+    // hoistable — which is what System.Text.Json's source generator does.
+    private readonly JsonEncodedText propertyName = JsonEncodedText.Encode(
+        WireName(member.MemberTraits, member.Name)
+    );
+
     public void Write(Utf8JsonWriter writer, TContainer container)
     {
         var value = member.GetValue(container);
@@ -349,7 +358,7 @@ internal sealed class JsonMemberWriter<TContainer, TValue>(
             value = defaultValue!;
         }
 
-        writer.WritePropertyName(WireName(member.MemberTraits, member.Name));
+        writer.WritePropertyName(propertyName);
         valueWriter.Write(writer, value);
     }
 }

--- a/packages/NSmithy.Codecs.Json/PooledByteBufferWriter.cs
+++ b/packages/NSmithy.Codecs.Json/PooledByteBufferWriter.cs
@@ -1,0 +1,114 @@
+using System.Buffers;
+using System.Text.Json;
+
+namespace NSmithy.Codecs.Json;
+
+/// <summary>
+/// An <see cref="IBufferWriter{T}"/> backed by <see cref="ArrayPool{T}"/>, used as
+/// scratch space while serializing.
+/// </summary>
+/// <remarks>
+/// Replaces a <see cref="MemoryStream"/> whose growth allocated a fresh array per
+/// doubling and whose <c>ToArray</c> then copied the whole payload once more. Here
+/// the intermediate buffers come from the pool and are returned, so a serialize
+/// call allocates only the array it hands back.
+/// </remarks>
+internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
+{
+    private byte[]? buffer;
+    private int written;
+
+    public PooledByteBufferWriter(int initialCapacity) =>
+        buffer = ArrayPool<byte>.Shared.Rent(Math.Max(initialCapacity, 256));
+
+    public int WrittenCount => written;
+
+    public ReadOnlySpan<byte> WrittenSpan => Current.AsSpan(0, written);
+
+    private byte[] Current =>
+        buffer ?? throw new ObjectDisposedException(nameof(PooledByteBufferWriter));
+
+    public void Advance(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, Current.Length - written);
+        written += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return Current.AsMemory(written);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return Current.AsSpan(written);
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 1)
+            sizeHint = 1;
+
+        var current = Current;
+        if (sizeHint <= current.Length - written)
+            return;
+
+        var next = ArrayPool<byte>.Shared.Rent(Math.Max(current.Length * 2, written + sizeHint));
+        current.AsSpan(0, written).CopyTo(next);
+        buffer = next;
+        ArrayPool<byte>.Shared.Return(current);
+    }
+
+    public void Dispose()
+    {
+        var current = buffer;
+        if (current is null)
+            return;
+
+        buffer = null;
+        ArrayPool<byte>.Shared.Return(current);
+    }
+}
+
+/// <summary>
+/// A per-thread <see cref="Utf8JsonWriter"/> that is reset rather than
+/// reallocated between serialize calls.
+/// </summary>
+/// <remarks>
+/// A <see cref="Utf8JsonWriter"/> carries an internal buffer, so constructing one
+/// per call was a per-call allocation on top of the payload itself. Reuse is safe
+/// here because serialization is synchronous and never reentrant — the compiled
+/// writers only write to the writer they are handed.
+/// <para>
+/// Writer options are left at their defaults deliberately: they determine escaping
+/// behaviour, and the wire output must not change.
+/// </para>
+/// </remarks>
+internal static class JsonWriterCache
+{
+    [ThreadStatic]
+    private static Utf8JsonWriter? cached;
+
+    public static Utf8JsonWriter Rent(IBufferWriter<byte> destination)
+    {
+        var writer = cached;
+        if (writer is null)
+        {
+            writer = new Utf8JsonWriter(destination);
+            cached = writer;
+            return writer;
+        }
+
+        writer.Reset(destination);
+        return writer;
+    }
+
+    /// <summary>
+    /// Detaches the writer from the pooled buffer, so a returned buffer is not
+    /// still referenced by the cached writer.
+    /// </summary>
+    public static void Return(Utf8JsonWriter writer) => writer.Reset(Stream.Null);
+}

--- a/tests/NSmithy.Tests/Codecs/Json/JsonCodecTests.cs
+++ b/tests/NSmithy.Tests/Codecs/Json/JsonCodecTests.cs
@@ -358,4 +358,58 @@ public sealed class JsonCodecTests
         Assert.Equal(expectedJson, json);
         Assert.Equal(input, decoded);
     }
+
+    // ---------------- explicit null vs absent, on a defaulted member ----------------
+
+    public sealed record Defaulted(int Count);
+
+    public sealed class DefaultedBuilder
+    {
+        // Sentinel, so a member the codec never touched is distinguishable from one
+        // it set to the modelled default of 7.
+        public int Count { get; set; } = -1;
+    }
+
+    private static StructSchema<Defaulted, DefaultedBuilder> DefaultedSchema() =>
+        Schemas
+            .Structure<Defaulted, DefaultedBuilder>(new ShapeId("example", "Defaulted"))
+            .Optional(
+                "count",
+                static s => s.Count,
+                static (b, v) => b.Count = v,
+                Schemas.Integer,
+                [new Trait(new ShapeId("smithy.api", "default"), Document.From(7))]
+            )
+            .Build(static () => new DefaultedBuilder(), static b => new Defaulted(b.Count));
+
+    // A member carrying @default always has a value in Smithy, so an explicit null
+    // must materialize the default rather than leaving the member unset. The value
+    // reader used to skip it, which produced an object the model says cannot exist.
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"count\":null}")]
+    public void DefaultedMemberIsMaterializedWhetherAbsentOrExplicitlyNull(string json)
+    {
+        var codec = JsonCodec.FromSchema(DefaultedSchema());
+
+        Assert.Equal(7, codec.DeserializeText(json).Count);
+    }
+
+    // The projection reader is a separate code path used for shapes whose members
+    // are split across the body and the HTTP envelope. It has to agree.
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"count\":null}")]
+    public void ProjectionReaderAgreesOnDefaultedMembers(string json)
+    {
+        var schema = DefaultedSchema();
+        var codec = JsonCodec.FromProjection(
+            Schemas.Project<Defaulted, DefaultedBuilder>(schema, Schemas.GetMembers(schema))
+        );
+
+        var builder = new DefaultedBuilder();
+        codec.ReadInto(System.Text.Encoding.UTF8.GetBytes(json), builder);
+
+        Assert.Equal(7, builder.Count);
+    }
 }


### PR DESCRIPTION
Three hot-path changes to the JSON codec, all byte-identical on the wire: serialization writes through a pooled buffer with a reused Utf8JsonWriter instead of a MemoryStream, member property names are encoded once at compile time rather than resolved and transcoded on every write, and structures are read in a single pass instead of scanning the payload once per member. Serialize is now 1.75-1.86x System.Text.Json source-gen (was 2.23-2.52x) with 1.2-1.6x the allocations (was 4.5-5.5x), and deserialize is 1.14-1.15x (was 1.38-1.44x). The read-path rewrite also surfaced a correctness bug that no test covered: an explicit null left a member carrying @default unset instead of materialising the default, so the codec could produce an object the model says cannot exist.