### PR TITLE
Update Smithy to 1.73.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/NSmithy.Client)](https://www.nuget.org/packages/NSmithy.Client)
 [![.NET 10](https://img.shields.io/badge/.NET-net10.0-512BD4)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/github/license/thomaslaich/smithy-dotnet)](https://github.com/thomaslaich/smithy-dotnet/blob/main/LICENSE)
-[![Smithy CLI](https://img.shields.io/badge/smithy--cli-1.71.0-orange)](https://github.com/smithy-lang/smithy/releases/tag/1.71.0)
+[![Smithy CLI](https://img.shields.io/badge/smithy--cli-1.73.0-orange)](https://github.com/smithy-lang/smithy/releases/tag/1.73.0)
 
 > **Preview:** NSmithy is in preview; expect some API changes before 1.0. Protocol implementations are not yet on par with the [Smithy reference implementations](https://github.com/smithy-lang/smithy).
 

--- a/benchmarks/stacks/NSmithy/smithy-build.json
+++ b/benchmarks/stacks/NSmithy/smithy-build.json
@@ -9,8 +9,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "software.amazon.smithy:smithy-openapi:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-openapi:1.73.0"
     ]
   },
   "plugins": {

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -49,9 +49,10 @@ subprojects {
 
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
-        // Target Java 17 bytecode so the plugin loads inside the JRE bundled
-        // with the Smithy CLI.
-        options.release.set(17)
+        // Target Java 21 bytecode — the toolchain above, and what the JRE 25
+        // bundled with the Smithy CLI since 1.73.0 loads. Consumers pointing
+        // SmithyCliPath at an own install need a CLI at least that new.
+        options.release.set(21)
 
         options.errorprone {
             // Error Prone's default-ERROR checks (real correctness bugs) stay

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 
-smithyVersion=1.71.0
+smithyVersion=1.73.0

--- a/examples/aws-localstack/smithy-build.json
+++ b/examples/aws-localstack/smithy-build.json
@@ -6,7 +6,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT"
     ]
   },

--- a/examples/polyglot/dotnet/smithy-build.json
+++ b/examples/polyglot/dotnet/smithy-build.json
@@ -6,7 +6,7 @@
       { "url": "https://repo.maven.apache.org/maven2/" }
     ],
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT"
     ]
   },

--- a/examples/restjson1-streaming/contracts/smithy-build.json
+++ b/examples/restjson1-streaming/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0"
     ]
   }
 }

--- a/examples/restjson1/contracts/smithy-build.json
+++ b/examples/restjson1/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0"
     ]
   }
 }

--- a/examples/rpcv2cbor-streaming/contracts/smithy-build.json
+++ b/examples/rpcv2cbor-streaming/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0"
     ]
   }
 }

--- a/examples/rpcv2cbor/contracts/smithy-build.json
+++ b/examples/rpcv2cbor/contracts/smithy-build.json
@@ -3,7 +3,7 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0"
     ]
   }
 }

--- a/nix/smithy-cli.nix
+++ b/nix/smithy-cli.nix
@@ -6,28 +6,28 @@
 }:
 
 let
-  version = "1.71.0";
+  version = "1.73.0";
 
   platform =
     if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
       {
         name = "darwin-aarch64";
-        hash = "447e1d3e08b54e1787fedd10057a259ed48954ed950f2909713de28d8ea0d3dc";
+        hash = "daf789553a20822138bc90b913233374613e1a4515a61358241d5c5489be0be9";
       }
     else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
       {
         name = "darwin-x86_64";
-        hash = "dcda65061f51687ccded52ede603ea66381e3ca2eeaf708bdf96f93df9eb535d";
+        hash = "eb6f7e72245ecf0e3df992314c80dde080e4215716214874a0c3b94f9813562f";
       }
     else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64 then
       {
         name = "linux-aarch64";
-        hash = "1de152a114bcb96a31bb1b3596df5b65794a2c81e292149596e5f065330d6816";
+        hash = "f69295411846274b9e8128f31ffa1d7ad02fa078047e2c4e46d5d85bcba4fc20";
       }
     else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
       {
         name = "linux-x86_64";
-        hash = "5bddf40fb64fd0581d85b6bdc51ae67bdc4dff0297b3db92cb800b324fa3b2ea";
+        hash = "9071a7db052da81ab6f4be1b4d43ea152b44b78217be0dd21d37d9ea5ec1942d";
       }
     else
       throw "Unsupported platform for smithy-cli: ${stdenv.hostPlatform.system}";

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.props
@@ -12,7 +12,7 @@
       Smithy CLI version bundled in this package. software.amazon.smithy:* Maven
       artifacts in your contracts smithy-build.json should use this version.
     -->
-    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
+    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.73.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''">0.0.0-SNAPSHOT</SmithyCSharpCodegenVersion>
     <!--
       Set to 'true' to inject the smithy-docgen plugin into the synthesized smithy-build.json

--- a/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
+++ b/packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets
@@ -35,7 +35,7 @@
        always wins.
        ================================================================ -->
   <PropertyGroup>
-    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.71.0</SmithyVersion>
+    <SmithyVersion Condition="'$(SmithyVersion)' == ''">1.73.0</SmithyVersion>
     <SmithyCSharpCodegenVersion Condition="'$(SmithyCSharpCodegenVersion)' == ''"
       >0.0.0-SNAPSHOT</SmithyCSharpCodegenVersion
     >

--- a/packages/NSmithy.MSBuild/tools/download-smithy-cli.sh
+++ b/packages/NSmithy.MSBuild/tools/download-smithy-cli.sh
@@ -10,18 +10,18 @@
 # Usage: bash tools/download-smithy-cli.sh
 set -euo pipefail
 
-SMITHY_VERSION="1.71.0"
+SMITHY_VERSION="1.73.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$SCRIPT_DIR/smithy-cli"
 BASE_URL="https://github.com/smithy-lang/smithy/releases/download/${SMITHY_VERSION}"
 
 # SHA256 hashes for smithy-cli-{platform}.zip — update when bumping SMITHY_VERSION.
 declare -A PLATFORM_SHA256=(
-  ["darwin-aarch64"]="447e1d3e08b54e1787fedd10057a259ed48954ed950f2909713de28d8ea0d3dc"
-  ["darwin-x86_64"]="dcda65061f51687ccded52ede603ea66381e3ca2eeaf708bdf96f93df9eb535d"
-  ["linux-aarch64"]="1de152a114bcb96a31bb1b3596df5b65794a2c81e292149596e5f065330d6816"
-  ["linux-x86_64"]="5bddf40fb64fd0581d85b6bdc51ae67bdc4dff0297b3db92cb800b324fa3b2ea"
-  ["windows-x64"]="173299c5f3b380c027a0c2d17cdec65f3cd2f756ee46d6ade0eb0cc53c6e0047"
+  ["darwin-aarch64"]="daf789553a20822138bc90b913233374613e1a4515a61358241d5c5489be0be9"
+  ["darwin-x86_64"]="eb6f7e72245ecf0e3df992314c80dde080e4215716214874a0c3b94f9813562f"
+  ["linux-aarch64"]="f69295411846274b9e8128f31ffa1d7ad02fa078047e2c4e46d5d85bcba4fc20"
+  ["linux-x86_64"]="9071a7db052da81ab6f4be1b4d43ea152b44b78217be0dd21d37d9ea5ec1942d"
+  ["windows-x64"]="32e00abc06f6d1ac9201d8f574bd7a2d62d65eaeb2ea16b3877be18d8febafc2"
 )
 
 all_platforms=(

--- a/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-client/smithy-build.json
@@ -4,9 +4,9 @@
     "dependencies": [
       "io.github.YOUR_ORG:your-service-contracts:1.0.0",
       //#if (IsRestJson1)
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
       //#elseif (IsRpcv2Cbor)
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0",
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-contracts/smithy-build.json
@@ -4,9 +4,9 @@
   "maven": {
     "dependencies": [
       //#if (IsRestJson1)
-      "software.amazon.smithy:smithy-aws-traits:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0"
       //#elseif (IsRpcv2Cbor)
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0"
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38"
       //#endif

--- a/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
+++ b/templates/NSmithy.Templates/content/nsmithy-server/smithy-build.json
@@ -4,9 +4,9 @@
   "maven": {
     "dependencies": [
       //#if (IsRestJson1)
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
       //#elseif (IsRpcv2Cbor)
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0",
       //#elseif (IsSimpleRestJson || IsGrpc)
       "com.disneystreaming.alloy:alloy-core:0.3.38",
       //#endif

--- a/tests/Conformance/AwsJson/smithy-build.json
+++ b/tests/Conformance/AwsJson/smithy-build.json
@@ -8,8 +8,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.73.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -12,8 +12,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.73.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RestXml/smithy-build.json
+++ b/tests/Conformance/RestXml/smithy-build.json
@@ -8,8 +8,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-aws-traits:1.71.0",
-      "software.amazon.smithy:smithy-aws-protocol-tests:1.71.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.73.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/RpcV2Cbor/smithy-build.json
+++ b/tests/Conformance/RpcV2Cbor/smithy-build.json
@@ -8,8 +8,8 @@
     ],
     "dependencies": [
       "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
-      "software.amazon.smithy:smithy-protocol-traits:1.71.0",
-      "software.amazon.smithy:smithy-protocol-tests:1.71.0"
+      "software.amazon.smithy:smithy-protocol-traits:1.73.0",
+      "software.amazon.smithy:smithy-protocol-tests:1.73.0"
     ]
   },
   "projections": {

--- a/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
+++ b/tests/Conformance/SimpleRestJson/SimpleRestJson.Conformance.csproj
@@ -21,7 +21,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!--
       alloy-protocol-tests 0.3.38 uses HttpRequestTestCase#code and HttpResponseTestCase#{uri,method}
-      which don't exist in smithy-model 1.71.0. The "Error validating trait" text in the WARNING
+      which don't exist in smithy-model 1.73.0. The "Error validating trait" text in the WARNING
       message body causes MSBuild's Exec task to treat it as a build error, so suppress it here.
     -->
     <SmithyExtraArgs>--hide-validators TraitValue.UnknownMember.smithy.test#HttpRequestTestCase.code,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.uri,TraitValue.UnknownMember.smithy.test#HttpResponseTestCase.method</SmithyExtraArgs>

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -19,7 +19,7 @@ numbers.
 ## Maven Dependency
 
 ```json
-"software.amazon.smithy:smithy-aws-traits:1.71.0"
+"software.amazon.smithy:smithy-aws-traits:1.73.0"
 ```
 
 ## NuGet Packages

--- a/website/src/content/docs/protocols/rest-json.md
+++ b/website/src/content/docs/protocols/rest-json.md
@@ -35,7 +35,7 @@ numbers.
 | Protocol | Dependency |
 | --- | --- |
 | `simpleRestJson` | `com.disneystreaming.alloy:alloy-core:0.3.38` |
-| `restJson1` | `software.amazon.smithy:smithy-aws-traits:1.71.0` |
+| `restJson1` | `software.amazon.smithy:smithy-aws-traits:1.73.0` |
 
 ## NuGet Packages
 

--- a/website/src/content/docs/reference/msbuild.md
+++ b/website/src/content/docs/reference/msbuild.md
@@ -75,7 +75,7 @@ cross-team model sharing outside the solution.
 
 ## Smithy CLI
 
-NSmithy bundles the Smithy CLI (version 1.71.0) inside `NSmithy.MSBuild` and
+NSmithy bundles the Smithy CLI (version 1.73.0) inside `NSmithy.MSBuild` and
 selects the correct platform binary automatically. No separate installation is
 required. The bundle is self-contained and includes a JRE, so Java does not
 need to be installed either.


### PR DESCRIPTION
Bumps the bundled Smithy CLI and every pin on the Smithy version axis from 1.71.0 to 1.73.0 — `download-smithy-cli.sh` (version plus all five platform SHA256s), `nix/smithy-cli.nix`, the MSBuild `SmithyVersion` defaults, `codegen/gradle.properties`, the `smithy-*-traits` / `*-protocol-tests` pins across conformance, examples and templates, and the docs. These have to move together: the CLI refuses to build when resolved dependencies pull a newer smithy-model than itself, so the trait jars cannot be bumped ahead of the CLI. Since 1.73.0 the CLI bundles a JRE 25 rather than 17, which grows the NSmithy.MSBuild package from roughly 133 MB to 153 MB (well under the 250 MB nuget.org limit) and lifts the ceiling on the codegen plugin's bytecode target, so that moves from 17 to 21 — matching upstream smithy-java, which also emits 21. All five conformance suites plus the unit tests pass against freshly generated code (RestJson1 1125, RpcV2Cbor 123, SimpleRestJson 87, RestXml 46, AwsJson 27, NSmithy.Tests 234).