### PR TITLE
Exercise modelled validation in the examples

### DIFF
--- a/examples/restjson1/README.md
+++ b/examples/restjson1/README.md
@@ -56,6 +56,73 @@ curl -i http://localhost:5000/cities/SEA/forecast
 curl -i http://localhost:5000/cities/SEA/flaky-forecast   # 503s two of every three calls
 ```
 
+## Rejecting a bad request
+
+The server enforces the model at the boundary, so a request that violates it is
+answered with a structured 4xx rather than reaching the handler. Nothing in the
+handler implements these checks — they are generated from the model.
+
+`CityId` is declared `@pattern("^[A-Za-z0-9 ]+$")`, so a city ID carrying a
+character the pattern excludes is rejected with `ValidationException`, which
+names the member and the constraint it failed:
+
+```bash
+curl -i 'http://localhost:5000/cities/SEA%21'   # "SEA!"
+```
+
+```
+HTTP/1.1 400 Bad Request
+X-Amzn-Errortype: ValidationException
+
+{"message":"1 validation error detected. Value at '/cityId' failed to satisfy
+constraint: Member must satisfy regular expression pattern: ^[A-Za-z0-9 ]+$",
+"fieldList":[{"path":"/cityId","message":"..."}]}
+```
+
+Input that cannot become modeled input at all fails earlier, during
+deserialization, and comes back as `SerializationException` — here `pageSize` is
+modeled as `Integer`:
+
+```bash
+curl -i 'http://localhost:5000/cities?pageSize=abc'
+```
+
+```
+HTTP/1.1 400 Bad Request
+X-Amzn-Errortype: SerializationException
+
+{"message":"Value 'abc' is not a valid integer."}
+```
+
+An `Accept` header that excludes the response's media type is answered with 406
+before the operation runs:
+
+```bash
+curl -i -H 'Accept: application/xml' http://localhost:5000/current-time
+```
+
+```
+HTTP/1.1 406 Not Acceptable
+X-Amzn-Errortype: NotAcceptableException
+
+{"message":"Response is 'application/json', which Accept 'application/xml' excludes."}
+```
+
+A request that satisfies the model but names something absent still reaches the
+handler and returns the error the operation models — a space is inside
+`CityId`'s pattern, so this is a `NoSuchResource`, not a validation failure:
+
+```bash
+curl -i 'http://localhost:5000/cities/%20'
+```
+
+```
+HTTP/1.1 400 Bad Request
+X-Amzn-Errortype: NoSuchResource
+
+{"resourceType":"City"}
+```
+
 ## Observability
 
 Both the client and the server export OpenTelemetry traces and metrics over

--- a/examples/restjson1/client/Program.cs
+++ b/examples/restjson1/client/Program.cs
@@ -1,5 +1,6 @@
 using Example.Weather;
 using NSmithy.Client;
+using NSmithy.Core.Validation;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -63,4 +64,33 @@ for (var i = 0; i < 3; i++)
 {
     var flaky = await client.GetFlakyForecastAsync(new GetFlakyForecastInput("SEA"));
     Console.WriteLine($"  Attempt group {i + 1}: {flaky.ChanceOfRain:P0} chance of rain");
+}
+
+// Rejected requests come last on purpose: each failed call spends part of the retry strategy's
+// shared budget, and the flaky-forecast loop above needs that budget to retry its way to success.
+
+// "Atlantis" satisfies the model, so it reaches the handler and comes back as the error the
+// operation declares — a modeled error, surfaced as a typed exception.
+try
+{
+    await client.GetCityAsync(new GetCityInput("Atlantis"));
+}
+catch (NoSuchResource error)
+{
+    Console.WriteLine($"No such {error.ResourceType}: Atlantis");
+}
+
+// CityId is @pattern("^[A-Za-z0-9 ]+$"), and constraints are enforced by the server — the client
+// sends what it is handed. The rejection comes back as smithy.framework#ValidationException, an
+// implicit modeled error on every operation, so it deserializes into a typed exception naming the
+// member and the constraint it failed rather than a bare 400.
+try
+{
+    await client.GetCityAsync(new GetCityInput("SEA!"));
+}
+catch (ValidationException error)
+{
+    Console.WriteLine($"Rejected \"SEA!\": {error.Message}");
+    foreach (var field in error.FieldList)
+        Console.WriteLine($"  {field.Path}: {field.Message}");
 }

--- a/examples/rpcv2cbor/client/Program.cs
+++ b/examples/rpcv2cbor/client/Program.cs
@@ -1,5 +1,6 @@
 using Example.Weather;
 using NSmithy.Client;
+using NSmithy.Core.Validation;
 
 var endpoint =
     args.FirstOrDefault(a => !a.StartsWith("--", StringComparison.Ordinal))
@@ -44,6 +45,19 @@ Console.WriteLine($"Seattle: ({seattle.Coordinates.Latitude}, {seattle.Coordinat
 var forecast = await client.GetForecastAsync(new GetForecastInput("SEA"));
 Console.WriteLine($"Forecast for SEA: {forecast.ChanceOfRain:P0} chance of rain");
 
+// The flaky endpoint fails two of every three calls with the retryable modeled error; the
+// standard retry strategy retries with backoff, so each call below succeeds after
+// transparent retries.
+Console.WriteLine("Flaky forecasts (each call succeeds after transparent retries):");
+for (var i = 0; i < 3; i++)
+{
+    var flaky = await client.GetFlakyForecastAsync(new GetFlakyForecastInput("SEA"));
+    Console.WriteLine($"  Attempt group {i + 1}: {flaky.ChanceOfRain:P0} chance of rain");
+}
+
+// Rejected requests come last on purpose: each failed call spends part of the retry strategy's
+// shared budget, and the flaky-forecast loop above needs that budget to retry its way to success.
+
 // Modeled errors surface as typed exceptions on the client.
 try
 {
@@ -54,12 +68,17 @@ catch (NoSuchResource error)
     Console.WriteLine($"No such {error.ResourceType}: Atlantis");
 }
 
-// The flaky endpoint fails two of every three calls with the retryable modeled error; the
-// standard retry strategy retries with backoff, so each call below succeeds after
-// transparent retries.
-Console.WriteLine("Flaky forecasts (each call succeeds after transparent retries):");
-for (var i = 0; i < 3; i++)
+// CityId is @pattern("^[A-Za-z0-9 ]+$"), and constraints are enforced by the server — the
+// client sends what it is handed. The rejection comes back as smithy.framework#ValidationException,
+// an implicit modeled error on every operation, so it deserializes into a typed exception that
+// names the member and the constraint it failed rather than a bare 400.
+try
 {
-    var flaky = await client.GetFlakyForecastAsync(new GetFlakyForecastInput("SEA"));
-    Console.WriteLine($"  Attempt group {i + 1}: {flaky.ChanceOfRain:P0} chance of rain");
+    await client.GetCityAsync(new GetCityInput("SEA!"));
+}
+catch (ValidationException error)
+{
+    Console.WriteLine($"Rejected \"SEA!\": {error.Message}");
+    foreach (var field in error.FieldList)
+        Console.WriteLine($"  {field.Path}: {field.Message}");
 }


### PR DESCRIPTION
Neither the restJson1 nor the rpcv2Cbor example demonstrated the model being enforced — no README mentioned it and no client probed it — which left 0.8.0's headline feature undemonstrated. Both example clients now send a request that violates `CityId`'s `@pattern` and catch the resulting `smithy.framework#ValidationException`, printing the member and constraint it failed, alongside a modelled `NoSuchResource` for contrast; the restJson1 README gains a section showing the same rejections over curl, including the 406 for an `Accept` that excludes the response media type. The probes are deliberately placed after the flaky-forecast loop rather than before it: each failed call spends part of the retry strategy's shared budget, and putting them first made the loop's third call exhaust its retries and crash — verified by running both examples end to end before and after.