### PR TITLE
perf: reduce Proto codec allocations

### DIFF
--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -134,58 +134,105 @@ concentrated in small calls and is open problem 2, not a codec problem.
 NSwag is close to hand-written on small calls despite using reflection-based
 `System.Text.Json`, which suggests the gap is not inherent to being generated.
 
-### 4. List wrapper types defensively copy
+### 4. Collection construction remains visible
 
-`OBSERVED`, cost not isolated.
+`OBSERVED`, remaining cost not isolated.
 
-Generated list shapes wrap their contents:
+Generated collection constructors still defensively copy caller-owned inputs.
+Schema-driven deserializers now transfer ownership of their private builders
+instead, so decoded lists and maps avoid the backing collection copy while
+retaining a read-only wrapper. That removes the avoidable copy without weakening
+the public model API's immutability.
 
-```csharp
-Values = System.Array.AsReadOnly(System.Linq.Enumerable.ToArray(values));
-```
+The wrapper and generated model object are still real allocations that the
+mutable Google.Protobuf message model does not necessarily mirror.
 
-That is an array copy plus two allocations per list instance, which the
-`System.Text.Json` baselines never pay. It is left in the measurement deliberately,
-since it is a real cost of the generated types, but it is a candidate for removal
-when the caller already hands over an array it owns.
-
-### 5. Proto dominates the measured gRPC gap
+### 5. Proto remains the largest measured gRPC gap
 
 `MEASURED`, unary gRPC suite, in-process toolchain, Tiered PGO disabled.
 
-| Layer | Scenario | Time ratio vs Grpc.Net / Google.Protobuf | Allocation ratio |
+| Layer | Scenario | Time ratio before -> after | Allocation ratio before -> after |
 | --- | --- | --- | --- |
-| client | get-item | 1.51x | 1.80x |
-| client | list-items-100 | 2.86x | 3.56x |
-| server | get-item | 1.21x | 1.25x |
-| server | list-items-100 | 1.50x | 3.98x |
-| deserialize only | get-item | 2.72x | 2.54x |
-| deserialize only | list-items-100 | 2.91x | 3.26x |
-| serialize only | get-item | 1.79x | 4.05x |
-| serialize only | list-items-100 | 1.92x | 10.84x |
+| client | get-item | 1.51x -> **1.35x** | 1.80x -> **1.53x** |
+| client | list-items-100 | 2.86x -> **1.98x** | 3.56x -> **2.27x** |
+| server | get-item | 1.21x -> 1.22x | 1.25x -> **1.19x** |
+| server | list-items-100 | 1.50x -> **1.41x** | 3.98x -> **1.70x** |
+| deserialize only | get-item | 2.72x -> **1.80x** | 2.54x -> **1.24x** |
+| deserialize only | list-items-100 | 2.91x -> **2.00x** | 3.26x -> **1.88x** |
+| serialize only | get-item | 1.79x -> **1.70x** | 4.05x -> **0.79x** |
+| serialize only | list-items-100 | 1.92x -> **1.67x** | 10.84x -> **1.53x** |
 
-The payload-dependent client gap is almost entirely explained by Proto
-deserialization: 2.86x for the full 100-item client call versus 2.91x for the
+The before column is the rebased gRPC benchmark branch, including PR #143's
+generated direct Proto write path. The after column is the combined
+`perf/proto-codec` branch from a fresh run on the same machine. Ratios normalize
+small movement in the unchanged Grpc.Net and Google.Protobuf controls.
+
+The optimized large client call fell from 50.77 us to 35.79 us and from 148.45 KB
+to 94.71 KB. Proto deserialization fell from 47.72 us to 33.11 us and from
+130,032 B to 75,120 B. Serialization improved less in time, 5% for get-item and
+13% for list-items-100, but its allocations fell by 81% and 86%. The large server
+allocation fell from 95.30 KB to 40.76 KB.
+
+The remaining payload-dependent client gap is still explained by Proto
+deserialization: 1.98x for the full 100-item client call versus 2.00x for the
 codec alone. The server has a larger shared ASP.NET Core cost, which dilutes the
-1.92x serialization gap to 1.50x end to end. This does not support client
+1.67x serialization gap to 1.41x end to end. This still does not support client
 invocation ceremony as the primary gRPC bottleneck.
 
-The allocation mechanisms are visible in source:
+The baseline allocation mechanisms were visible in source:
 
-- `OBSERVED` Each nested message creates a 64-byte `ProtoWriter`, grows its own
-  buffer, calls `ToArray()`, and is copied again into its parent. Each string is
-  first materialized with `Encoding.UTF8.GetBytes`.
-- `OBSERVED` Each decoded structure creates its generated builder plus a
-  `ProtoReadState` containing a dictionary and hash set. Field dispatch also uses
+- `OBSERVED` Each nested message created a 64-byte `ProtoWriter`, grew its own
+  buffer, called `ToArray()`, and was copied again into its parent. Each string
+  was first materialized with `Encoding.UTF8.GetBytes`.
+- `OBSERVED` Each decoded structure created its generated builder plus a
+  `ProtoReadState` containing a dictionary and hash set. Field dispatch also used
   a dictionary lookup, while Google.Protobuf-generated parsers use direct field
   switches.
-- `OBSERVED` Generated list wrappers copy their builder into an array and wrap it
+- `OBSERVED` Generated list wrappers copied their builder into an array and wrapped it
   in `ReadOnlyCollection<T>`, adding two allocations per decoded list.
 
-These measurements include the generated direct Proto write path from PR #143.
-Against the pre-#143 run, serialization moved from 2.30x/2.35x to 1.79x/1.92x
-for one/100 items, and the small full-client ratio moved from 2.09x to 1.51x.
-Deserialization is unchanged and still dominates the large client result.
+The changes directly address all three allocation mechanisms above: one pooled
+writer now backpatches nested lengths and transcodes strings in place; read state
+is stack-local with dense field dispatch and lazily allocated collection slots;
+and generated schema builds can consume codec-owned collection builders without
+copying them.
+
+The remaining 1.7-2.0x codec gap is no longer explained by obvious temporary
+buffers. Generated model construction and the per-field schema dispatch are the
+next profiler targets.
+
+#### Post-improvement protocol comparison
+
+`MEASURED`, current combined branch, Tiered PGO disabled. JSON and CBOR serialize
+the same generated `ListItemsOutput`; the Proto rows use the analogous gRPC
+response shape, so the cross-format numbers are directional rather than a strict
+wire-format shootout.
+
+| NSmithy format | One item, time / allocated | 100 items, time / allocated |
+| --- | --- | --- |
+| REST JSON codec | 282.9 ns / 312 B | 21.40 us / 17.45 KB |
+| RPCv2 CBOR codec | 479.7 ns / 1.63 KB | 31.86 us / 46.97 KB |
+| gRPC Proto codec | **217.6 ns / 120 B** | **19.73 us / 8.92 KB** |
+
+Proto is the fastest and lowest-allocation serializer in these current NSmithy
+measurements. CBOR is 1.70x slower than JSON for one item and 1.49x slower for
+100, while allocating substantially more because `CborWriter.Encode()` still
+copies into a new output array.
+
+The REST and gRPC suites also share comparable canned-client and in-memory-server
+workloads. There is not yet an equivalent end-to-end RPCv2 CBOR benchmark.
+
+| Layer | Scenario | REST JSON | gRPC |
+| --- | --- | --- | --- |
+| client | get-item | 1.797 us / 4.90 KB | **1.611 us / 4.98 KB** |
+| client | list-items-100 | 63.04 us / **80.90 KB** | **35.79 us** / 94.71 KB |
+| server | get-item | **10.92 us / 13.03 KB** | 12.86 us / 14.75 KB |
+| server | list-items-100 | 46.46 us / 73.59 KB | **41.52 us / 40.76 KB** |
+
+The result is mixed for small end-to-end calls because fixed HTTP and runtime
+costs dominate. For the 100-item workload, gRPC is 43% faster on the client and
+11% faster on the server; its server allocation is 45% lower, while its client
+allocation is 17% higher.
 
 ### 6. Codec optimization candidates, by codec
 

--- a/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcClientBenchmarks-report-github.md
+++ b/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcClientBenchmarks-report-github.md
@@ -1,0 +1,17 @@
+```
+
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.2 (25F84) [Darwin 25.5.0]
+Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
+.NET SDK 10.0.201
+  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
+
+Toolchain=InProcessEmitToolchain
+
+```
+| Method                | Scenario       | Mean      | Error     | StdDev    | Ratio | Gen0    | Gen1   | Allocated | Alloc Ratio |
+|---------------------- |--------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| **&#39;Grpc.Net client&#39;**     | **get-item**       |  **1.189 μs** | **0.0042 μs** | **0.0039 μs** |  **1.00** |  **0.3986** | **0.0038** |   **3.26 KB** |        **1.00** |
+| &#39;NSmithy gRPC client&#39; | get-item       |  1.611 μs | 0.0081 μs | 0.0076 μs |  1.35 |  0.6084 | 0.0038 |   4.98 KB |        1.53 |
+|                       |                |           |           |           |       |         |        |           |             |
+| **&#39;Grpc.Net client&#39;**     | **list-items-100** | **18.054 μs** | **0.0587 μs** | **0.0549 μs** |  **1.00** |  **5.0964** | **0.6104** |  **41.68 KB** |        **1.00** |
+| &#39;NSmithy gRPC client&#39; | list-items-100 | 35.792 μs | 0.1244 μs | 0.1163 μs |  1.98 | 11.5356 | 1.4038 |  94.71 KB |        2.27 |

--- a/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcDeserializationBenchmarks-report-github.md
+++ b/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcDeserializationBenchmarks-report-github.md
@@ -1,0 +1,17 @@
+```
+
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.2 (25F84) [Darwin 25.5.0]
+Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
+.NET SDK 10.0.201
+  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
+
+Toolchain=InProcessEmitToolchain
+
+```
+| Method                        | Scenario       | Mean        | Error     | StdDev    | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
+|------------------------------ |--------------- |------------:|----------:|----------:|------:|-------:|-------:|----------:|------------:|
+| **&#39;Google.Protobuf deserialize&#39;** | **get-item**       |    **184.9 ns** |   **0.81 ns** |   **0.76 ns** |  **1.00** | **0.0687** |      **-** |     **576 B** |        **1.00** |
+| &#39;NSmithy Proto deserialize&#39;   | get-item       |    333.4 ns |   0.91 ns |   0.85 ns |  1.80 | 0.0849 |      - |     712 B |        1.24 |
+|                               |                |             |           |           |       |        |        |           |             |
+| **&#39;Google.Protobuf deserialize&#39;** | **list-items-100** | **16,574.5 ns** |  **80.20 ns** |  **71.10 ns** |  **1.00** | **4.7607** | **0.5188** |   **39936 B** |        **1.00** |
+| &#39;NSmithy Proto deserialize&#39;   | list-items-100 | 33,107.4 ns | 136.91 ns | 121.36 ns |  2.00 | 8.9722 | 0.9766 |   75120 B |        1.88 |

--- a/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcSerializationBenchmarks-report-github.md
+++ b/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcSerializationBenchmarks-report-github.md
@@ -1,0 +1,17 @@
+```
+
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.2 (25F84) [Darwin 25.5.0]
+Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
+.NET SDK 10.0.201
+  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
+
+Toolchain=InProcessEmitToolchain
+
+```
+| Method                      | Scenario       | Mean        | Error     | StdDev    | Ratio | Gen0   | Allocated | Alloc Ratio |
+|---------------------------- |--------------- |------------:|----------:|----------:|------:|-------:|----------:|------------:|
+| **&#39;Google.Protobuf serialize&#39;** | **get-item**       |    **127.9 ns** |   **0.74 ns** |   **0.69 ns** |  **1.00** | **0.0181** |     **152 B** |        **1.00** |
+| &#39;NSmithy Proto serialize&#39;   | get-item       |    217.6 ns |   0.73 ns |   0.69 ns |  1.70 | 0.0143 |     120 B |        0.79 |
+|                             |                |             |           |           |       |        |           |             |
+| **&#39;Google.Protobuf serialize&#39;** | **list-items-100** | **11,838.5 ns** |  **28.55 ns** |  **25.31 ns** |  **1.00** | **0.7019** |    **5968 B** |        **1.00** |
+| &#39;NSmithy Proto serialize&#39;   | list-items-100 | 19,727.4 ns | 138.12 ns | 129.20 ns |  1.67 | 1.0681 |    9136 B |        1.53 |

--- a/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcServerBenchmarks-report-github.md
+++ b/benchmarks/results/proto-optimized/results/Bench.Micro.GrpcServerBenchmarks-report-github.md
@@ -1,0 +1,17 @@
+```
+
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.2 (25F84) [Darwin 25.5.0]
+Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
+.NET SDK 10.0.201
+  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
+
+Toolchain=InProcessEmitToolchain
+
+```
+| Method                   | Scenario       | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
+|------------------------- |--------------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
+| **&#39;Grpc.AspNetCore server&#39;** | **get-item**       | **10.51 μs** | **0.146 μs** | **0.122 μs** |  **1.00** |    **0.02** | **1.5259** | **0.0305** |  **12.38 KB** |        **1.00** |
+| &#39;NSmithy gRPC server&#39;    | get-item       | 12.86 μs | 0.156 μs | 0.138 μs |  1.22 |    0.02 | 1.8158 | 0.0610 |  14.75 KB |        1.19 |
+|                          |                |          |          |          |       |         |        |        |           |             |
+| **&#39;Grpc.AspNetCore server&#39;** | **list-items-100** | **29.47 μs** | **0.549 μs** | **0.514 μs** |  **1.00** |    **0.02** | **3.0212** | **0.1221** |  **23.92 KB** |        **1.00** |
+| &#39;NSmithy gRPC server&#39;    | list-items-100 | 41.52 μs | 0.150 μs | 0.133 μs |  1.41 |    0.03 | 5.2490 | 0.1831 |  40.76 KB |        1.70 |

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -51,6 +51,16 @@ public final class ListGenerator implements Runnable {
                     "Values = System.Array.AsReadOnly(System.Linq.Enumerable.ToArray(values));");
               });
           writer.write("");
+          writer.write(
+              "private $L(System.Collections.Generic.List<$L> values)", typeName, memberType);
+          writer.openBlock("{", "}", () -> writer.write("Values = values.AsReadOnly();"));
+          writer.write("");
+          writer.write(
+              "internal static $L FromOwnedList(System.Collections.Generic.List<$L> values)"
+                  + " => new(values);",
+              typeName,
+              memberType);
+          writer.write("");
           writer.writeXmlDocs(shape.getMember());
           writer.write(
               "public System.Collections.Generic.IReadOnlyList<$L> Values { get; }", memberType);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -63,6 +63,28 @@ public final class MapGenerator implements Runnable {
                     valueType);
               });
           writer.write("");
+          writer.write(
+              "private $L(System.Collections.Generic.Dictionary<$L, $L> values)",
+              typeName,
+              keyType,
+              valueType);
+          writer.openBlock(
+              "{",
+              "}",
+              () ->
+                  writer.write(
+                      "Values = new System.Collections.ObjectModel.ReadOnlyDictionary<$L,"
+                          + " $L>(values);",
+                      keyType,
+                      valueType));
+          writer.write("");
+          writer.write(
+              "internal static $L FromOwnedDictionary("
+                  + "System.Collections.Generic.Dictionary<$L, $L> values) => new(values);",
+              typeName,
+              keyType,
+              valueType);
+          writer.write("");
           writer.writeXmlDocs(shape.getValue());
           writer.write(
               "public System.Collections.Generic.IReadOnlyDictionary<$L, $L> Values { get; }",

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -301,7 +301,7 @@ public final class SchemaGenerator {
           writer.write("static value => value.Values,");
           writer.write("static () => new $L(),", builderType);
           writer.write("static (builder, value) => builder.Add(value),");
-          writer.write("static builder => new $L(builder),", typeName);
+          writer.write("static builder => $L.FromOwnedList(builder),", typeName);
           writer.write(
               "$L, elementTraits: $L);",
               traitsExpr(shape.getAllTraits().values()),
@@ -342,7 +342,7 @@ public final class SchemaGenerator {
           writer.write("static value => value.Values,");
           writer.write("static () => new $L(System.StringComparer.Ordinal),", builderType);
           writer.write("static (builder, key, value) => builder[key] = value,");
-          writer.write("static builder => new $L(builder),", typeName);
+          writer.write("static builder => $L.FromOwnedDictionary(builder),", typeName);
           writer.write(
               "$L, keyTraits: $L, valueTraits: $L, key: $L);",
               traitsExpr(shape.getAllTraits().values()),

--- a/packages/NSmithy.Codecs.Proto/CompiledProtoCodec.cs
+++ b/packages/NSmithy.Codecs.Proto/CompiledProtoCodec.cs
@@ -6,6 +6,7 @@ internal sealed class CompiledProtoCodec<T> : IProtoCodec<T>
 {
     private readonly IProtoMessageWriter<T> writer;
     private readonly IProtoMessageReader<T> reader;
+    private int sizeHint = 64;
 
     public CompiledProtoCodec(Schema<T> schema)
     {
@@ -21,9 +22,18 @@ internal sealed class CompiledProtoCodec<T> : IProtoCodec<T>
             return [];
         }
 
-        var writer = new ProtoWriter();
-        this.writer.Write(writer, value);
-        return writer.ToArray();
+        var writer = ProtoWriterCache.Rent(sizeHint);
+        try
+        {
+            this.writer.Write(writer, value);
+            var result = writer.ToArray();
+            sizeHint = result.Length;
+            return result;
+        }
+        finally
+        {
+            ProtoWriterCache.Return(writer);
+        }
     }
 
     public T Deserialize(byte[] payload)

--- a/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
@@ -24,10 +24,13 @@ internal interface IProtoFieldReader<in TBuilder>
         TBuilder builder,
         ref ProtoReader reader,
         WireType wireType,
-        ProtoReadState state
+        ref ProtoReadState state
     );
+}
 
-    void Complete(TBuilder builder, ProtoReadState state);
+internal interface IProtoFieldCompleter<in TBuilder>
+{
+    void Complete(TBuilder builder, ref ProtoReadState state);
 }
 
 internal interface IProtoUnionCaseReader<out TUnion>
@@ -37,24 +40,47 @@ internal interface IProtoUnionCaseReader<out TUnion>
     TUnion Read(ref ProtoReader reader, WireType wireType);
 }
 
-internal sealed class ProtoReadState
+internal struct ProtoReadState(int slotCount)
 {
-    private readonly Dictionary<int, object> builders = [];
-    private readonly HashSet<int> seen = [];
+    private object? firstBuilder;
+    private object?[]? additionalBuilders;
 
-    public bool WasSeen(int fieldNumber) => seen.Contains(fieldNumber);
-
-    public TBuilder GetOrCreate<TBuilder>(int fieldNumber, Func<TBuilder> create)
+    public TBuilder GetOrCreate<TBuilder>(int slot, Func<TBuilder> create)
     {
-        seen.Add(fieldNumber);
-        if (builders.TryGetValue(fieldNumber, out var builder))
+        if (slot == 0)
         {
-            return (TBuilder)builder;
+            if (firstBuilder is TBuilder first)
+            {
+                return first;
+            }
+
+            var created = create();
+            firstBuilder = created;
+            return created;
         }
 
-        var created = create();
-        builders.Add(fieldNumber, created!);
-        return created;
+        additionalBuilders ??= new object?[slotCount - 1];
+        if (additionalBuilders[slot - 1] is TBuilder builder)
+        {
+            return builder;
+        }
+
+        var additional = create();
+        additionalBuilders[slot - 1] = additional;
+        return additional;
+    }
+
+    public bool TryGet<TBuilder>(int slot, out TBuilder builder)
+    {
+        var value = slot == 0 ? firstBuilder : additionalBuilders?[slot - 1];
+        if (value is TBuilder typed)
+        {
+            builder = typed;
+            return true;
+        }
+
+        builder = default!;
+        return false;
     }
 }
 
@@ -156,7 +182,8 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
             new StructureProtoMessageReader<T, TBuilder>(
                 schema.CreateTypedBuilder,
                 schema.Build,
-                visitor.Readers
+                visitor.Readers,
+                visitor.StateSlotCount
             )
         );
     }
@@ -236,7 +263,8 @@ internal sealed class MessageReaderVisitor(ProtoValueReaderCompiler compiler)
         return new StructureProtoMessageReader<T, TBuilder>(
             schema.CreateTypedBuilder,
             schema.Build,
-            visitor.Readers
+            visitor.Readers,
+            visitor.StateSlotCount
         );
     }
 
@@ -434,8 +462,11 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
 ) : IMemberVisitor<TContainer, TBuilder>
 {
     private readonly List<IProtoFieldReader<TBuilder>> readers = [];
+    private int stateSlotCount;
 
     public IReadOnlyList<IProtoFieldReader<TBuilder>> Readers => readers;
+
+    public int StateSlotCount => stateSlotCount;
 
     public void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member)
     {
@@ -450,8 +481,18 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
         readers.Add(
             target switch
             {
-                IListSchema list => CreateListReader(member, (dynamic)list, fieldNumber),
-                IMapSchema map => CreateMapReader(member, (dynamic)map, fieldNumber),
+                IListSchema list => CreateListReader(
+                    member,
+                    (dynamic)list,
+                    fieldNumber,
+                    stateSlotCount++
+                ),
+                IMapSchema map => CreateMapReader(
+                    member,
+                    (dynamic)map,
+                    fieldNumber,
+                    stateSlotCount++
+                ),
                 _ => new ValueProtoFieldReader<TContainer, TBuilder, TValue>(
                     member,
                     fieldNumber,
@@ -483,12 +524,14 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
     > CreateListReader<TValue, TElement, TCollectionBuilder>(
         IMemberSchema<TContainer, TBuilder, TValue> member,
         IListSchema<TValue, TElement, TCollectionBuilder> list,
-        int fieldNumber
+        int fieldNumber,
+        int stateSlot
     ) =>
         new(
             member,
             list,
             fieldNumber,
+            stateSlot,
             compiler.CompileValue(
                 list.TypedElementMember.TargetSchema,
                 list.TypedElementMember.MemberTraits
@@ -504,12 +547,14 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
     > CreateMapReader<TValue, TMapValue, TMapBuilder>(
         IMemberSchema<TContainer, TBuilder, TValue> member,
         IMapSchema<TValue, TMapValue, TMapBuilder> map,
-        int fieldNumber
+        int fieldNumber,
+        int stateSlot
     ) =>
         new(
             member,
             map,
             fieldNumber,
+            stateSlot,
             ProtoWire.IsSparse((Schema)map),
             compiler.CompileValue(
                 map.TypedValueMember.TargetSchema,
@@ -530,7 +575,7 @@ internal sealed class ValueProtoFieldReader<TContainer, TBuilder, TValue>(
         TBuilder builder,
         ref ProtoReader reader,
         WireType wireType,
-        ProtoReadState state
+        ref ProtoReadState state
     )
     {
         try
@@ -543,8 +588,6 @@ internal sealed class ValueProtoFieldReader<TContainer, TBuilder, TValue>(
             throw;
         }
     }
-
-    public void Complete(TBuilder builder, ProtoReadState state) { }
 }
 
 internal sealed class ListProtoFieldReader<
@@ -557,8 +600,9 @@ internal sealed class ListProtoFieldReader<
     IMemberSchema<TContainer, TBuilder, TCollection> member,
     IListSchema<TCollection, TElement, TCollectionBuilder> list,
     int fieldNumber,
+    int stateSlot,
     IProtoValueReader<TElement> elementReader
-) : IProtoFieldReader<TBuilder>
+) : IProtoFieldReader<TBuilder>, IProtoFieldCompleter<TBuilder>
 {
     public int FieldNumber { get; } = fieldNumber;
 
@@ -566,10 +610,10 @@ internal sealed class ListProtoFieldReader<
         TBuilder builder,
         ref ProtoReader reader,
         WireType wireType,
-        ProtoReadState state
+        ref ProtoReadState state
     )
     {
-        var accumulator = state.GetOrCreate(FieldNumber, list.CreateTypedBuilder);
+        var accumulator = state.GetOrCreate(stateSlot, list.CreateTypedBuilder);
         var element = ProtoWire.Unwrap(list.ElementSchema);
         if (wireType == WireType.Len && ProtoWire.IsPackableScalar(element.Kind))
         {
@@ -590,10 +634,10 @@ internal sealed class ListProtoFieldReader<
         list.Add(accumulator, elementReader.ReadBody(ref reader, wireType));
     }
 
-    public void Complete(TBuilder builder, ProtoReadState state)
+    public void Complete(TBuilder builder, ref ProtoReadState state)
     {
-        var accumulator = state.WasSeen(FieldNumber)
-            ? state.GetOrCreate(FieldNumber, list.CreateTypedBuilder)
+        var accumulator = state.TryGet<TCollectionBuilder>(stateSlot, out var existing)
+            ? existing
             : list.CreateTypedBuilder();
         member.SetValue(builder, list.Build(accumulator));
     }
@@ -603,9 +647,10 @@ internal sealed class MapProtoFieldReader<TContainer, TBuilder, TDictionary, TVa
     IMemberSchema<TContainer, TBuilder, TDictionary> member,
     IMapSchema<TDictionary, TValue, TMapBuilder> map,
     int fieldNumber,
+    int stateSlot,
     bool sparse,
     IProtoValueReader<TValue> valueReader
-) : IProtoFieldReader<TBuilder>
+) : IProtoFieldReader<TBuilder>, IProtoFieldCompleter<TBuilder>
 {
     public int FieldNumber { get; } = fieldNumber;
 
@@ -617,17 +662,17 @@ internal sealed class MapProtoFieldReader<TContainer, TBuilder, TDictionary, TVa
         TBuilder builder,
         ref ProtoReader reader,
         WireType wireType,
-        ProtoReadState state
+        ref ProtoReadState state
     )
     {
-        var accumulator = state.GetOrCreate(FieldNumber, map.CreateTypedBuilder);
+        var accumulator = state.GetOrCreate(stateSlot, map.CreateTypedBuilder);
         ReadMapEntry(accumulator, reader.ReadLengthDelimited());
     }
 
-    public void Complete(TBuilder builder, ProtoReadState state)
+    public void Complete(TBuilder builder, ref ProtoReadState state)
     {
-        var accumulator = state.WasSeen(FieldNumber)
-            ? state.GetOrCreate(FieldNumber, map.CreateTypedBuilder)
+        var accumulator = state.TryGet<TMapBuilder>(stateSlot, out var existing)
+            ? existing
             : map.CreateTypedBuilder();
         member.SetValue(builder, map.Build(accumulator));
     }
@@ -696,35 +741,70 @@ internal sealed class InlinedProtoUnionCaseReader<TContainer, TBuilder, TUnion, 
         TBuilder builder,
         ref ProtoReader reader,
         WireType wireType,
-        ProtoReadState state
+        ref ProtoReadState state
     )
     {
         member.SetValue(builder, unionCase.Create(valueReader.ReadBody(ref reader, wireType)));
     }
-
-    public void Complete(TBuilder builder, ProtoReadState state) { }
 }
 
-internal sealed class StructureProtoMessageReader<T, TBuilder>(
-    Func<TBuilder> createBuilder,
-    Func<TBuilder, T> build,
-    IReadOnlyList<IProtoFieldReader<TBuilder>> fieldReaders
-) : IProtoMessageReader<T>
+internal sealed class StructureProtoMessageReader<T, TBuilder> : IProtoMessageReader<T>
 {
-    private readonly Dictionary<int, IProtoFieldReader<TBuilder>> readersByField =
-        fieldReaders.ToDictionary(reader => reader.FieldNumber);
+    private const int MaxDenseFieldNumber = 256;
+
+    private readonly Func<TBuilder> createBuilder;
+    private readonly Func<TBuilder, T> build;
+    private readonly IReadOnlyList<IProtoFieldCompleter<TBuilder>> completers;
+    private readonly IProtoFieldReader<TBuilder>?[]? denseReaders;
+    private readonly Dictionary<int, IProtoFieldReader<TBuilder>>? sparseReaders;
+    private readonly int stateSlotCount;
+
+    public StructureProtoMessageReader(
+        Func<TBuilder> createBuilder,
+        Func<TBuilder, T> build,
+        IReadOnlyList<IProtoFieldReader<TBuilder>> fieldReaders,
+        int stateSlotCount
+    )
+    {
+        this.createBuilder = createBuilder;
+        this.build = build;
+        this.stateSlotCount = stateSlotCount;
+        completers = fieldReaders.OfType<IProtoFieldCompleter<TBuilder>>().ToArray();
+
+        var maxFieldNumber =
+            fieldReaders.Count == 0 ? 0 : fieldReaders.Max(reader => reader.FieldNumber);
+        if (maxFieldNumber <= MaxDenseFieldNumber)
+        {
+            denseReaders = new IProtoFieldReader<TBuilder>?[maxFieldNumber + 1];
+            foreach (var fieldReader in fieldReaders)
+            {
+                if (denseReaders[fieldReader.FieldNumber] is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate protobuf field number {fieldReader.FieldNumber}."
+                    );
+                }
+
+                denseReaders[fieldReader.FieldNumber] = fieldReader;
+            }
+        }
+        else
+        {
+            sparseReaders = fieldReaders.ToDictionary(reader => reader.FieldNumber);
+        }
+    }
 
     public T Read(ReadOnlySpan<byte> bytes)
     {
         var builder = createBuilder();
-        var state = new ProtoReadState();
+        var state = new ProtoReadState(stateSlotCount);
         var reader = new ProtoReader(bytes);
         while (!reader.End)
         {
             var (number, wireType) = reader.ReadTag();
-            if (readersByField.TryGetValue(number, out var fieldReader))
+            if (TryGetFieldReader(number, out var fieldReader))
             {
-                fieldReader.ReadInto(builder, ref reader, wireType, state);
+                fieldReader.ReadInto(builder, ref reader, wireType, ref state);
             }
             else
             {
@@ -732,12 +812,32 @@ internal sealed class StructureProtoMessageReader<T, TBuilder>(
             }
         }
 
-        foreach (var fieldReader in fieldReaders)
+        foreach (var completer in completers)
         {
-            fieldReader.Complete(builder, state);
+            completer.Complete(builder, ref state);
         }
 
         return build(builder);
+    }
+
+    private bool TryGetFieldReader(int fieldNumber, out IProtoFieldReader<TBuilder> fieldReader)
+    {
+        if (denseReaders is not null)
+        {
+            if (
+                (uint)fieldNumber < (uint)denseReaders.Length
+                && denseReaders[fieldNumber] is { } denseReader
+            )
+            {
+                fieldReader = denseReader;
+                return true;
+            }
+
+            fieldReader = default!;
+            return false;
+        }
+
+        return sparseReaders!.TryGetValue(fieldNumber, out fieldReader!);
     }
 }
 

--- a/packages/NSmithy.Codecs.Proto/ProtoWire.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWire.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Globalization;
 using System.Numerics;
@@ -20,15 +21,18 @@ internal enum WireType : byte
 }
 
 /// <summary>
-/// A minimal append-only protobuf encoder. Nested messages, maps, and unions are encoded by
-/// serializing the child into its own buffer and embedding it as a length-delimited field, which
-/// keeps the writer single-pass and the code easy to follow at the cost of some intermediate
-/// allocations — appropriate for the current exploration.
+/// A minimal append-only protobuf encoder backed by a pooled buffer. Nested messages reserve their
+/// length prefix in this buffer and backpatch it when complete.
 /// </summary>
-internal sealed class ProtoWriter
+internal sealed class ProtoWriter : IDisposable
 {
-    private byte[] buffer = new byte[64];
+    private byte[] buffer;
     private int length;
+
+    public ProtoWriter(int initialCapacity = 64)
+    {
+        buffer = ArrayPool<byte>.Shared.Rent(Math.Max(initialCapacity, 64));
+    }
 
     public int Length => length;
 
@@ -68,6 +72,74 @@ internal sealed class ProtoWriter
         Append(value);
     }
 
+    public void WriteLengthDelimitedUtf8(string value)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        WriteVarint((ulong)byteCount);
+        EnsureCapacity(byteCount);
+        length += Encoding.UTF8.GetBytes(value, buffer.AsSpan(length, byteCount));
+    }
+
+    public int BeginLengthDelimited()
+    {
+        var prefixOffset = length;
+        Append(0);
+        return prefixOffset;
+    }
+
+    public void EndLengthDelimited(int prefixOffset)
+    {
+        if ((uint)prefixOffset >= (uint)length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(prefixOffset));
+        }
+
+        var valueLength = length - prefixOffset - 1;
+        var prefixLength = VarintLength((ulong)valueLength);
+        if (prefixLength > 1)
+        {
+            var shift = prefixLength - 1;
+            EnsureCapacity(shift);
+            buffer
+                .AsSpan(prefixOffset + 1, valueLength)
+                .CopyTo(buffer.AsSpan(prefixOffset + prefixLength));
+            length += shift;
+        }
+
+        WriteVarintAt(prefixOffset, (ulong)valueLength);
+    }
+
+    public void Rewind(int position)
+    {
+        if ((uint)position > (uint)length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(position));
+        }
+
+        length = position;
+    }
+
+    public void Dispose()
+    {
+        var rented = buffer;
+        buffer = [];
+        length = 0;
+        if (rented.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public void Reset(int initialCapacity)
+    {
+        if (buffer.Length != 0)
+        {
+            throw new InvalidOperationException("Proto writer is already in use.");
+        }
+
+        buffer = ArrayPool<byte>.Shared.Rent(Math.Max(initialCapacity, 64));
+    }
+
     /// <summary>ZigZag-encodes a signed value for <c>sint32</c>/<c>sint64</c> fields.</summary>
     public static ulong ZigZag(long value) => (ulong)((value << 1) ^ (value >> 63));
 
@@ -86,6 +158,8 @@ internal sealed class ProtoWriter
 
     private void EnsureCapacity(int extra)
     {
+        ObjectDisposedException.ThrowIf(buffer.Length == 0, this);
+
         if (length + extra <= buffer.Length)
         {
             return;
@@ -97,7 +171,58 @@ internal sealed class ProtoWriter
             capacity *= 2;
         }
 
-        Array.Resize(ref buffer, capacity);
+        var replacement = ArrayPool<byte>.Shared.Rent(capacity);
+        buffer.AsSpan(0, length).CopyTo(replacement);
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = replacement;
+    }
+
+    private static int VarintLength(ulong value)
+    {
+        var result = 1;
+        while (value >= 0x80)
+        {
+            result++;
+            value >>= 7;
+        }
+
+        return result;
+    }
+
+    private void WriteVarintAt(int offset, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            buffer[offset++] = (byte)(value | 0x80);
+            value >>= 7;
+        }
+
+        buffer[offset] = (byte)value;
+    }
+}
+
+internal static class ProtoWriterCache
+{
+    [ThreadStatic]
+    private static ProtoWriter? cached;
+
+    public static ProtoWriter Rent(int initialCapacity)
+    {
+        var writer = cached;
+        cached = null;
+        if (writer is null)
+        {
+            return new ProtoWriter(initialCapacity);
+        }
+
+        writer.Reset(initialCapacity);
+        return writer;
+    }
+
+    public static void Return(ProtoWriter writer)
+    {
+        writer.Dispose();
+        cached ??= writer;
     }
 }
 
@@ -330,7 +455,7 @@ internal static class ProtoWire
         }
     }
 
-    internal static byte[] EncodeTimestamp(DateTimeOffset value)
+    internal static void EncodeTimestamp(ProtoWriter writer, DateTimeOffset value)
     {
         var ticks = value.UtcTicks - DateTimeOffset.UnixEpoch.UtcTicks;
         var seconds = Math.DivRem(ticks, TimeSpan.TicksPerSecond, out var remainderTicks);
@@ -341,7 +466,6 @@ internal static class ProtoWire
         }
 
         var nanos = (int)remainderTicks * 100;
-        var writer = new ProtoWriter();
         if (seconds != 0)
         {
             writer.WriteTag(1, WireType.Varint);
@@ -353,8 +477,6 @@ internal static class ProtoWire
             writer.WriteTag(2, WireType.Varint);
             writer.WriteVarint((ulong)(long)nanos);
         }
-
-        return writer.ToArray();
     }
 
     internal static DateTimeOffset DecodeTimestamp(ReadOnlySpan<byte> bytes)
@@ -503,7 +625,7 @@ internal static class ProtoWire
         {
             case ShapeKind.String:
                 writer.WriteTag(ValueStringField, WireType.Len);
-                writer.WriteLengthDelimited(Encoding.UTF8.GetBytes((string)(object)value));
+                writer.WriteLengthDelimitedUtf8((string)(object)value);
                 break;
             case ShapeKind.Boolean:
                 writer.WriteTag(ValueBoolField, WireType.Varint);
@@ -595,41 +717,41 @@ internal static class ProtoWire
                 break;
             case DocumentKind.String:
                 writer.WriteTag(ValueStringField, WireType.Len);
-                writer.WriteLengthDelimited(Encoding.UTF8.GetBytes(document.AsString()));
+                writer.WriteLengthDelimitedUtf8(document.AsString());
                 break;
             case DocumentKind.Array:
             {
-                var list = new ProtoWriter();
+                writer.WriteTag(ValueListField, WireType.Len);
+                var listPrefix = writer.BeginLengthDelimited();
                 foreach (var item in document.AsArray())
                 {
-                    var element = new ProtoWriter();
-                    EncodeDocumentValue(element, item);
-                    list.WriteTag(1, WireType.Len);
-                    list.WriteLengthDelimited(element.ToArray());
+                    writer.WriteTag(1, WireType.Len);
+                    var elementPrefix = writer.BeginLengthDelimited();
+                    EncodeDocumentValue(writer, item);
+                    writer.EndLengthDelimited(elementPrefix);
                 }
 
-                writer.WriteTag(ValueListField, WireType.Len);
-                writer.WriteLengthDelimited(list.ToArray());
+                writer.EndLengthDelimited(listPrefix);
                 break;
             }
             case DocumentKind.Object:
             {
-                var structWriter = new ProtoWriter();
+                writer.WriteTag(ValueStructField, WireType.Len);
+                var structPrefix = writer.BeginLengthDelimited();
                 foreach (var (key, item) in document.AsObject())
                 {
-                    var entry = new ProtoWriter();
-                    entry.WriteTag(1, WireType.Len);
-                    entry.WriteLengthDelimited(Encoding.UTF8.GetBytes(key));
-                    var element = new ProtoWriter();
-                    EncodeDocumentValue(element, item);
-                    entry.WriteTag(2, WireType.Len);
-                    entry.WriteLengthDelimited(element.ToArray());
-                    structWriter.WriteTag(1, WireType.Len);
-                    structWriter.WriteLengthDelimited(entry.ToArray());
+                    writer.WriteTag(1, WireType.Len);
+                    var entryPrefix = writer.BeginLengthDelimited();
+                    writer.WriteTag(1, WireType.Len);
+                    writer.WriteLengthDelimitedUtf8(key);
+                    writer.WriteTag(2, WireType.Len);
+                    var elementPrefix = writer.BeginLengthDelimited();
+                    EncodeDocumentValue(writer, item);
+                    writer.EndLengthDelimited(elementPrefix);
+                    writer.EndLengthDelimited(entryPrefix);
                 }
 
-                writer.WriteTag(ValueStructField, WireType.Len);
-                writer.WriteLengthDelimited(structWriter.ToArray());
+                writer.EndLengthDelimited(structPrefix);
                 break;
             }
             default:

--- a/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
@@ -367,23 +367,19 @@ internal sealed class ScalarProtoValueWriter<T>(
                 writer.WriteFixed64(BitConverter.DoubleToUInt64Bits((double)(object)value!));
                 break;
             case ShapeKind.String:
-                writer.WriteLengthDelimited(Encoding.UTF8.GetBytes((string)(object)value!));
+                writer.WriteLengthDelimitedUtf8((string)(object)value!);
                 break;
             case ShapeKind.Blob:
                 writer.WriteLengthDelimited((byte[])(object)value!);
                 break;
             case ShapeKind.BigInteger:
-                writer.WriteLengthDelimited(
-                    Encoding.UTF8.GetBytes(
-                        ((BigInteger)(object)value!).ToString(CultureInfo.InvariantCulture)
-                    )
+                writer.WriteLengthDelimitedUtf8(
+                    ((BigInteger)(object)value!).ToString(CultureInfo.InvariantCulture)
                 );
                 break;
             case ShapeKind.BigDecimal:
-                writer.WriteLengthDelimited(
-                    Encoding.UTF8.GetBytes(
-                        ((decimal)(object)value!).ToString(CultureInfo.InvariantCulture)
-                    )
+                writer.WriteLengthDelimitedUtf8(
+                    ((decimal)(object)value!).ToString(CultureInfo.InvariantCulture)
                 );
                 break;
             case ShapeKind.IntEnum:
@@ -392,9 +388,9 @@ internal sealed class ScalarProtoValueWriter<T>(
                 );
                 break;
             case ShapeKind.Timestamp:
-                writer.WriteLengthDelimited(
-                    ProtoWire.EncodeTimestamp((DateTimeOffset)(object)value!)
-                );
+                var timestamp = writer.BeginLengthDelimited();
+                ProtoWire.EncodeTimestamp(writer, (DateTimeOffset)(object)value!);
+                writer.EndLengthDelimited(timestamp);
                 break;
             case ShapeKind.Enum:
                 writer.WriteVarint(
@@ -436,9 +432,9 @@ internal sealed class MessageProtoValueWriter<T>(IProtoMessageWriter<T> messageW
 
     public void WriteBody(ProtoWriter writer, T value)
     {
-        var sub = new ProtoWriter();
-        messageWriter.Write(sub, value);
-        writer.WriteLengthDelimited(sub.ToArray());
+        var prefix = writer.BeginLengthDelimited();
+        messageWriter.Write(writer, value);
+        writer.EndLengthDelimited(prefix);
     }
 }
 
@@ -448,9 +444,9 @@ internal sealed class DocumentProtoValueWriter : IProtoValueWriter<Document>
 
     public void WriteBody(ProtoWriter writer, Document value)
     {
-        var sub = new ProtoWriter();
-        ProtoWire.EncodeDocumentValue(sub, value);
-        writer.WriteLengthDelimited(sub.ToArray());
+        var prefix = writer.BeginLengthDelimited();
+        ProtoWire.EncodeDocumentValue(writer, value);
+        writer.EndLengthDelimited(prefix);
     }
 }
 
@@ -572,16 +568,21 @@ internal sealed class ListProtoMemberPlan<TCollection, TElement>(
 
         if (packable)
         {
-            var packed = new ProtoWriter();
+            var fieldOffset = writer.Length;
+            writer.WriteTag(fieldNumber, WireType.Len);
+            var prefix = writer.BeginLengthDelimited();
             foreach (var item in list.GetElements(memberValue))
             {
-                elementWriter.WriteBody(packed, item);
+                elementWriter.WriteBody(writer, item);
             }
 
-            if (packed.Length > 0)
+            if (writer.Length == prefix + 1)
             {
-                writer.WriteTag(fieldNumber, WireType.Len);
-                writer.WriteLengthDelimited(packed.ToArray());
+                writer.Rewind(fieldOffset);
+            }
+            else
+            {
+                writer.EndLengthDelimited(prefix);
             }
 
             return;
@@ -615,23 +616,23 @@ internal sealed class MapProtoMemberPlan<TDictionary, TValue>(
 
         foreach (var entry in map.GetEntries(memberValue))
         {
-            var sub = new ProtoWriter();
-            sub.WriteTag(1, WireType.Len);
-            sub.WriteLengthDelimited(Encoding.UTF8.GetBytes(entry.Key));
+            writer.WriteTag(fieldNumber, WireType.Len);
+            var entryPrefix = writer.BeginLengthDelimited();
+            writer.WriteTag(1, WireType.Len);
+            writer.WriteLengthDelimitedUtf8(entry.Key);
 
             if (sparse)
             {
-                sub.WriteTag(2, WireType.Len);
-                sparseWriter.WriteBody(sub, entry.Value);
+                writer.WriteTag(2, WireType.Len);
+                sparseWriter.WriteBody(writer, entry.Value);
             }
             else if (entry.Value is not null)
             {
-                sub.WriteTag(2, valueWriter.WireType);
-                valueWriter.WriteBody(sub, entry.Value);
+                writer.WriteTag(2, valueWriter.WireType);
+                valueWriter.WriteBody(writer, entry.Value);
             }
 
-            writer.WriteTag(fieldNumber, WireType.Len);
-            writer.WriteLengthDelimited(sub.ToArray());
+            writer.EndLengthDelimited(entryPrefix);
         }
     }
 }
@@ -640,9 +641,9 @@ internal sealed class SparseScalarValueWriter<T>(Schema<T> schema)
 {
     public void WriteBody(ProtoWriter writer, T? value)
     {
-        var sub = new ProtoWriter();
-        ProtoWire.EncodeScalarValueMessage(sub, schema, value);
-        writer.WriteLengthDelimited(sub.ToArray());
+        var prefix = writer.BeginLengthDelimited();
+        ProtoWire.EncodeScalarValueMessage(writer, schema, value);
+        writer.EndLengthDelimited(prefix);
     }
 }
 

--- a/tests/NSmithy.Tests/Codecs/Proto/ProtoCodecTests.cs
+++ b/tests/NSmithy.Tests/Codecs/Proto/ProtoCodecTests.cs
@@ -670,6 +670,29 @@ public sealed class ProtoCodecTests
         Assert.Equal("y", result["tags"].AsArray()[1].AsString());
     }
 
+    [Fact]
+    public void BackpatchesMultiByteNestedMessageLengths()
+    {
+        var codec = ProtoCodec.FromSchema(
+            Schemas
+                .Structure<Envelope, EnvelopeBuilder>(ShapeId.Parse("test#LargeEnvelope"))
+                .Required(
+                    "payload",
+                    x => x.Payload,
+                    (b, v) => b.Payload = v,
+                    Schemas.Document,
+                    Field(1)
+                )
+                .Build(() => new EnvelopeBuilder(), b => new Envelope(b.Payload))
+        );
+        var payload = Document.From(new string('x', 128));
+
+        var bytes = codec.Serialize(new Envelope(payload));
+
+        Assert.Equal([0x0A, 0x83, 0x01, 0x1A, 0x80, 0x01], bytes[..6]);
+        Assert.Equal(payload, codec.Deserialize(bytes).Payload);
+    }
+
     /// <summary>
     /// A framework shape carries no <c>@protoIndex</c> — it comes from the runtime, not a model file
     /// — so the codec numbers its members by declaration order instead. The server runtime can


### PR DESCRIPTION
Depends on #145.

## Summary

- pool and backpatch Proto write buffers
- replace reader dictionaries with dense stack-local state
- transfer codec-owned collection builders without copying

## Results

- client: 1.35x / 1.98x Grpc.Net time for one / 100 items
- deserialize: 1.80-2.00x Google.Protobuf time, 1.24-1.88x allocations
- serialize: 1.67-1.70x time, 0.79-1.53x allocations
- 100-item client: 50.8 us / 148.5 KB -> 35.8 us / 94.7 KB

## Verification

- `just build`
- `just test` (1,643 .NET tests plus Gradle)
- 90 benchmark parity tests
- all 101 microbenchmark cases
