### PR TITLE
Match fake responses against @examples inputs, including error examples

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -2,6 +2,8 @@
  * Fake client generator, opt-in via generateFakes. Emits:
  *   - `Fake{Service}Client : I{Service}Client` whose methods return canned responses synthesized
  *     by FakeValueSynthesizer, with no network call, serialization, or protocol involvement.
+ *     Operations with multiple @examples entries (or error examples) match the incoming input
+ *     against the example inputs via FakeExampleMatcher to pick the response.
  *
  * Operation methods are virtual so a subclass can replace individual operations. Because no wire
  * protocol is involved, every operation responds, including event-stream operations the real
@@ -12,7 +14,6 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
-import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
 import java.util.List;
@@ -32,12 +33,14 @@ public final class FakeClientGenerator implements Runnable {
   private final CSharpWriter writer;
   private final ServiceShape service;
   private final FakeValueSynthesizer values;
+  private final FakeExampleMatcher matcher;
 
   public FakeClientGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, "fake client");
+    this.matcher = new FakeExampleMatcher(c, values);
   }
 
   @Override
@@ -58,9 +61,12 @@ public final class FakeClientGenerator implements Runnable {
     writer.writeXmlDocs(
         "Fake "
             + interfaceName
-            + " returning canned responses without any network call: the output of each"
-            + " operation's first non-error @examples entry when present, otherwise placeholder"
-            + " values synthesized from the model. Responses are deterministic. Override an"
+            + " returning canned responses without any network call. When an operation has"
+            + " multiple @examples entries the input is matched against the example inputs in"
+            + " model order (members absent from an example are wildcards) and the first match"
+            + " decides the response; a matched error example throws the modeled error. Otherwise"
+            + " the first non-error @examples output is returned when present, placeholder values"
+            + " synthesized from the model otherwise. Responses are deterministic. Override an"
             + " operation method in a subclass to replace individual operations.",
         Map.of());
     writer.write("public class $L : $L", fakeClass, interfaceName);
@@ -75,6 +81,7 @@ public final class FakeClientGenerator implements Runnable {
             writer.write("");
           }
           writer.write("public virtual void Dispose() { }");
+          matcher.writePendingMatchers(writer);
           values.writePendingIterators(writer);
         });
   }
@@ -82,17 +89,8 @@ public final class FakeClientGenerator implements Runnable {
   // ---------------- operation methods ----------------
 
   private void writeOperationMethod(OperationShape op) {
-    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     writer.write("public virtual $L", ClientGenerator.operationSignature(context, op));
-    if (!hasOutput) {
-      writer.openBlock(
-          "{", "}", () -> writer.write("return System.Threading.Tasks.Task.CompletedTask;"));
-      return;
-    }
-
-    String expr = values.outputExpr(op);
-    writer.openBlock(
-        "{", "}", () -> writer.write("return System.Threading.Tasks.Task.FromResult($L);", expr));
+    writer.openBlock("{", "}", () -> matcher.writeOperationBody(writer, op));
   }
 
   /**

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
@@ -1,0 +1,350 @@
+/*
+ * Example input matching for the generated fakes. When an operation has more than one @examples
+ * entry, or any error example, the fake picks its response by matching the incoming input against
+ * each example's input in model order; the first match wins. Matching is a subset comparison at
+ * every nesting level: members present in the example input must equal the corresponding input
+ * property, members absent from the example are wildcards. A matched non-error example returns
+ * that example's output, a matched error example throws the modeled error, and when nothing
+ * matches the fake falls back to the canned response FakeValueSynthesizer produces. Operations
+ * with a single non-error example generate no matching code at all, so their responses stay
+ * exactly as before.
+ */
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
+import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.ExamplesTrait;
+
+final class FakeExampleMatcher {
+
+  private static final Logger LOGGER = Logger.getLogger(FakeExampleMatcher.class.getName());
+
+  private final GenerationContext context;
+  private final FakeValueSynthesizer values;
+  private final List<PendingMatcher> pendingMatchers = new ArrayList<>();
+
+  private record PendingMatcher(
+      String name, String title, String inputType, List<String> conditions) {}
+
+  private record Arm(String matchMethod, String title, String statement) {}
+
+  FakeExampleMatcher(GenerationContext context, FakeValueSynthesizer values) {
+    this.context = context;
+    this.values = values;
+  }
+
+  /**
+   * Writes the statements of a fake operation method: one match arm per @examples entry in model
+   * order, then the unconditional fallback return.
+   */
+  void writeOperationBody(CSharpWriter writer, OperationShape op) {
+    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
+    for (Arm arm : arms(op)) {
+      writer.write("// $L", quote(arm.title()));
+      writer.write("if ($L(input))", arm.matchMethod());
+      writer.openBlock("{", "}", () -> writer.write("$L", arm.statement()));
+    }
+    if (hasOutput) {
+      writer.write("return System.Threading.Tasks.Task.FromResult($L);", values.outputExpr(op));
+    } else {
+      writer.write("return System.Threading.Tasks.Task.CompletedTask;");
+    }
+  }
+
+  /** Writes the private match-condition methods recorded while writing operation bodies. */
+  void writePendingMatchers(CSharpWriter writer) {
+    for (PendingMatcher matcher : pendingMatchers) {
+      writer.write("");
+      writer.write(
+          "// True when the input matches the $L @examples entry.", quote(matcher.title()));
+      writer.write("private static bool $L($L input)", matcher.name(), matcher.inputType());
+      writer.openBlock(
+          "{",
+          "}",
+          () -> {
+            for (String condition : matcher.conditions()) {
+              writer.write("if (!($L))", condition);
+              writer.openBlock("{", "}", () -> writer.write("return false;"));
+            }
+            writer.write("return true;");
+          });
+    }
+  }
+
+  private List<Arm> arms(OperationShape op) {
+    List<ExamplesTrait.Example> examples =
+        op.getTrait(ExamplesTrait.class).map(ExamplesTrait::getExamples).orElse(List.of());
+    if (examples.isEmpty()) {
+      return List.of();
+    }
+    // A single non-error example is already the unconditional fallback response.
+    if (examples.size() == 1 && examples.get(0).getError().isEmpty()) {
+      return List.of();
+    }
+    if (ShapeSupport.isUnit(op.getInputShape())) {
+      LOGGER.warning(
+          () ->
+              op.getId()
+                  + " has multiple or error @examples but no input to match; the "
+                  + values.subject()
+                  + " always returns the fallback response.");
+      return List.of();
+    }
+
+    Model model = context.model();
+    StructureShape input = model.expectShape(op.getInputShape(), StructureShape.class);
+    String inputType = values.qualifiedType(input);
+    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
+    String outputType =
+        hasOutput ? values.qualifiedType(model.expectShape(op.getOutputShape())) : null;
+
+    List<Arm> arms = new ArrayList<>();
+    for (int i = 0; i < examples.size(); i++) {
+      ExamplesTrait.Example example = examples.get(i);
+      String name = "Matches" + CSharpNaming.typeName(op.getId().getName()) + "Example" + i;
+      List<String> conditions = new ArrayList<>();
+      structureConditions("input", input, example.getInput(), conditions, new int[] {0});
+      pendingMatchers.add(new PendingMatcher(name, example.getTitle(), inputType, conditions));
+
+      String statement;
+      Optional<ExamplesTrait.ErrorExample> error = example.getError();
+      if (error.isPresent()) {
+        String errorExpr = values.errorExpr(error.get().getShapeId(), error.get().getContent());
+        statement =
+            hasOutput
+                ? "return System.Threading.Tasks.Task.FromException<"
+                    + outputType
+                    + ">("
+                    + errorExpr
+                    + ");"
+                : "return System.Threading.Tasks.Task.FromException(" + errorExpr + ");";
+      } else if (hasOutput) {
+        ObjectNode output = example.getOutput().orElse(Node.objectNode());
+        statement =
+            "return System.Threading.Tasks.Task.FromResult("
+                + values.outputExprFor(op, output)
+                + ");";
+      } else {
+        statement = "return System.Threading.Tasks.Task.CompletedTask;";
+      }
+      arms.add(new Arm(name, example.getTitle(), statement));
+    }
+    return arms;
+  }
+
+  // ---------------- condition generation ----------------
+
+  /** Adds one condition per member present in the example node; absent members are wildcards. */
+  private void structureConditions(
+      String subject, StructureShape shape, ObjectNode node, List<String> out, int[] counter) {
+    Model model = context.model();
+    for (Map.Entry<String, Node> entry : node.getStringMap().entrySet()) {
+      MemberShape member = shape.getMember(entry.getKey()).orElse(null);
+      if (member == null) {
+        LOGGER.warning(
+            () ->
+                "Example input member "
+                    + entry.getKey()
+                    + " does not exist on "
+                    + shape.getId()
+                    + "; the "
+                    + values.subject()
+                    + " ignores it when matching.");
+        continue;
+      }
+      Node valueNode = entry.getValue();
+      if (valueNode.isNullNode()) {
+        continue;
+      }
+      if (ShapeSupport.isEventStreamMember(model, member)
+          || ShapeSupport.isStreamingBlobMember(model, member)) {
+        LOGGER.warning(
+            () ->
+                "Example input member "
+                    + member.getId()
+                    + " is a streaming member; the "
+                    + values.subject()
+                    + " ignores it when matching.");
+        continue;
+      }
+      valueConditions(
+          subject + "." + CSharpNaming.propertyName(member.getMemberName()),
+          model.expectShape(member.getTarget()),
+          valueNode,
+          out,
+          counter);
+    }
+  }
+
+  private void valueConditions(
+      String expr, Shape target, Node node, List<String> out, int[] counter) {
+    Model model = context.model();
+    switch (target.getType()) {
+      case BOOLEAN ->
+          out.add(expr + " == " + (node.expectBooleanNode().getValue() ? "true" : "false"));
+      case STRING ->
+          out.add(expr + " == " + CSharpNaming.formatString(node.expectStringNode().getValue()));
+      case ENUM -> out.add(expr + " == " + values.enumExpr(target, node));
+      case INT_ENUM -> out.add(expr + " == " + values.intEnumExpr(target, node));
+      case BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BIG_INTEGER, BIG_DECIMAL ->
+          numberConditions(expr, target, node, out, counter);
+      case TIMESTAMP -> out.add(expr + " == " + values.timestampExpr(node));
+      case BLOB -> {
+        String v = nextVar(counter);
+        out.add(expr + " is { } " + v);
+        out.add(
+            "System.Linq.Enumerable.SequenceEqual("
+                + v
+                + ", "
+                + values.blobBytesExpr(node, "")
+                + ")");
+      }
+      case DOCUMENT ->
+          LOGGER.warning(
+              () ->
+                  "Example input value for document member at "
+                      + expr
+                      + " cannot be compared; the "
+                      + values.subject()
+                      + " treats it as always matching.");
+      case STRUCTURE -> {
+        if (ShapeSupport.isUnit(target.getId())) {
+          return;
+        }
+        String v = nextVar(counter);
+        out.add(expr + " is { } " + v);
+        structureConditions(
+            v, target.asStructureShape().orElseThrow(), node.expectObjectNode(), out, counter);
+      }
+      case UNION -> unionConditions(expr, target.asUnionShape().orElseThrow(), node, out, counter);
+      case LIST, SET -> {
+        MemberShape elementMember =
+            target.getType() == ShapeType.LIST
+                ? target.asListShape().map(ListShape::getMember).orElseThrow()
+                : target.asSetShape().orElseThrow().getMember();
+        Shape elementTarget = model.expectShape(elementMember.getTarget());
+        ArrayNode array = node.expectArrayNode();
+        String v = nextVar(counter);
+        out.add(expr + " is { } " + v);
+        out.add(v + ".Values.Count == " + array.size());
+        List<Node> elements = array.getElements();
+        for (int i = 0; i < elements.size(); i++) {
+          Node element = elements.get(i);
+          if (element.isNullNode()) {
+            out.add(v + ".Values[" + i + "] is null");
+          } else {
+            valueConditions(v + ".Values[" + i + "]", elementTarget, element, out, counter);
+          }
+        }
+      }
+      case MAP -> {
+        MapShape map = target.asMapShape().orElseThrow();
+        Shape valueTarget = model.expectShape(map.getValue().getTarget());
+        ObjectNode obj = node.expectObjectNode();
+        String v = nextVar(counter);
+        out.add(expr + " is { } " + v);
+        out.add(v + ".Values.Count == " + obj.size());
+        for (Map.Entry<String, Node> entry : obj.getStringMap().entrySet()) {
+          String mv = nextVar(counter);
+          out.add(
+              v
+                  + ".Values.TryGetValue("
+                  + CSharpNaming.formatString(entry.getKey())
+                  + ", out var "
+                  + mv
+                  + ")");
+          if (entry.getValue().isNullNode()) {
+            out.add(mv + " is null");
+          } else {
+            valueConditions(mv, valueTarget, entry.getValue(), out, counter);
+          }
+        }
+      }
+      default ->
+          LOGGER.warning(
+              () ->
+                  "Example input value at "
+                      + expr
+                      + " has unsupported shape type "
+                      + target.getType()
+                      + "; the "
+                      + values.subject()
+                      + " treats it as always matching.");
+    }
+  }
+
+  private void numberConditions(
+      String expr, Shape target, Node node, List<String> out, int[] counter) {
+    ShapeType type = target.getType();
+    if (node.isStringNode() && (type == ShapeType.FLOAT || type == ShapeType.DOUBLE)) {
+      String csType = type == ShapeType.FLOAT ? "float" : "double";
+      switch (node.expectStringNode().getValue()) {
+        case "NaN" -> {
+          String v = nextVar(counter);
+          out.add(expr + " is { } " + v + " && " + csType + ".IsNaN(" + v + ")");
+        }
+        case "Infinity" -> out.add(expr + " == " + csType + ".PositiveInfinity");
+        case "-Infinity" -> out.add(expr + " == " + csType + ".NegativeInfinity");
+        default -> out.add("false");
+      }
+      return;
+    }
+    out.add(expr + " == " + values.numberExpr(type, node, null, target));
+  }
+
+  private void unionConditions(
+      String expr, UnionShape union, Node node, List<String> out, int[] counter) {
+    ObjectNode obj = node.expectObjectNode();
+    for (Map.Entry<String, Node> entry : obj.getStringMap().entrySet()) {
+      Optional<MemberShape> variant = union.getMember(entry.getKey());
+      if (variant.isEmpty()) {
+        continue;
+      }
+      String variantType =
+          values.qualifiedType(union) + "." + CSharpNaming.typeName(variant.get().getMemberName());
+      String v = nextVar(counter);
+      out.add(expr + " is " + variantType + " " + v);
+      valueConditions(
+          v + ".Value",
+          context.model().expectShape(variant.get().getTarget()),
+          entry.getValue(),
+          out,
+          counter);
+      return;
+    }
+    LOGGER.warning(
+        () ->
+            "Example input value for union at "
+                + expr
+                + " names no known variant; the "
+                + values.subject()
+                + " treats it as always matching.");
+  }
+
+  private static String nextVar(int[] counter) {
+    return "v" + counter[0]++;
+  }
+
+  private static String quote(String title) {
+    return "\"" + title.replace('\n', ' ').replace('\r', ' ') + "\"";
+  }
+}

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -1,8 +1,10 @@
 /*
  * Fake handler generator, opt-in via generateFakes. Emits:
  *   - `Fake{Service}Handler : I{Service}Handler` whose methods return canned responses
- *     synthesized by FakeValueSynthesizer (the first non-error @examples output when present,
- *     deterministic placeholders otherwise).
+ *     synthesized by FakeValueSynthesizer. Operations with multiple @examples entries (or error
+ *     examples) match the incoming input against the example inputs via FakeExampleMatcher to
+ *     pick the response; otherwise the first non-error @examples output is returned when present,
+ *     deterministic placeholders otherwise.
  *
  * The class is registered through the ordinary Add{Service}Handler<T>() extension. Its operation
  * methods are virtual so a subclass can replace individual operations; registering a real
@@ -34,12 +36,14 @@ public final class FakeHandlerGenerator implements Runnable {
   private final CSharpWriter writer;
   private final ServiceShape service;
   private final FakeValueSynthesizer values;
+  private final FakeExampleMatcher matcher;
 
   public FakeHandlerGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, "fake handler");
+    this.matcher = new FakeExampleMatcher(c, values);
   }
 
   @Override
@@ -62,9 +66,12 @@ public final class FakeHandlerGenerator implements Runnable {
     writer.writeXmlDocs(
         "Fake "
             + aggInterface
-            + " returning canned responses: the output of each operation's first non-error"
-            + " @examples entry when present, otherwise placeholder values synthesized from the"
-            + " model. Responses are deterministic. Override an operation method in a subclass, or"
+            + " returning canned responses. When an operation has multiple @examples entries the"
+            + " input is matched against the example inputs in model order (members absent from an"
+            + " example are wildcards) and the first match decides the response; a matched error"
+            + " example throws the modeled error. Otherwise the first non-error @examples output is"
+            + " returned when present, placeholder values synthesized from the model otherwise."
+            + " Responses are deterministic. Override an operation method in a subclass, or"
             + " register a real per-operation handler after this one, to replace individual"
             + " operations.",
         Map.of());
@@ -81,6 +88,7 @@ public final class FakeHandlerGenerator implements Runnable {
             first = false;
             writeOperationMethod(op);
           }
+          matcher.writePendingMatchers(writer);
           values.writePendingIterators(writer);
         });
   }
@@ -88,17 +96,8 @@ public final class FakeHandlerGenerator implements Runnable {
   // ---------------- operation methods ----------------
 
   private void writeOperationMethod(OperationShape op) {
-    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     writer.write("public virtual $L", operationSignature(op));
-    if (!hasOutput) {
-      writer.openBlock(
-          "{", "}", () -> writer.write("return System.Threading.Tasks.Task.CompletedTask;"));
-      return;
-    }
-
-    String expr = values.outputExpr(op);
-    writer.openBlock(
-        "{", "}", () -> writer.write("return System.Threading.Tasks.Task.FromResult($L);", expr));
+    writer.openBlock("{", "}", () -> matcher.writeOperationBody(writer, op));
   }
 
   /** Same delegate shape the handler interfaces declare; see ServerGenerator. */

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
@@ -1,7 +1,8 @@
 /*
  * Shared value synthesis for the generated fakes (FakeHandlerGenerator and FakeClientGenerator).
- * Produces C# expressions for canned operation outputs: the output of the operation's first
- * non-error @examples entry when present, otherwise placeholder values synthesized from the
+ * Produces C# expressions for canned operation outputs and errors: the output of a specific
+ * @examples entry (FakeExampleMatcher picks which one by matching the input), the fallback output
+ * of the operation's first non-error @examples entry, or placeholder values synthesized from the
  * shapes (self-describing strings, first enum and union variants, single-element collections,
  * constraint minimums). All values are compiled in as literals, so responses are deterministic
  * across calls, runs, and regenerations of an unchanged model.
@@ -60,6 +61,10 @@ final class FakeValueSynthesizer {
     this.subject = subject;
   }
 
+  String subject() {
+    return subject;
+  }
+
   /** The full C# expression for the operation's fake output; the output must not be Unit. */
   String outputExpr(OperationShape op) {
     Model model = context.model();
@@ -80,6 +85,60 @@ final class FakeValueSynthesizer {
           "Cannot synthesize a fake output for operation " + op.getId() + ".");
     }
     return expr;
+  }
+
+  /** The C# expression for the operation's output built from a specific @examples output node. */
+  String outputExprFor(OperationShape op, ObjectNode example) {
+    StructureShape output = context.model().expectShape(op.getOutputShape(), StructureShape.class);
+    String expr = structureExpr(output, example, new LinkedHashSet<>(), op);
+    if (expr == null) {
+      throw new CodegenException(
+          "Cannot synthesize a fake output for operation " + op.getId() + ".");
+    }
+    return expr;
+  }
+
+  /**
+   * The C# expression constructing a generated error (an Exception subclass, so the first
+   * constructor parameter is the message and the remaining parameters are camelCase named
+   * arguments) from an @examples error content node. Members absent from the content are omitted
+   * when optional and synthesized as placeholders when required.
+   */
+  String errorExpr(ShapeId errorId, ObjectNode content) {
+    Model model = context.model();
+    StructureShape error = model.expectShape(errorId, StructureShape.class);
+    MemberShape messageMember = ShapeSupport.errorMessageMember(model, error).orElse(null);
+
+    List<String> args = new ArrayList<>();
+    Node messageNode =
+        messageMember == null
+            ? null
+            : content.getMember(messageMember.getMemberName()).orElse(null);
+    args.add(
+        "message: "
+            + (messageNode != null && messageNode.isStringNode()
+                ? CSharpNaming.formatString(messageNode.expectStringNode().getValue())
+                : "null"));
+
+    for (MemberShape member : ShapeSupport.constructorMembers(error, messageMember)) {
+      Node valueNode = content.getMember(member.getMemberName()).orElse(null);
+      if (valueNode != null && valueNode.isNullNode()) {
+        valueNode = null;
+      }
+      if (valueNode == null && !ShapeSupport.isRequired(member)) {
+        continue;
+      }
+      String expr = memberExpr(member, valueNode, new LinkedHashSet<>());
+      if (expr == null) {
+        if (ShapeSupport.isRequired(member)) {
+          throw new CodegenException(
+              "Cannot synthesize a fake value for required error member " + member.getId() + ".");
+        }
+        continue;
+      }
+      args.add(CSharpNaming.parameterName(member.getMemberName()) + ": " + expr);
+    }
+    return "new " + qualifiedType(error) + "(" + String.join(", ", args) + ")";
   }
 
   /** Writes the async iterators recorded for event-stream members, one blank line before each. */
@@ -205,7 +264,7 @@ final class FakeValueSynthesizer {
     };
   }
 
-  private String enumExpr(Shape target, Node node) {
+  String enumExpr(Shape target, Node node) {
     String typeName = qualifiedType(target);
     if (node != null && node.isStringNode()) {
       return "new "
@@ -218,7 +277,7 @@ final class FakeValueSynthesizer {
     return typeName + "." + CSharpNaming.propertyName(members.get(0).getMemberName());
   }
 
-  private String intEnumExpr(Shape target, Node node) {
+  String intEnumExpr(Shape target, Node node) {
     String typeName = qualifiedType(target);
     if (node != null && node.isNumberNode()) {
       return "(" + typeName + ")" + node.expectNumberNode().getValue().longValue();
@@ -374,16 +433,27 @@ final class FakeValueSynthesizer {
       return null;
     }
 
-    String name =
+    String base =
         "Fake"
             + CSharpNaming.typeName(op.getId().getName())
             + CSharpNaming.propertyName(member.getMemberName())
             + "Events";
+    // One iterator per synthesized expression: match arms for different @examples entries of the
+    // same event-stream operation each need their own method.
+    String name = base;
+    int suffix = 1;
+    while (hasPendingIterator(name)) {
+      name = base + suffix++;
+    }
     pendingIterators.add(new PendingIterator(name, eventType, events));
     return name + "()";
   }
 
-  private String blobBytesExpr(Node node, String hint) {
+  private boolean hasPendingIterator(String name) {
+    return pendingIterators.stream().anyMatch(iterator -> iterator.name().equals(name));
+  }
+
+  String blobBytesExpr(Node node, String hint) {
     if (node != null && node.isStringNode()) {
       return "System.Convert.FromBase64String("
           + CSharpNaming.formatString(node.expectStringNode().getValue())
@@ -392,7 +462,7 @@ final class FakeValueSynthesizer {
     return "System.Text.Encoding.UTF8.GetBytes(" + CSharpNaming.formatString(hint) + ")";
   }
 
-  private String timestampExpr(Node node) {
+  String timestampExpr(Node node) {
     if (node != null && node.isNumberNode()) {
       return "System.DateTimeOffset.FromUnixTimeSeconds("
           + node.expectNumberNode().getValue().longValue()
@@ -406,7 +476,7 @@ final class FakeValueSynthesizer {
     return "System.DateTimeOffset.FromUnixTimeSeconds(" + PLACEHOLDER_EPOCH_SECONDS + ")";
   }
 
-  private String numberExpr(ShapeType type, Node node, MemberShape member, Shape target) {
+  String numberExpr(ShapeType type, Node node, MemberShape member, Shape target) {
     if (node != null
         && node.isStringNode()
         && (type == ShapeType.FLOAT || type == ShapeType.DOUBLE)) {
@@ -480,7 +550,7 @@ final class FakeValueSynthesizer {
     return target.getTrait(traitClass).orElse(null);
   }
 
-  private String qualifiedType(Shape shape) {
+  String qualifiedType(Shape shape) {
     return CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(shape));
   }
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
@@ -40,6 +40,14 @@ final class FakeClientGeneratorTest {
               title: "Get city",
               input: { id: "c1" },
               output: { name: "Zurich", population: 400000 }
+          },
+          {
+              title: "Get missing city",
+              input: { id: "nope" },
+              error: {
+                  shapeId: "example.fake#NoSuchCity",
+                  content: { message: "unknown city" }
+              }
           }
       ])
       operation GetCity {
@@ -52,6 +60,13 @@ final class FakeClientGeneratorTest {
               name: String
               population: Integer
           }
+          errors: [NoSuchCity]
+      }
+
+      @error("client")
+      structure NoSuchCity {
+          @required
+          message: String
       }
 
       @paginated(inputToken: "nextToken", outputToken: "nextToken", items: "items")
@@ -114,6 +129,23 @@ final class FakeClientGeneratorTest {
         generated.contains(
             "return System.Threading.Tasks.Task.FromResult(new Example.Example.Fake.GetCityOutput("
                 + "Name: \"Zurich\", Population: 400000));"),
+        generated);
+  }
+
+  @Test
+  void matchesExampleInputsAndThrowsMatchedErrorExamples() throws Exception {
+    String generated = renderFake();
+
+    assertTrue(generated.contains("if (MatchesGetCityExample0(input))"), generated);
+    assertTrue(
+        generated.contains(
+            "private static bool MatchesGetCityExample1(Example.Example.Fake.GetCityInput input)"),
+        generated);
+    assertTrue(generated.contains("if (!(input.Id == \"nope\"))"), generated);
+    assertTrue(
+        generated.contains(
+            "return System.Threading.Tasks.Task.FromException<Example.Example.Fake.GetCityOutput>("
+                + "new Example.Example.Fake.NoSuchCity(message: \"unknown city\"));"),
         generated);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
@@ -32,7 +32,7 @@ final class FakeHandlerGeneratorTest {
 
       service Fakeable {
           version: "1"
-          operations: [GetCity, GetStatus, GetTree, Ping, Watch]
+          operations: [GetCity, GetStatus, GetTree, Lookup, Ping, Watch]
       }
 
       @examples([
@@ -76,6 +76,49 @@ final class FakeHandlerGeneratorTest {
               @required
               root: TreeNode
           }
+      }
+
+      @examples([
+          {
+              title: "Lookup Zurich",
+              input: { query: "zrh", limit: 1 },
+              output: { label: "Zurich" }
+          },
+          {
+              title: "Lookup by filter",
+              input: { filter: { tags: ["a", "b"] } },
+              output: { label: "Filtered" }
+          },
+          {
+              title: "Lookup missing",
+              input: { query: "nope" },
+              error: {
+                  shapeId: "example.fake#LookupError",
+                  content: { message: "no such city", hint: "try zrh" }
+              }
+          }
+      ])
+      operation Lookup {
+          input := {
+              query: String
+              limit: Integer
+              filter: Filter
+          }
+          output := {
+              @required
+              label: String
+          }
+          errors: [LookupError]
+      }
+
+      structure Filter {
+          tags: TagList
+      }
+
+      @error("client")
+      structure LookupError {
+          message: String
+          hint: String
       }
 
       operation Ping {}
@@ -214,6 +257,62 @@ final class FakeHandlerGeneratorTest {
             "yield return Example.Example.Fake.ChatEvent.FromMessage(new"
                 + " Example.Example.Fake.MessageEvent(Text: \"text\"));"),
         generated);
+  }
+
+  @Test
+  void multipleExamplesMatchInputInModelOrderWithFallback() throws Exception {
+    String generated = renderFake();
+
+    assertTrue(generated.contains("if (MatchesLookupExample0(input))"), generated);
+    assertTrue(generated.contains("if (MatchesLookupExample1(input))"), generated);
+    assertTrue(generated.contains("if (MatchesLookupExample2(input))"), generated);
+    assertTrue(
+        generated.contains(
+            "private static bool MatchesLookupExample0(Example.Example.Fake.LookupInput input)"),
+        generated);
+    assertTrue(generated.contains("if (!(input.Query == \"zrh\"))"), generated);
+    assertTrue(generated.contains("if (!(input.Limit == 1))"), generated);
+    assertTrue(
+        generated.contains(
+            "return System.Threading.Tasks.Task.FromResult(new"
+                + " Example.Example.Fake.LookupOutput(Label: \"Filtered\"));"),
+        generated);
+    // The fallback stays the first non-error example output.
+    assertTrue(
+        generated.contains(
+            "return System.Threading.Tasks.Task.FromResult(new"
+                + " Example.Example.Fake.LookupOutput(Label: \"Zurich\"));"),
+        generated);
+  }
+
+  @Test
+  void nestedStructureAndListExampleInputsCompareStructurally() throws Exception {
+    String generated = renderFake();
+
+    assertTrue(generated.contains("if (!(input.Filter is { } v0))"), generated);
+    assertTrue(generated.contains("if (!(v0.Tags is { } v1))"), generated);
+    assertTrue(generated.contains("if (!(v1.Values.Count == 2))"), generated);
+    assertTrue(generated.contains("if (!(v1.Values[0] == \"a\"))"), generated);
+    assertTrue(generated.contains("if (!(v1.Values[1] == \"b\"))"), generated);
+  }
+
+  @Test
+  void matchedErrorExampleThrowsTheModeledError() throws Exception {
+    String generated = renderFake();
+
+    assertTrue(
+        generated.contains(
+            "return System.Threading.Tasks.Task.FromException<Example.Example.Fake.LookupOutput>("
+                + "new Example.Example.Fake.LookupError(message: \"no such city\","
+                + " hint: \"try zrh\"));"),
+        generated);
+  }
+
+  @Test
+  void singleNonErrorExampleGeneratesNoMatching() throws Exception {
+    String generated = renderFake();
+
+    assertFalse(generated.contains("MatchesGetCityExample"), generated);
   }
 
   private String renderFake() throws Exception {

--- a/tests/Fakes/FakeClientTests.cs
+++ b/tests/Fakes/FakeClientTests.cs
@@ -28,7 +28,8 @@ public class FakeClientTests
     public async Task ConsumerLogicRunsAgainstTheFakeWithoutAServer()
     {
         // Out of the box: ListCities has no @examples, so the fake returns one
-        // synthesized summary; GetCity returns its @examples entry (Seattle).
+        // synthesized summary; its city ID matches no GetCity example, so
+        // GetCity falls back to its first @examples entry (Seattle).
         using IWeatherClient client = new FakeWeatherClient();
 
         var names = await CityReport.NorthernCityNamesAsync(client);
@@ -44,6 +45,34 @@ public class FakeClientTests
         var names = await CityReport.NorthernCityNamesAsync(client);
 
         Assert.Equal(["Seattle"], names);
+    }
+
+    [Fact]
+    public async Task InputMatchingPicksTheExampleResponse()
+    {
+        using var client = new FakeWeatherClient();
+
+        var seattle = await client.GetCityAsync(new GetCityInput("SEA"));
+        var houston = await client.GetCityAsync(new GetCityInput("HOU"));
+        var fallback = await client.GetCityAsync(new GetCityInput("nowhere"));
+
+        Assert.Equal("Seattle", seattle.Name);
+        Assert.Equal("Houston", houston.Name);
+        Assert.Equal(29.8f, houston.Coordinates.Latitude);
+        // Unmatched inputs fall back to the first non-error example.
+        Assert.Equal("Seattle", fallback.Name);
+    }
+
+    [Fact]
+    public async Task MatchedErrorExampleThrowsTheModeledError()
+    {
+        using var client = new FakeWeatherClient();
+
+        var error = await Assert.ThrowsAsync<NoSuchCity>(() =>
+            client.GetCityAsync(new GetCityInput("UNK"))
+        );
+
+        Assert.Equal("no city with ID UNK", error.Message);
     }
 
     [Fact]

--- a/tests/Fakes/FakeHandlerTests.cs
+++ b/tests/Fakes/FakeHandlerTests.cs
@@ -27,6 +27,17 @@ public class FakeHandlerTests
         Assert.Equal("Seattle", city.Name);
         Assert.Equal(47.6f, city.Coordinates.Latitude);
 
+        // The fake handler matches the input against the @examples inputs, so
+        // each example's data (including its error example) survives the round
+        // trip over the wire.
+        var houston = await client.GetCityAsync(new GetCityInput("HOU"));
+        Assert.Equal("Houston", houston.Name);
+
+        var error = await Assert.ThrowsAsync<NoSuchCity>(() =>
+            client.GetCityAsync(new GetCityInput("UNK"))
+        );
+        Assert.Equal("no city with ID UNK", error.Message);
+
         await app.StopAsync();
     }
 }

--- a/tests/Fakes/model/weather.smithy
+++ b/tests/Fakes/model/weather.smithy
@@ -22,6 +22,22 @@ service Weather {
             coordinates: { latitude: 47.6, longitude: -122.3 }
         }
     }
+    {
+        title: "Get Houston"
+        input: { cityId: "HOU" }
+        output: {
+            name: "Houston"
+            coordinates: { latitude: 29.8, longitude: -95.4 }
+        }
+    }
+    {
+        title: "Get unknown city"
+        input: { cityId: "UNK" }
+        error: {
+            shapeId: "example.weather#NoSuchCity"
+            content: { message: "no city with ID UNK" }
+        }
+    }
 ])
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}")
@@ -38,6 +54,16 @@ operation GetCity {
         @required
         coordinates: CityCoordinates
     }
+
+    errors: [NoSuchCity]
+}
+
+/// The requested city does not exist.
+@error("client")
+@httpError(404)
+structure NoSuchCity {
+    @required
+    message: String
 }
 
 /// Returns the current server time in UTC.

--- a/website/src/content/docs/guides/client-configuration/fake-clients.md
+++ b/website/src/content/docs/guides/client-configuration/fake-clients.md
@@ -26,8 +26,11 @@ services.AddSingleton<IWeatherClient, FakeWeatherClient>();
 
 Responses come from the same synthesis as
 [fake handlers](/smithy-dotnet/servers/fake-handlers/#where-the-responses-come-from):
-the output of each operation's first non-error `@examples` entry when
-present, deterministic placeholders otherwise. The fake client is generated
+with several `@examples` entries the input is matched against the example
+inputs and the first match decides the response, with a matched error example
+throwing the modeled error; otherwise the output of the first non-error
+`@examples` entry when present, deterministic placeholders everywhere else.
+The fake client is generated
 with the client surface (`SmithyGenerateClient`, on by default). Projects
 with an explicit `smithy-build.json` set `"generateFakes": true` on the
 `csharp-codegen` plugin instead.
@@ -35,7 +38,8 @@ with an explicit `smithy-build.json` set `"generateFakes": true` on the
 ## Differences from the real client
 
 - No serialization, protocol, or validation is involved. Every call returns
-  the canned response, including calls a real client or server would reject.
+  its canned response (or throws its matched error example), including calls
+  a real client or server would reject.
 - Paginators yield a single page. The canned output's continuation token may
   be non-null, and following it would never terminate.
 - Every operation responds, including event-stream operations the real

--- a/website/src/content/docs/servers/fake-handlers.md
+++ b/website/src/content/docs/servers/fake-handlers.md
@@ -37,12 +37,20 @@ with the client surface.
 Responses are compiled into the generated code, so they are deterministic
 across calls, runs, and rebuilds of an unchanged model. For each operation:
 
-1. **`@examples` output.** When the operation carries the
-   [`@examples` trait](https://smithy.io/2.0/spec/documentation-traits.html#examples-trait),
-   the fake returns the output of the first non-error example. Optional
-   members absent from the example are omitted.
+1. **`@examples` input matching.** When the operation carries several
+   [`@examples`](https://smithy.io/2.0/spec/documentation-traits.html#examples-trait)
+   entries, the incoming input is matched against the example inputs in model
+   order and the first match decides the response. Matching is a subset
+   comparison: members present in the example input must equal the incoming
+   input, members absent from the example match anything, at every nesting
+   level. A matched error example throws the modeled error, which the server
+   serializes like any handler-thrown error.
 
-2. **Synthesized placeholders.** Without an example, strings echo the member
+2. **`@examples` output.** When no example input matches (or the operation
+   has a single example), the fake returns the output of the first non-error
+   example. Optional members absent from the example are omitted.
+
+3. **Synthesized placeholders.** Without an example, strings echo the member
    name (`"name"`, `"nextToken"`), numbers are `0`, enums and unions take
    their first variant, lists and maps contain a single entry, and timestamps
    are a fixed instant. `@length` and `@range` minimums are honored;
@@ -56,6 +64,19 @@ across calls, runs, and rebuilds of an unchanged model. For each operation:
         input: { cityId: "zrh" }
         output: { name: "Zurich", coordinates: { latitude: 47.3769, longitude: 8.5417 } }
     }
+    {
+        title: "Get Geneva"
+        input: { cityId: "gva" }
+        output: { name: "Geneva", coordinates: { latitude: 46.2044, longitude: 6.1432 } }
+    }
+    {
+        title: "Get unknown city"
+        input: { cityId: "xxx" }
+        error: {
+            shapeId: "example.weather#NoSuchCity"
+            content: { message: "no city with ID xxx" }
+        }
+    }
 ])
 operation GetCity {
     // ...
@@ -63,7 +84,17 @@ operation GetCity {
 ```
 
 ```json
-// GET /cities/zrh: from the example
+// GET /cities/zrh: from the matched example
+{"name":"Zurich","coordinates":{"latitude":47.3769,"longitude":8.5417}}
+
+// GET /cities/gva: from the matched example
+{"name":"Geneva","coordinates":{"latitude":46.2044,"longitude":6.1432}}
+
+// GET /cities/xxx: the matched error example, served as a modeled error
+// (404, X-Amzn-Errortype: NoSuchCity)
+{"message":"no city with ID xxx"}
+
+// GET /cities/brn: no match, first non-error example
 {"name":"Zurich","coordinates":{"latitude":47.3769,"longitude":8.5417}}
 
 // GET /cities: no example, synthesized


### PR DESCRIPTION
With more than one @examples entry (or any error example) the generated fakes now pick their response by matching the incoming input against the example inputs in model order: members present in the example input must equal the input at every nesting level, absent members are wildcards, and a matched error example throws the modeled error (also over the real wire from the fake handler). Unmatched inputs keep the previous fallback, and operations with a single non-error example generate unchanged code.
