### PR TITLE
feat: expand AWS protocol and auth support

### DIFF
--- a/NSmithy.slnx
+++ b/NSmithy.slnx
@@ -9,6 +9,7 @@
     <Project Path="packages/NSmithy.EventStream/NSmithy.EventStream.csproj" />
     <Project Path="packages/NSmithy.Codecs.Json/NSmithy.Codecs.Json.csproj" />
     <Project Path="packages/NSmithy.Protocols.AwsJson/NSmithy.Protocols.AwsJson.csproj" />
+    <Project Path="packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj" />
     <Project Path="packages/NSmithy.Protocols.Rest/NSmithy.Protocols.Rest.csproj" />
     <Project Path="packages/NSmithy.Protocols.RestJson/NSmithy.Protocols.RestJson.csproj" />
     <Project Path="packages/NSmithy.Protocols.RestXml/NSmithy.Protocols.RestXml.csproj" />
@@ -31,7 +32,9 @@
     <Project Path="tests/NSmithy.Tests/NSmithy.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Conformance/">
+    <Project Path="tests/Conformance/AwsQuery/AwsQuery.Conformance.csproj" />
     <Project Path="tests/Conformance/AwsJson/AwsJson.Conformance.csproj" />
+    <Project Path="tests/Conformance/Ec2Query/Ec2Query.Conformance.csproj" />
     <Project Path="tests/Conformance/RestJson1/RestJson1.Conformance.csproj" />
     <Project Path="tests/Conformance/RestXml/RestXml.Conformance.csproj" />
     <Project Path="tests/Conformance/RpcV2Cbor/RpcV2Cbor.Conformance.csproj" />

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NSmithy is a .NET toolkit that turns a [Smithy](https://smithy.io) model into id
 - **Contract-first**: The Smithy model is the source of truth. NSmithy generates C# model types, clients, and ASP.NET Core server stubs from it.
 - **Protocol-agnostic**: The same model can target multiple protocols; switching protocols requires no changes to client or server code.
 - **Part of the Smithy ecosystem**: A .NET service built with NSmithy can be called from clients generated for Java, TypeScript, Python, Go, Rust, Swift, and more, and vice versa.
-- **Protocol support**: REST JSON, REST XML, AWS JSON, RPC v2 CBOR, and native gRPC.
+- **Protocol support**: REST JSON, REST XML, AWS JSON, AWS Query / EC2 Query, RPC v2 CBOR, and native gRPC.
 - **Streaming support**: Event streaming, bidirectional streaming, and streaming blob payloads.
 - **Smithy-native architecture**: Follows Smithy's official [code generator guidance](https://smithy.io/2.0/guides/building-codegen/index.html).
 - **Conformance-tested**: Tested against official Smithy, AWS, and alloy conformance suites.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NSmithy is a .NET toolkit that turns a [Smithy](https://smithy.io) model into id
 - **Contract-first**: The Smithy model is the source of truth. NSmithy generates C# model types, clients, and ASP.NET Core server stubs from it.
 - **Protocol-agnostic**: The same model can target multiple protocols; switching protocols requires no changes to client or server code.
 - **Part of the Smithy ecosystem**: A .NET service built with NSmithy can be called from clients generated for Java, TypeScript, Python, Go, Rust, Swift, and more, and vice versa.
-- **Protocol support**: REST JSON, REST XML, AWS JSON, AWS Query / EC2 Query, RPC v2 CBOR, and native gRPC.
+- **Protocol support**: REST JSON, REST XML, AWS JSON, AWS Query / EC2 Query, RPC v2 CBOR, and gRPC.
 - **Streaming support**: Event streaming, bidirectional streaming, and streaming blob payloads.
 - **Smithy-native architecture**: Follows Smithy's official [code generator guidance](https://smithy.io/2.0/guides/building-codegen/index.html).
 - **Conformance-tested**: Tested against official Smithy, AWS, and alloy conformance suites.

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/RuntimeTypes.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/RuntimeTypes.java
@@ -14,6 +14,7 @@ public final class RuntimeTypes {
   public static final String NSMITHY_CORE_VALIDATION = "NSmithy.Core.Validation";
   public static final String NSMITHY_CLIENT = "NSmithy.Client";
   public static final String NSMITHY_PROTOCOLS_AWSJSON = "NSmithy.Protocols.AwsJson";
+  public static final String NSMITHY_PROTOCOLS_AWSQUERY = "NSmithy.Protocols.AwsQuery";
   public static final String NSMITHY_PROTOCOLS_RESTJSON = "NSmithy.Protocols.RestJson";
   public static final String NSMITHY_PROTOCOLS_RESTXML = "NSmithy.Protocols.RestXml";
   public static final String NSMITHY_PROTOCOLS_RPCV2CBOR = "NSmithy.Protocols.RpcV2Cbor";

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/TraitIds.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/TraitIds.java
@@ -11,6 +11,9 @@ public final class TraitIds {
   public static final ShapeId SIMPLE_REST_JSON = ShapeId.from("alloy#simpleRestJson");
   public static final ShapeId AWS_JSON_1_0 = ShapeId.from("aws.protocols#awsJson1_0");
   public static final ShapeId AWS_JSON_1_1 = ShapeId.from("aws.protocols#awsJson1_1");
+  public static final ShapeId AWS_QUERY = ShapeId.from("aws.protocols#awsQuery");
+  public static final ShapeId EC2_QUERY = ShapeId.from("aws.protocols#ec2Query");
+  public static final ShapeId AWS_QUERY_ERROR = ShapeId.from("aws.protocols#awsQueryError");
   public static final ShapeId REST_JSON_1 = ShapeId.from("aws.protocols#restJson1");
   public static final ShapeId REST_XML = ShapeId.from("aws.protocols#restXml");
   public static final ShapeId RPC_V2_CBOR = ShapeId.from("smithy.protocols#rpcv2Cbor");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -3,6 +3,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
+import io.github.thomaslaich.nsmithy.csharp.codegen.TraitIds;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
 import java.util.List;
@@ -81,6 +82,18 @@ public final class OperationSchemaGenerator implements Runnable {
   }
 
   private static int httpErrorCode(StructureShape error) {
+    var awsQueryError = error.findTrait(TraitIds.AWS_QUERY_ERROR);
+    if (awsQueryError.isPresent()) {
+      return awsQueryError
+          .get()
+          .toNode()
+          .expectObjectNode()
+          .getMember("httpResponseCode")
+          .orElseThrow()
+          .expectNumberNode()
+          .getValue()
+          .intValue();
+    }
     return error
         .getTrait(HttpErrorTrait.class)
         .map(HttpErrorTrait::getCode)

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
@@ -4,7 +4,7 @@
  *   public static partial class {Service}Schema
  *   {
  *       public static ServiceSchema Schema { get; } =
- *           Schemas.Service(ShapeId.Parse("ns#Service"), traits);
+ *           Schemas.Service(ShapeId.Parse("ns#Service"), "2020-01-01", traits);
  *   }
  *
  * The service schema is service-scoped (carries the service shape id + service-level traits) and is
@@ -43,8 +43,9 @@ public final class ServiceSchemaGenerator implements Runnable {
           writer.write("public static ServiceSchema Schema { get; } =");
           writer.indent();
           writer.write(
-              "Schemas.Service($L, $L);",
+              "Schemas.Service($L, $S, $L);",
               SchemaGenerator.shapeIdExpr(service.getId()),
+              service.getVersion(),
               SchemaGenerator.traitsExpr(service.getAllTraits().values()));
           writer.dedent();
         });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
@@ -1,6 +1,6 @@
 /*
  * Encapsulates protocol-specific decisions for HTTP client codegen:
- *   - which runtime helper class to call (RestJsonClientProtocol, RestXmlClientProtocol, RpcV2CborClientProtocol)
+ *   - which runtime helper class to call (REST, AWS JSON/Query, rpcv2Cbor, and gRPC protocols)
  *   - which codec to use (JSON / XML / CBOR)
  *   - whether to use HTTP binding traits or treat the whole input/output as the body
  *   - how to dispatch errors (status code vs error type from body)
@@ -29,6 +29,8 @@ public final class ProtocolSupport {
   public enum Kind {
     AWS_JSON_1_0,
     AWS_JSON_1_1,
+    AWS_QUERY,
+    EC2_QUERY,
     SIMPLE_REST_JSON,
     REST_JSON_1,
     REST_XML,
@@ -50,6 +52,14 @@ public final class ProtocolSupport {
 
   public static boolean isAwsJson11Service(ServiceShape s) {
     return s.findTrait(TraitIds.AWS_JSON_1_1).isPresent();
+  }
+
+  public static boolean isAwsQueryService(ServiceShape s) {
+    return s.findTrait(TraitIds.AWS_QUERY).isPresent();
+  }
+
+  public static boolean isEc2QueryService(ServiceShape s) {
+    return s.findTrait(TraitIds.EC2_QUERY).isPresent();
   }
 
   public static boolean isSimpleRestJsonService(ServiceShape s) {
@@ -79,6 +89,8 @@ public final class ProtocolSupport {
   public static Kind kindOf(ServiceShape s) {
     if (isRpcV2CborService(s)) return Kind.RPC_V2_CBOR;
     if (isRestXmlService(s)) return Kind.REST_XML;
+    if (isAwsQueryService(s)) return Kind.AWS_QUERY;
+    if (isEc2QueryService(s)) return Kind.EC2_QUERY;
     if (isAwsJson11Service(s)) return Kind.AWS_JSON_1_1;
     if (isAwsJson10Service(s)) return Kind.AWS_JSON_1_0;
     if (isSimpleRestJsonService(s)) return Kind.SIMPLE_REST_JSON;
@@ -88,14 +100,17 @@ public final class ProtocolSupport {
 
   /**
    * Every protocol the service declares, in the documented precedence order {@code rpcv2Cbor >
-   * restXml > awsJson1_1 > awsJson1_0 > simpleRestJson > restJson1 > grpc}. The unified client
-   * builder generates a {@code With{Kind}()} method per declared kind and uses the first as the
-   * default protocol. Returns an empty list for a service with no supported protocol trait.
+   * restXml > awsQuery > ec2Query > awsJson1_1 > awsJson1_0 > simpleRestJson > restJson1 > grpc}.
+   * The unified client builder generates a {@code With{Kind}()} method per declared kind and uses
+   * the first as the default protocol. Returns an empty list for a service with no supported
+   * protocol trait.
    */
   public static List<Kind> declaredKinds(ServiceShape s) {
     List<Kind> kinds = new ArrayList<>();
     if (isRpcV2CborService(s)) kinds.add(Kind.RPC_V2_CBOR);
     if (isRestXmlService(s)) kinds.add(Kind.REST_XML);
+    if (isAwsQueryService(s)) kinds.add(Kind.AWS_QUERY);
+    if (isEc2QueryService(s)) kinds.add(Kind.EC2_QUERY);
     if (isAwsJson11Service(s)) kinds.add(Kind.AWS_JSON_1_1);
     if (isAwsJson10Service(s)) kinds.add(Kind.AWS_JSON_1_0);
     if (isSimpleRestJsonService(s)) kinds.add(Kind.SIMPLE_REST_JSON);
@@ -108,6 +123,8 @@ public final class ProtocolSupport {
     return switch (kind) {
       case AWS_JSON_1_0 -> TraitIds.AWS_JSON_1_0;
       case AWS_JSON_1_1 -> TraitIds.AWS_JSON_1_1;
+      case AWS_QUERY -> TraitIds.AWS_QUERY;
+      case EC2_QUERY -> TraitIds.EC2_QUERY;
       case SIMPLE_REST_JSON -> TraitIds.SIMPLE_REST_JSON;
       case REST_JSON_1 -> TraitIds.REST_JSON_1;
       case REST_XML -> TraitIds.REST_XML;
@@ -199,6 +216,8 @@ public final class ProtocolSupport {
                   ", ",
                   TraitIds.RPC_V2_CBOR.toString(),
                   TraitIds.REST_XML.toString(),
+                  TraitIds.AWS_QUERY.toString(),
+                  TraitIds.EC2_QUERY.toString(),
                   TraitIds.AWS_JSON_1_1.toString(),
                   TraitIds.AWS_JSON_1_0.toString(),
                   TraitIds.SIMPLE_REST_JSON.toString(),
@@ -214,6 +233,8 @@ public final class ProtocolSupport {
     return switch (kind) {
       case AWS_JSON_1_0 -> "AwsJson10Protocol";
       case AWS_JSON_1_1 -> "AwsJson11Protocol";
+      case AWS_QUERY -> "AwsQueryProtocol";
+      case EC2_QUERY -> "Ec2QueryProtocol";
       case SIMPLE_REST_JSON -> "SimpleRestJsonProtocol";
       case REST_JSON_1 -> "RestJson1Protocol";
       case REST_XML -> "RestXmlProtocol";
@@ -226,6 +247,7 @@ public final class ProtocolSupport {
     return switch (kind) {
       case AWS_JSON_1_0 -> "application/x-amz-json-1.0";
       case AWS_JSON_1_1 -> "application/x-amz-json-1.1";
+      case AWS_QUERY, EC2_QUERY -> "application/x-www-form-urlencoded";
       case SIMPLE_REST_JSON, REST_JSON_1 -> "application/json";
       case REST_XML -> "application/xml";
       case RPC_V2_CBOR -> "application/cbor";
@@ -237,6 +259,7 @@ public final class ProtocolSupport {
   public static String runtimeProtocolNamespace(Kind kind) {
     return switch (kind) {
       case AWS_JSON_1_0, AWS_JSON_1_1 -> RuntimeTypes.NSMITHY_PROTOCOLS_AWSJSON;
+      case AWS_QUERY, EC2_QUERY -> RuntimeTypes.NSMITHY_PROTOCOLS_AWSQUERY;
       case SIMPLE_REST_JSON, REST_JSON_1 -> RuntimeTypes.NSMITHY_PROTOCOLS_RESTJSON;
       case REST_XML -> RuntimeTypes.NSMITHY_PROTOCOLS_RESTXML;
       case RPC_V2_CBOR -> RuntimeTypes.NSMITHY_PROTOCOLS_RPCV2CBOR;
@@ -248,7 +271,7 @@ public final class ProtocolSupport {
   public static boolean supportsEventStreams(Kind kind) {
     return switch (kind) {
       case REST_JSON_1, SIMPLE_REST_JSON, RPC_V2_CBOR, GRPC -> true;
-      case AWS_JSON_1_0, AWS_JSON_1_1, REST_XML -> false;
+      case AWS_JSON_1_0, AWS_JSON_1_1, AWS_QUERY, EC2_QUERY, REST_XML -> false;
     };
   }
 
@@ -256,6 +279,7 @@ public final class ProtocolSupport {
   public static String codecNamespace(Kind kind) {
     return switch (kind) {
       case AWS_JSON_1_0, AWS_JSON_1_1 -> RuntimeTypes.NSMITHY_CODECS_JSON;
+      case AWS_QUERY, EC2_QUERY -> RuntimeTypes.NSMITHY_CODECS_XML;
       case SIMPLE_REST_JSON, REST_JSON_1 -> RuntimeTypes.NSMITHY_CODECS_JSON;
       case REST_XML -> RuntimeTypes.NSMITHY_CODECS_XML;
       case RPC_V2_CBOR -> RuntimeTypes.NSMITHY_CODECS_CBOR;

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
@@ -278,10 +278,9 @@ public final class ProtocolSupport {
   /** Runtime namespace housing the codec singleton. */
   public static String codecNamespace(Kind kind) {
     return switch (kind) {
-      case AWS_JSON_1_0, AWS_JSON_1_1 -> RuntimeTypes.NSMITHY_CODECS_JSON;
-      case AWS_QUERY, EC2_QUERY -> RuntimeTypes.NSMITHY_CODECS_XML;
-      case SIMPLE_REST_JSON, REST_JSON_1 -> RuntimeTypes.NSMITHY_CODECS_JSON;
-      case REST_XML -> RuntimeTypes.NSMITHY_CODECS_XML;
+      case AWS_JSON_1_0, AWS_JSON_1_1, SIMPLE_REST_JSON, REST_JSON_1 ->
+          RuntimeTypes.NSMITHY_CODECS_JSON;
+      case AWS_QUERY, EC2_QUERY, REST_XML -> RuntimeTypes.NSMITHY_CODECS_XML;
       case RPC_V2_CBOR -> RuntimeTypes.NSMITHY_CODECS_CBOR;
       case GRPC -> RuntimeTypes.NSMITHY_CODECS_PROTO;
     };

--- a/examples/aws-localstack/README.md
+++ b/examples/aws-localstack/README.md
@@ -5,6 +5,8 @@ This example exercises one generated AWS client for each AWS HTTP protocol suppo
 - AWS JSON 1.0: DynamoDB `ListTables`
 - AWS restXml: S3 `ListBuckets`
 - AWS restJson1: Lambda `ListFunctions`
+- AWS Query: SQS `ListQueues`
+- EC2 Query: EC2 `DescribeRegions`
 
 On startup, an init hook (`init/ready.d/seed.sh`) seeds a little data into each
 service so the `List*` calls return populated responses, so you should see:
@@ -13,6 +15,8 @@ service so the `List*` calls return populated responses, so you should see:
 AWS JSON / DynamoDB ListTables: 2 table(s) [Authors, Books]
 restXml / S3 ListBuckets: 2 bucket(s) [nsmithy-demo-assets, nsmithy-demo-logs]
 restJson1 / Lambda ListFunctions: 1 function(s) [nsmithy-greeter]
+AWS Query / SQS ListQueues: 2 queue(s) [...nsmithy-demo-events, ...nsmithy-demo-jobs]
+EC2 Query / EC2 DescribeRegions: one or more LocalStack regions
 ```
 
 Run it against LocalStack (runs in Docker, so a running Docker daemon is

--- a/examples/aws-localstack/client/NSmithy.Examples.AwsLocalStack.Client.csproj
+++ b/examples/aws-localstack/client/NSmithy.Examples.AwsLocalStack.Client.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="NSmithy.Codecs.Json" Version="0.0.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Codecs.Xml" Version="0.0.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Protocols.AwsJson" Version="0.0.0-SNAPSHOT" />
+    <PackageReference Include="NSmithy.Protocols.AwsQuery" Version="0.0.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Protocols.RestJson" Version="0.0.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.Protocols.RestXml" Version="0.0.0-SNAPSHOT" />
     <PackageReference Include="NSmithy.MSBuild" Version="0.0.0-SNAPSHOT" PrivateAssets="all" />

--- a/examples/aws-localstack/client/Program.cs
+++ b/examples/aws-localstack/client/Program.cs
@@ -36,3 +36,23 @@ var functionNames = functions.Functions?.Values.Select(f => f.FunctionName) ?? [
 Console.WriteLine(
     $"restJson1 / Lambda ListFunctions: {functions.Functions?.Values.Count ?? 0} function(s) [{string.Join(", ", functionNames)}]"
 );
+
+using var sqs = new SQSClient(
+    endpoint,
+    new() { AuthSchemes = { new AwsSigV4AuthScheme("sqs", region, credentials) } }
+);
+var queues = await sqs.ListQueuesAsync(new ListQueuesInput());
+var queueUrls = queues.QueueUrls?.Values ?? [];
+Console.WriteLine(
+    $"AWS Query / SQS ListQueues: {queueUrls.Count} queue(s) [{string.Join(", ", queueUrls)}]"
+);
+
+using var ec2 = new EC2Client(
+    endpoint,
+    new() { AuthSchemes = { new AwsSigV4AuthScheme("ec2", region, credentials) } }
+);
+var regions = await ec2.DescribeRegionsAsync(new DescribeRegionsInput());
+var regionNames = regions.Regions?.Values.Select(value => value.Name) ?? [];
+Console.WriteLine(
+    $"EC2 Query / EC2 DescribeRegions: {regions.Regions?.Values.Count ?? 0} region(s) [{string.Join(", ", regionNames)}]"
+);

--- a/examples/aws-localstack/compose.yaml
+++ b/examples/aws-localstack/compose.yaml
@@ -6,11 +6,11 @@ services:
     ports:
       - "4566:4566"
     environment:
-      - SERVICES=dynamodb,s3,lambda
+      - SERVICES=dynamodb,s3,lambda,sqs,ec2
       - DEBUG=0
     volumes:
       # Required so the Lambda service can spawn function containers.
       - "/var/run/docker.sock:/var/run/docker.sock"
       # Seed a little data once the gateway is ready (DynamoDB tables, S3
-      # buckets, a Lambda function) so the example's List* calls return data.
+      # buckets, queues, and a Lambda function) so the example's List* calls return data.
       - "./init/ready.d:/etc/localstack/init/ready.d"

--- a/examples/aws-localstack/init/ready.d/seed.sh
+++ b/examples/aws-localstack/init/ready.d/seed.sh
@@ -26,6 +26,11 @@ done
 awslocal s3api put-object \
   --bucket nsmithy-demo-assets --key hello.txt --body /etc/hostname >/dev/null 2>&1 || true
 
+echo "[seed] SQS queues"
+for queue in nsmithy-demo-jobs nsmithy-demo-events; do
+  awslocal sqs create-queue --queue-name "$queue" >/dev/null 2>&1 || true
+done
+
 echo "[seed] Lambda function"
 # Build a minimal deployment package with python3 (always present in the image),
 # so we don't depend on `zip` being installed. LocalStack doesn't enforce IAM,

--- a/examples/aws-localstack/model/localstack-aws.smithy
+++ b/examples/aws-localstack/model/localstack-aws.smithy
@@ -4,6 +4,8 @@ namespace localstack.aws
 
 use aws.auth#sigv4
 use aws.protocols#awsJson1_0
+use aws.protocols#awsQuery
+use aws.protocols#ec2Query
 use aws.protocols#restJson1
 use aws.protocols#restXml
 
@@ -71,6 +73,56 @@ structure S3Bucket {
 service Lambda {
     version: "2015-03-31"
     operations: [ListFunctions]
+}
+
+@awsQuery
+@sigv4(name: "sqs")
+@xmlNamespace(uri: "http://queue.amazonaws.com/doc/2012-11-05/")
+service SQS {
+    version: "2012-11-05"
+    operations: [ListQueues]
+}
+
+operation ListQueues {
+    input := {}
+    output := {
+        @xmlFlattened
+        @xmlName("QueueUrl")
+        queueUrls: QueueUrlList
+    }
+}
+
+list QueueUrlList {
+    member: String
+}
+
+@ec2Query
+@sigv4(name: "ec2")
+@xmlNamespace(uri: "http://ec2.amazonaws.com/doc/2016-11-15/")
+service EC2 {
+    version: "2016-11-15"
+    operations: [DescribeRegions]
+}
+
+operation DescribeRegions {
+    input := {}
+    output := {
+        @xmlName("regionInfo")
+        regions: RegionList
+    }
+}
+
+list RegionList {
+    @xmlName("item")
+    member: Region
+}
+
+structure Region {
+    @xmlName("regionName")
+    name: String
+
+    @xmlName("regionEndpoint")
+    endpoint: String
 }
 
 @http(method: "GET", uri: "/2015-03-31/functions/")

--- a/examples/aws-localstack/smithy-build.json
+++ b/examples/aws-localstack/smithy-build.json
@@ -43,6 +43,28 @@
           "baseNamespace": ""
         }
       }
+    },
+    "awsquery": {
+      "transforms": [
+        { "name": "includeServices", "args": { "services": ["localstack.aws#SQS"] } }
+      ],
+      "plugins": {
+        "csharp-codegen": {
+          "service": "localstack.aws#SQS",
+          "baseNamespace": ""
+        }
+      }
+    },
+    "ec2query": {
+      "transforms": [
+        { "name": "includeServices", "args": { "services": ["localstack.aws#EC2"] } }
+      ],
+      "plugins": {
+        "csharp-codegen": {
+          "service": "localstack.aws#EC2",
+          "baseNamespace": ""
+        }
+      }
     }
   }
 }

--- a/packages/NSmithy.Aws/AwsCredentialsProviderException.cs
+++ b/packages/NSmithy.Aws/AwsCredentialsProviderException.cs
@@ -1,0 +1,27 @@
+namespace NSmithy.Aws;
+
+/// <summary>An expected credentials-provider failure with enough context to diagnose the chain.</summary>
+public sealed class AwsCredentialsProviderException : Exception
+{
+    public AwsCredentialsProviderException(
+        string providerName,
+        string message,
+        bool isNotConfigured = false,
+        Exception? innerException = null
+    )
+        : base(message, innerException)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+        ProviderName = providerName;
+        IsNotConfigured = isNotConfigured;
+    }
+
+    public string ProviderName { get; }
+
+    /// <summary>
+    /// True when the provider has no configuration in this environment, so a default chain may
+    /// safely continue to the next source. False means configuration existed but was invalid or
+    /// the configured source failed.
+    /// </summary>
+    public bool IsNotConfigured { get; }
+}

--- a/packages/NSmithy.Aws/AwsRegionalEndpointResolver.cs
+++ b/packages/NSmithy.Aws/AwsRegionalEndpointResolver.cs
@@ -1,0 +1,74 @@
+using NSmithy.Client;
+
+namespace NSmithy.Aws;
+
+/// <summary>
+/// Resolves the standard regional AWS endpoint pattern across commercial, China, GovCloud, and
+/// isolated partitions. Services with modeled endpoint rules can still replace this resolver.
+/// </summary>
+public sealed class AwsRegionalEndpointResolver : IEndpointResolver
+{
+    private readonly SmithyEndpoint endpoint;
+
+    public AwsRegionalEndpointResolver(
+        string endpointPrefix,
+        string region,
+        bool useFips = false,
+        bool useDualStack = false,
+        IReadOnlyDictionary<string, string>? headers = null,
+        IReadOnlyList<string>? authSchemes = null
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpointPrefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+        var partition = AwsPartition.ForRegion(region);
+        var hostPrefix = endpointPrefix + (useFips ? "-fips" : string.Empty);
+        var dnsSuffix = useDualStack
+            ? partition.DualStackDnsSuffix
+                ?? throw new NotSupportedException(
+                    $"The AWS partition for region '{region}' does not define dual-stack endpoints."
+                )
+            : partition.DnsSuffix;
+        var host = $"{hostPrefix}.{region}.{dnsSuffix}";
+        endpoint = new SmithyEndpoint(new Uri("https://" + host), headers, authSchemes);
+    }
+
+    public ValueTask<SmithyEndpoint> ResolveEndpointAsync(
+        SmithyEndpointParameters parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(endpoint);
+    }
+
+    public SmithyEndpoint? StaticEndpoint => endpoint;
+
+    private sealed record AwsPartition(string DnsSuffix, string? DualStackDnsSuffix)
+    {
+        public static AwsPartition ForRegion(string region)
+        {
+            if (region.StartsWith("cn-", StringComparison.Ordinal))
+            {
+                return new AwsPartition("amazonaws.com.cn", "api.amazonwebservices.com.cn");
+            }
+            if (region.StartsWith("us-iso-", StringComparison.Ordinal))
+            {
+                return new AwsPartition("c2s.ic.gov", null);
+            }
+            if (region.StartsWith("us-isob-", StringComparison.Ordinal))
+            {
+                return new AwsPartition("sc2s.sgov.gov", null);
+            }
+            if (region.StartsWith("eu-isoe-", StringComparison.Ordinal))
+            {
+                return new AwsPartition("cloud.adc-e.uk", null);
+            }
+            if (region.StartsWith("us-isof-", StringComparison.Ordinal))
+            {
+                return new AwsPartition("csp.hci.ic.gov", null);
+            }
+            return new AwsPartition("amazonaws.com", "api.aws");
+        }
+    }
+}

--- a/packages/NSmithy.Aws/AwsSigV4Presigner.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Presigner.cs
@@ -1,0 +1,30 @@
+using NSmithy.Http;
+
+namespace NSmithy.Aws;
+
+/// <summary>Creates SigV4 presigned request URIs using credentials resolved on demand.</summary>
+public sealed class AwsSigV4Presigner(
+    string service,
+    string region,
+    IAwsCredentialsProvider credentialsProvider,
+    Uri? endpoint = null,
+    TimeProvider? timeProvider = null
+)
+{
+    private readonly IAwsCredentialsProvider credentialsProvider =
+        credentialsProvider ?? throw new ArgumentNullException(nameof(credentialsProvider));
+    private readonly AwsSigV4Signer signer = new(endpoint, service, region, timeProvider);
+
+    public async ValueTask<Uri> PresignAsync(
+        SmithyHttpRequest request,
+        TimeSpan expires,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var credentials = await credentialsProvider
+            .GetCredentialsAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return signer.Presign(request, credentials, expires);
+    }
+}

--- a/packages/NSmithy.Aws/AwsSigV4Signer.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Signer.cs
@@ -7,7 +7,12 @@ using NSmithy.Http;
 namespace NSmithy.Aws;
 
 /// <summary>Signs HTTP requests with AWS Signature Version 4.</summary>
-public sealed class AwsSigV4Signer : ISmithySigner
+public sealed class AwsSigV4Signer(
+    Uri? endpoint,
+    string service,
+    string region,
+    TimeProvider? timeProvider = null
+) : ISmithySigner
 {
     private const string Algorithm = "AWS4-HMAC-SHA256";
     private static readonly HashSet<string> PresignAuthenticationParameters = new(
@@ -26,39 +31,23 @@ public sealed class AwsSigV4Signer : ISmithySigner
         .InvariantCulture
         .DateTimeFormat;
 
-    private readonly Uri? endpoint;
+    private readonly Uri? endpoint =
+        endpoint is null || endpoint.IsAbsoluteUri
+            ? endpoint
+            : throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
 
-    private readonly string service;
+    private readonly string service = string.IsNullOrWhiteSpace(service)
+        ? throw new ArgumentException("Service must be set.", nameof(service))
+        : service;
 
-    private readonly string region;
+    private readonly string region = string.IsNullOrWhiteSpace(region)
+        ? throw new ArgumentException("Region must be set.", nameof(region))
+        : region;
 
-    private readonly TimeProvider timeProvider;
+    private readonly TimeProvider timeProvider = timeProvider ?? TimeProvider.System;
 
     public AwsSigV4Signer(string service, string region, TimeProvider? timeProvider = null)
         : this(null, service, region, timeProvider) { }
-
-    public AwsSigV4Signer(
-        Uri? endpoint,
-        string service,
-        string region,
-        TimeProvider? timeProvider = null
-    )
-    {
-        this.endpoint =
-            endpoint is null || endpoint.IsAbsoluteUri
-                ? endpoint
-                : throw new ArgumentException(
-                    "Endpoint must be an absolute URI.",
-                    nameof(endpoint)
-                );
-        this.service = string.IsNullOrWhiteSpace(service)
-            ? throw new ArgumentException("Service must be set.", nameof(service))
-            : service;
-        this.region = string.IsNullOrWhiteSpace(region)
-            ? throw new ArgumentException("Region must be set.", nameof(region))
-            : region;
-        this.timeProvider = timeProvider ?? TimeProvider.System;
-    }
 
     public ValueTask<SmithyHttpRequest> SignAsync(
         SmithyContext context,

--- a/packages/NSmithy.Aws/AwsSigV4Signer.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Signer.cs
@@ -10,6 +10,18 @@ namespace NSmithy.Aws;
 public sealed class AwsSigV4Signer : ISmithySigner
 {
     private const string Algorithm = "AWS4-HMAC-SHA256";
+    private static readonly HashSet<string> PresignAuthenticationParameters = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        "X-Amz-Algorithm",
+        "X-Amz-Credential",
+        "X-Amz-Date",
+        "X-Amz-Expires",
+        "X-Amz-Signature",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Security-Token",
+    };
     private static readonly DateTimeFormatInfo InvariantDateTime = CultureInfo
         .InvariantCulture
         .DateTimeFormat;
@@ -72,6 +84,9 @@ public sealed class AwsSigV4Signer : ISmithySigner
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(credentials);
 
+        // A retry or caller may hand the signer a previously signed request. Authentication
+        // material is output, never canonical input; remove it before rebuilding the signature.
+        request.Headers.Remove("Authorization");
         var requestUri = ResolveRequestUri(request.RequestUri);
         var amzDate = now.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'", InvariantDateTime);
         var date = now.UtcDateTime.ToString("yyyyMMdd", InvariantDateTime);
@@ -83,6 +98,10 @@ public sealed class AwsSigV4Signer : ISmithySigner
         if (!string.IsNullOrEmpty(credentials.SessionToken))
         {
             request.Headers["X-Amz-Security-Token"] = [credentials.SessionToken];
+        }
+        else
+        {
+            request.Headers.Remove("X-Amz-Security-Token");
         }
 
         var canonicalHeaders = CanonicalHeaders(request);
@@ -116,6 +135,144 @@ public sealed class AwsSigV4Signer : ISmithySigner
         [
             $"{Algorithm} Credential={credentials.AccessKeyId}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}",
         ];
+    }
+
+    /// <summary>
+    /// Adds SigV4 authentication query parameters to a request and returns its absolute presigned
+    /// URI. The request is mutated so it can be sent directly after this call.
+    /// </summary>
+    /// <remarks>
+    /// Presigning uses <c>UNSIGNED-PAYLOAD</c>, the standard AWS query-signing behavior. AWS caps
+    /// SigV4 presigned URLs at seven days because the derived signing key is date-scoped.
+    /// </remarks>
+    public Uri Presign(
+        SmithyHttpRequest request,
+        AwsCredentials credentials,
+        TimeSpan expires
+    ) => Presign(request, credentials, expires, timeProvider.GetUtcNow());
+
+    internal Uri Presign(
+        SmithyHttpRequest request,
+        AwsCredentials credentials,
+        TimeSpan expires,
+        DateTimeOffset now
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(credentials);
+        if (expires < TimeSpan.FromSeconds(1) || expires > TimeSpan.FromDays(7))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(expires),
+                expires,
+                "SigV4 presigning duration must be between one second and seven days."
+            );
+        }
+
+        request.Headers.Remove("Authorization");
+        request.Headers.Remove("X-Amz-Date");
+        request.Headers.Remove("X-Amz-Security-Token");
+        var requestUri = ResolveRequestUri(request.RequestUri);
+        request.Headers["Host"] = [HostHeader(requestUri)];
+
+        var amzDate = now.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'", InvariantDateTime);
+        var date = now.UtcDateTime.ToString("yyyyMMdd", InvariantDateTime);
+        var credentialScope = $"{date}/{region}/{service}/aws4_request";
+        var canonicalHeaders = CanonicalHeaders(request);
+        var signedHeaders = string.Join(';', canonicalHeaders.Select(header => header.Name));
+
+        var query = QueryWithoutAuthentication(requestUri);
+        AddQueryParameter(query, "X-Amz-Algorithm", Algorithm);
+        AddQueryParameter(
+            query,
+            "X-Amz-Credential",
+            $"{credentials.AccessKeyId}/{credentialScope}"
+        );
+        AddQueryParameter(query, "X-Amz-Date", amzDate);
+        AddQueryParameter(
+            query,
+            "X-Amz-Expires",
+            ((long)expires.TotalSeconds).ToString(CultureInfo.InvariantCulture)
+        );
+        AddQueryParameter(query, "X-Amz-SignedHeaders", signedHeaders);
+        if (!string.IsNullOrEmpty(credentials.SessionToken))
+        {
+            AddQueryParameter(query, "X-Amz-Security-Token", credentials.SessionToken);
+        }
+
+        var unsignedUri = WithQuery(requestUri, query);
+        var canonicalRequest = string.Join(
+            '\n',
+            request.Method.Method.ToUpperInvariant(),
+            CanonicalPath(unsignedUri),
+            CanonicalQuery(unsignedUri),
+            string.Concat(canonicalHeaders.Select(header => $"{header.Name}:{header.Value}\n")),
+            signedHeaders,
+            "UNSIGNED-PAYLOAD"
+        );
+        var stringToSign = string.Join(
+            '\n',
+            Algorithm,
+            amzDate,
+            credentialScope,
+            Sha256Hex(Encoding.UTF8.GetBytes(canonicalRequest))
+        );
+        var signature = ToHex(
+            HmacSha256(
+                DeriveSigningKey(credentials.SecretAccessKey, date, region, service),
+                stringToSign
+            )
+        );
+        AddQueryParameter(query, "X-Amz-Signature", signature);
+
+        var presigned = WithQuery(requestUri, query);
+        request.RequestUri = presigned.AbsoluteUri;
+        return presigned;
+    }
+
+    private static List<KeyValuePair<string, string>> QueryWithoutAuthentication(Uri uri)
+    {
+        var result = new List<KeyValuePair<string, string>>();
+        if (string.IsNullOrEmpty(uri.Query) || uri.Query == "?")
+        {
+            return result;
+        }
+
+        foreach (var part in uri.Query[1..].Split('&', StringSplitOptions.None))
+        {
+            var equals = part.IndexOf('=', StringComparison.Ordinal);
+            var name = equals >= 0 ? part[..equals] : part;
+            var decodedName = Uri.UnescapeDataString(name);
+            if (PresignAuthenticationParameters.Contains(decodedName))
+            {
+                continue;
+            }
+            result.Add(
+                new KeyValuePair<string, string>(name, equals >= 0 ? part[(equals + 1)..] : "")
+            );
+        }
+        return result;
+    }
+
+    private static void AddQueryParameter(
+        List<KeyValuePair<string, string>> query,
+        string name,
+        string value
+    ) =>
+        query.Add(
+            new KeyValuePair<string, string>(
+                EscapeQueryComponent(name),
+                EscapeQueryComponent(value)
+            )
+        );
+
+    private static Uri WithQuery(Uri uri, IEnumerable<KeyValuePair<string, string>> query)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            Query = string.Join('&', query.Select(parameter => $"{parameter.Key}={parameter.Value}")),
+        };
+        return builder.Uri;
     }
 
     private Uri ResolveRequestUri(string requestUri)

--- a/packages/NSmithy.Aws/AwsSigV4Signer.cs
+++ b/packages/NSmithy.Aws/AwsSigV4Signer.cs
@@ -145,11 +145,8 @@ public sealed class AwsSigV4Signer : ISmithySigner
     /// Presigning uses <c>UNSIGNED-PAYLOAD</c>, the standard AWS query-signing behavior. AWS caps
     /// SigV4 presigned URLs at seven days because the derived signing key is date-scoped.
     /// </remarks>
-    public Uri Presign(
-        SmithyHttpRequest request,
-        AwsCredentials credentials,
-        TimeSpan expires
-    ) => Presign(request, credentials, expires, timeProvider.GetUtcNow());
+    public Uri Presign(SmithyHttpRequest request, AwsCredentials credentials, TimeSpan expires) =>
+        Presign(request, credentials, expires, timeProvider.GetUtcNow());
 
     internal Uri Presign(
         SmithyHttpRequest request,
@@ -270,7 +267,10 @@ public sealed class AwsSigV4Signer : ISmithySigner
     {
         var builder = new UriBuilder(uri)
         {
-            Query = string.Join('&', query.Select(parameter => $"{parameter.Key}={parameter.Value}")),
+            Query = string.Join(
+                '&',
+                query.Select(parameter => $"{parameter.Key}={parameter.Value}")
+            ),
         };
         return builder.Uri;
     }

--- a/packages/NSmithy.Aws/DefaultAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/DefaultAwsCredentialsProvider.cs
@@ -1,0 +1,51 @@
+namespace NSmithy.Aws;
+
+/// <summary>
+/// Resolves AWS credentials in SDK-compatible order: environment, shared profile (including cached
+/// IAM Identity Center/SSO sessions), then EC2 instance metadata.
+/// </summary>
+public sealed class DefaultAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private readonly IAwsCredentialsProvider[] providers;
+
+    public DefaultAwsCredentialsProvider(IEnumerable<IAwsCredentialsProvider>? providers = null)
+    {
+        this.providers =
+        [
+            .. providers
+                ?? [
+                    new EnvironmentAwsCredentialsProvider(),
+                    new ProfileAwsCredentialsProvider(),
+                    new InstanceMetadataAwsCredentialsProvider(),
+                ],
+        ];
+        if (this.providers.Length == 0)
+        {
+            throw new ArgumentException("At least one credentials provider is required.", nameof(providers));
+        }
+    }
+
+    public async ValueTask<AwsCredentials> GetCredentialsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        List<Exception>? unavailable = null;
+        foreach (var provider in providers)
+        {
+            try
+            {
+                return await provider.GetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (AwsCredentialsProviderException exception) when (exception.IsNotConfigured)
+            {
+                (unavailable ??= []).Add(exception);
+            }
+        }
+
+        throw new AwsCredentialsProviderException(
+            nameof(DefaultAwsCredentialsProvider),
+            "No AWS credentials were found in the environment, shared profile, or instance metadata.",
+            innerException: unavailable is null ? null : new AggregateException(unavailable)
+        );
+    }
+}

--- a/packages/NSmithy.Aws/DefaultAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/DefaultAwsCredentialsProvider.cs
@@ -13,7 +13,8 @@ public sealed class DefaultAwsCredentialsProvider : IAwsCredentialsProvider
         this.providers =
         [
             .. providers
-                ?? [
+                ??
+                [
                     new EnvironmentAwsCredentialsProvider(),
                     new ProfileAwsCredentialsProvider(),
                     new InstanceMetadataAwsCredentialsProvider(),
@@ -21,7 +22,10 @@ public sealed class DefaultAwsCredentialsProvider : IAwsCredentialsProvider
         ];
         if (this.providers.Length == 0)
         {
-            throw new ArgumentException("At least one credentials provider is required.", nameof(providers));
+            throw new ArgumentException(
+                "At least one credentials provider is required.",
+                nameof(providers)
+            );
         }
     }
 

--- a/packages/NSmithy.Aws/EnvironmentAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/EnvironmentAwsCredentialsProvider.cs
@@ -14,8 +14,7 @@ public sealed class EnvironmentAwsCredentialsProvider(
         cancellationToken.ThrowIfCancellationRequested();
 
         var accessKeyId =
-            getEnvironmentVariable("AWS_ACCESS_KEY_ID")
-            ?? getEnvironmentVariable("AWS_ACCESS_KEY");
+            getEnvironmentVariable("AWS_ACCESS_KEY_ID") ?? getEnvironmentVariable("AWS_ACCESS_KEY");
         var secretAccessKey =
             getEnvironmentVariable("AWS_SECRET_ACCESS_KEY")
             ?? getEnvironmentVariable("AWS_SECRET_KEY");
@@ -24,7 +23,8 @@ public sealed class EnvironmentAwsCredentialsProvider(
         if (string.IsNullOrWhiteSpace(accessKeyId) || string.IsNullOrWhiteSpace(secretAccessKey))
         {
             var noneConfigured =
-                string.IsNullOrWhiteSpace(accessKeyId) && string.IsNullOrWhiteSpace(secretAccessKey);
+                string.IsNullOrWhiteSpace(accessKeyId)
+                && string.IsNullOrWhiteSpace(secretAccessKey);
             throw new AwsCredentialsProviderException(
                 nameof(EnvironmentAwsCredentialsProvider),
                 "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be set.",

--- a/packages/NSmithy.Aws/EnvironmentAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/EnvironmentAwsCredentialsProvider.cs
@@ -1,21 +1,34 @@
 namespace NSmithy.Aws;
 
-public sealed class EnvironmentAwsCredentialsProvider : IAwsCredentialsProvider
+public sealed class EnvironmentAwsCredentialsProvider(
+    Func<string, string?>? getEnvironmentVariable = null
+) : IAwsCredentialsProvider
 {
+    private readonly Func<string, string?> getEnvironmentVariable =
+        getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+
     public ValueTask<AwsCredentials> GetCredentialsAsync(
         CancellationToken cancellationToken = default
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var accessKeyId = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");
-        var secretAccessKey = Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
-        var sessionToken = Environment.GetEnvironmentVariable("AWS_SESSION_TOKEN");
+        var accessKeyId =
+            getEnvironmentVariable("AWS_ACCESS_KEY_ID")
+            ?? getEnvironmentVariable("AWS_ACCESS_KEY");
+        var secretAccessKey =
+            getEnvironmentVariable("AWS_SECRET_ACCESS_KEY")
+            ?? getEnvironmentVariable("AWS_SECRET_KEY");
+        var sessionToken = getEnvironmentVariable("AWS_SESSION_TOKEN");
 
         if (string.IsNullOrWhiteSpace(accessKeyId) || string.IsNullOrWhiteSpace(secretAccessKey))
         {
-            throw new InvalidOperationException(
-                "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set."
+            var noneConfigured =
+                string.IsNullOrWhiteSpace(accessKeyId) && string.IsNullOrWhiteSpace(secretAccessKey);
+            throw new AwsCredentialsProviderException(
+                nameof(EnvironmentAwsCredentialsProvider),
+                "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be set.",
+                isNotConfigured: noneConfigured
             );
         }
 

--- a/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
@@ -10,6 +10,7 @@ public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProv
     {
         Timeout = TimeSpan.FromSeconds(2),
     };
+    // AWS exposes the EC2 Instance Metadata Service at this link-local address.
     private static readonly Uri DefaultEndpoint = new("http://169.254.169.254/");
 
     private readonly HttpClient httpClient;

--- a/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Text.Json.Serialization;
+
+namespace NSmithy.Aws;
+
+/// <summary>Loads EC2 role credentials through IMDSv2, with the standard optional IMDSv1 fallback.</summary>
+public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(2) };
+    private static readonly Uri DefaultEndpoint = new("http://169.254.169.254/");
+
+    private readonly HttpClient httpClient;
+    private readonly Uri endpoint;
+    private readonly bool allowV1Fallback;
+    private readonly Func<string, string?> getEnvironmentVariable;
+
+    public InstanceMetadataAwsCredentialsProvider(
+        HttpClient? httpClient = null,
+        Uri? endpoint = null,
+        bool allowV1Fallback = true,
+        Func<string, string?>? getEnvironmentVariable = null
+    )
+    {
+        this.httpClient = httpClient ?? SharedHttpClient;
+        this.endpoint = endpoint ?? DefaultEndpoint;
+        if (!this.endpoint.IsAbsoluteUri)
+        {
+            throw new ArgumentException("IMDS endpoint must be absolute.", nameof(endpoint));
+        }
+        this.allowV1Fallback = allowV1Fallback;
+        this.getEnvironmentVariable =
+            getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+    }
+
+    public async ValueTask<AwsCredentials> GetCredentialsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (
+            string.Equals(
+                getEnvironmentVariable("AWS_EC2_METADATA_DISABLED"),
+                "true",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(InstanceMetadataAwsCredentialsProvider),
+                "EC2 instance metadata is disabled by AWS_EC2_METADATA_DISABLED.",
+                isNotConfigured: true
+            );
+        }
+
+        var token = await GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        var roleName = (
+            await GetStringAsync("latest/meta-data/iam/security-credentials/", token, cancellationToken)
+                .ConfigureAwait(false)
+        )
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(roleName))
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(InstanceMetadataAwsCredentialsProvider),
+                "EC2 instance metadata did not return an IAM role name.",
+                isNotConfigured: true
+            );
+        }
+
+        var json = await GetStringAsync(
+                "latest/meta-data/iam/security-credentials/" + Uri.EscapeDataString(roleName),
+                token,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        var document = System.Text.Json.JsonSerializer.Deserialize<ImdsCredentials>(json);
+        if (
+            document is null
+            || !string.Equals(document.Code, "Success", StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(document.AccessKeyId)
+            || string.IsNullOrWhiteSpace(document.SecretAccessKey)
+        )
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(InstanceMetadataAwsCredentialsProvider),
+                "EC2 instance metadata returned an invalid credentials document."
+            );
+        }
+        return new AwsCredentials(
+            document.AccessKeyId,
+            document.SecretAccessKey,
+            document.Token,
+            document.Expiration
+        );
+    }
+
+    private async Task<string?> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, Resolve("latest/api/token"));
+        request.Headers.TryAddWithoutValidation("X-aws-ec2-metadata-token-ttl-seconds", "21600");
+        using var response = await httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        if (
+            IsV1FallbackEnabled()
+            && response.StatusCode
+                is HttpStatusCode.Forbidden
+                    or HttpStatusCode.NotFound
+                    or HttpStatusCode.MethodNotAllowed
+        )
+        {
+            return null;
+        }
+        throw new AwsCredentialsProviderException(
+            nameof(InstanceMetadataAwsCredentialsProvider),
+            $"IMDSv2 token request returned HTTP {(int)response.StatusCode}."
+        );
+    }
+
+    private async Task<string> GetStringAsync(
+        string path,
+        string? token,
+        CancellationToken cancellationToken
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, Resolve(path));
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.TryAddWithoutValidation("X-aws-ec2-metadata-token", token);
+        }
+        using var response = await httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(InstanceMetadataAwsCredentialsProvider),
+                $"Instance metadata request '{path}' returned HTTP {(int)response.StatusCode}.",
+                isNotConfigured: response.StatusCode == HttpStatusCode.NotFound
+            );
+        }
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private Uri Resolve(string path) => new(endpoint, path);
+
+    private bool IsV1FallbackEnabled() =>
+        allowV1Fallback
+        && !string.Equals(
+            getEnvironmentVariable("AWS_EC2_METADATA_V1_DISABLED"),
+            "true",
+            StringComparison.OrdinalIgnoreCase
+        );
+
+    private sealed record ImdsCredentials(
+        [property: JsonPropertyName("Code")] string? Code,
+        [property: JsonPropertyName("AccessKeyId")] string? AccessKeyId,
+        [property: JsonPropertyName("SecretAccessKey")] string? SecretAccessKey,
+        [property: JsonPropertyName("Token")] string? Token,
+        [property: JsonPropertyName("Expiration")] DateTimeOffset? Expiration
+    );
+}

--- a/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
@@ -6,7 +6,10 @@ namespace NSmithy.Aws;
 /// <summary>Loads EC2 role credentials through IMDSv2, with the standard optional IMDSv1 fallback.</summary>
 public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProvider
 {
-    private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(2) };
+    private static readonly HttpClient SharedHttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(2),
+    };
     private static readonly Uri DefaultEndpoint = new("http://169.254.169.254/");
 
     private readonly HttpClient httpClient;
@@ -28,8 +31,7 @@ public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProv
             throw new ArgumentException("IMDS endpoint must be absolute.", nameof(endpoint));
         }
         this.allowV1Fallback = allowV1Fallback;
-        this.getEnvironmentVariable =
-            getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+        this.getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
     }
 
     public async ValueTask<AwsCredentials> GetCredentialsAsync(
@@ -53,10 +55,17 @@ public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProv
 
         var token = await GetTokenAsync(cancellationToken).ConfigureAwait(false);
         var roleName = (
-            await GetStringAsync("latest/meta-data/iam/security-credentials/", token, cancellationToken)
+            await GetStringAsync(
+                    "latest/meta-data/iam/security-credentials/",
+                    token,
+                    cancellationToken
+                )
                 .ConfigureAwait(false)
         )
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(
+                ['\r', '\n'],
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
             .FirstOrDefault();
         if (string.IsNullOrWhiteSpace(roleName))
         {
@@ -103,7 +112,9 @@ public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProv
             .ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
         {
-            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return await response
+                .Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
         if (
             IsV1FallbackEnabled()

--- a/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/InstanceMetadataAwsCredentialsProvider.cs
@@ -10,6 +10,7 @@ public sealed class InstanceMetadataAwsCredentialsProvider : IAwsCredentialsProv
     {
         Timeout = TimeSpan.FromSeconds(2),
     };
+
     // AWS exposes the EC2 Instance Metadata Service at this link-local address.
     private static readonly Uri DefaultEndpoint = new("http://169.254.169.254/");
 

--- a/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
@@ -29,8 +29,7 @@ public sealed class ProfileAwsCredentialsProvider : IAwsCredentialsProvider
         this.ssoCacheDirectory = ssoCacheDirectory;
         this.httpClient = httpClient ?? SharedHttpClient;
         this.timeProvider = timeProvider ?? TimeProvider.System;
-        this.getEnvironmentVariable =
-            getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+        this.getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
     }
 
     public ValueTask<AwsCredentials> GetCredentialsAsync(
@@ -153,7 +152,9 @@ public sealed class ProfileAwsCredentialsProvider : IAwsCredentialsProvider
     }
 
     private static string ConfigSection(string profile) =>
-        string.Equals(profile, "default", StringComparison.Ordinal) ? profile : "profile " + profile;
+        string.Equals(profile, "default", StringComparison.Ordinal)
+            ? profile
+            : "profile " + profile;
 
     private static bool TryGetSsoSettings(
         Dictionary<string, string> values,

--- a/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
@@ -1,0 +1,188 @@
+namespace NSmithy.Aws;
+
+/// <summary>Loads static or IAM Identity Center credentials from AWS shared profile files.</summary>
+public sealed class ProfileAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private static readonly HttpClient SharedHttpClient = new();
+
+    private readonly string? profileName;
+    private readonly string? credentialsPath;
+    private readonly string? configPath;
+    private readonly string? ssoCacheDirectory;
+    private readonly HttpClient httpClient;
+    private readonly Func<string, string?> getEnvironmentVariable;
+    private readonly TimeProvider timeProvider;
+
+    public ProfileAwsCredentialsProvider(
+        string? profileName = null,
+        string? credentialsPath = null,
+        string? configPath = null,
+        string? ssoCacheDirectory = null,
+        HttpClient? httpClient = null,
+        TimeProvider? timeProvider = null,
+        Func<string, string?>? getEnvironmentVariable = null
+    )
+    {
+        this.profileName = profileName;
+        this.credentialsPath = credentialsPath;
+        this.configPath = configPath;
+        this.ssoCacheDirectory = ssoCacheDirectory;
+        this.httpClient = httpClient ?? SharedHttpClient;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+        this.getEnvironmentVariable =
+            getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+    }
+
+    public ValueTask<AwsCredentials> GetCredentialsAsync(
+        CancellationToken cancellationToken = default
+    ) => GetCredentialsCoreAsync(cancellationToken);
+
+    private async ValueTask<AwsCredentials> GetCredentialsCoreAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var selectedProfile =
+            profileName
+            ?? getEnvironmentVariable("AWS_PROFILE")
+            ?? getEnvironmentVariable("AWS_DEFAULT_PROFILE")
+            ?? "default";
+        var awsDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".aws"
+        );
+        var resolvedCredentialsPath =
+            credentialsPath
+            ?? getEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE")
+            ?? Path.Combine(awsDirectory, "credentials");
+        var resolvedConfigPath =
+            configPath
+            ?? getEnvironmentVariable("AWS_CONFIG_FILE")
+            ?? Path.Combine(awsDirectory, "config");
+
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        MergeSection(values, ReadIniFile(resolvedConfigPath), ConfigSection(selectedProfile));
+        MergeSection(values, ReadIniFile(resolvedCredentialsPath), selectedProfile);
+
+        if (
+            values.TryGetValue("aws_access_key_id", out var accessKeyId)
+            && values.TryGetValue("aws_secret_access_key", out var secretAccessKey)
+        )
+        {
+            values.TryGetValue("aws_session_token", out var sessionToken);
+            return new AwsCredentials(accessKeyId, secretAccessKey, sessionToken);
+        }
+
+        if (TryGetSsoSettings(values, resolvedConfigPath, out var sso))
+        {
+            var provider = new SsoAwsCredentialsProvider(
+                sso.AccountId,
+                sso.RoleName,
+                sso.Region,
+                sso.StartUrl,
+                ssoCacheDirectory ?? Path.Combine(awsDirectory, "sso", "cache"),
+                httpClient,
+                timeProvider
+            );
+            return await provider.GetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (values.Count == 0)
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(ProfileAwsCredentialsProvider),
+                $"AWS profile '{selectedProfile}' was not found.",
+                isNotConfigured: true
+            );
+        }
+
+        throw new AwsCredentialsProviderException(
+            nameof(ProfileAwsCredentialsProvider),
+            $"AWS profile '{selectedProfile}' does not contain static credentials or a complete SSO configuration."
+        );
+    }
+
+    private static Dictionary<string, Dictionary<string, string>> ReadIniFile(string path)
+    {
+        var sections = new Dictionary<string, Dictionary<string, string>>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        if (!File.Exists(path))
+        {
+            return sections;
+        }
+
+        Dictionary<string, string>? current = null;
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] is '#' or ';')
+            {
+                continue;
+            }
+            if (line[0] == '[' && line[^1] == ']')
+            {
+                var name = line[1..^1].Trim();
+                current = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                sections[name] = current;
+                continue;
+            }
+            var equals = line.IndexOf('=', StringComparison.Ordinal);
+            if (current is not null && equals > 0)
+            {
+                current[line[..equals].Trim()] = line[(equals + 1)..].Trim();
+            }
+        }
+        return sections;
+    }
+
+    private static void MergeSection(
+        Dictionary<string, string> destination,
+        Dictionary<string, Dictionary<string, string>> sections,
+        string section
+    )
+    {
+        if (!sections.TryGetValue(section, out var values))
+        {
+            return;
+        }
+        foreach (var value in values)
+        {
+            destination[value.Key] = value.Value;
+        }
+    }
+
+    private static string ConfigSection(string profile) =>
+        string.Equals(profile, "default", StringComparison.Ordinal) ? profile : "profile " + profile;
+
+    private static bool TryGetSsoSettings(
+        Dictionary<string, string> values,
+        string configPath,
+        out SsoSettings settings
+    )
+    {
+        if (values.TryGetValue("sso_session", out var session))
+        {
+            MergeSection(values, ReadIniFile(configPath), "sso-session " + session);
+        }
+        if (
+            values.TryGetValue("sso_start_url", out var startUrl)
+            && values.TryGetValue("sso_region", out var region)
+            && values.TryGetValue("sso_account_id", out var accountId)
+            && values.TryGetValue("sso_role_name", out var roleName)
+        )
+        {
+            settings = new SsoSettings(startUrl, region, accountId, roleName);
+            return true;
+        }
+        settings = default;
+        return false;
+    }
+
+    private readonly record struct SsoSettings(
+        string StartUrl,
+        string Region,
+        string AccountId,
+        string RoleName
+    );
+}

--- a/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/ProfileAwsCredentialsProvider.cs
@@ -1,36 +1,26 @@
 namespace NSmithy.Aws;
 
 /// <summary>Loads static or IAM Identity Center credentials from AWS shared profile files.</summary>
-public sealed class ProfileAwsCredentialsProvider : IAwsCredentialsProvider
+public sealed class ProfileAwsCredentialsProvider(
+    string? profileName = null,
+    string? credentialsPath = null,
+    string? configPath = null,
+    string? ssoCacheDirectory = null,
+    HttpClient? httpClient = null,
+    TimeProvider? timeProvider = null,
+    Func<string, string?>? getEnvironmentVariable = null
+) : IAwsCredentialsProvider
 {
     private static readonly HttpClient SharedHttpClient = new();
 
-    private readonly string? profileName;
-    private readonly string? credentialsPath;
-    private readonly string? configPath;
-    private readonly string? ssoCacheDirectory;
-    private readonly HttpClient httpClient;
-    private readonly Func<string, string?> getEnvironmentVariable;
-    private readonly TimeProvider timeProvider;
-
-    public ProfileAwsCredentialsProvider(
-        string? profileName = null,
-        string? credentialsPath = null,
-        string? configPath = null,
-        string? ssoCacheDirectory = null,
-        HttpClient? httpClient = null,
-        TimeProvider? timeProvider = null,
-        Func<string, string?>? getEnvironmentVariable = null
-    )
-    {
-        this.profileName = profileName;
-        this.credentialsPath = credentialsPath;
-        this.configPath = configPath;
-        this.ssoCacheDirectory = ssoCacheDirectory;
-        this.httpClient = httpClient ?? SharedHttpClient;
-        this.timeProvider = timeProvider ?? TimeProvider.System;
-        this.getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
-    }
+    private readonly string? profileName = profileName;
+    private readonly string? credentialsPath = credentialsPath;
+    private readonly string? configPath = configPath;
+    private readonly string? ssoCacheDirectory = ssoCacheDirectory;
+    private readonly HttpClient httpClient = httpClient ?? SharedHttpClient;
+    private readonly Func<string, string?> getEnvironmentVariable =
+        getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+    private readonly TimeProvider timeProvider = timeProvider ?? TimeProvider.System;
 
     public ValueTask<AwsCredentials> GetCredentialsAsync(
         CancellationToken cancellationToken = default

--- a/packages/NSmithy.Aws/SsoAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/SsoAwsCredentialsProvider.cs
@@ -1,0 +1,169 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace NSmithy.Aws;
+
+/// <summary>
+/// Exchanges an AWS CLI/IAM Identity Center cached access token for role credentials.
+/// Interactive SSO login remains the CLI's responsibility.
+/// </summary>
+public sealed class SsoAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private readonly string accountId;
+    private readonly string roleName;
+    private readonly string region;
+    private readonly string startUrl;
+    private readonly string cacheDirectory;
+    private readonly HttpClient httpClient;
+    private readonly TimeProvider timeProvider;
+
+    public SsoAwsCredentialsProvider(
+        string accountId,
+        string roleName,
+        string region,
+        string startUrl,
+        string cacheDirectory,
+        HttpClient httpClient,
+        TimeProvider? timeProvider = null
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accountId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+        ArgumentException.ThrowIfNullOrWhiteSpace(startUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheDirectory);
+        this.accountId = accountId;
+        this.roleName = roleName;
+        this.region = region;
+        this.startUrl = startUrl;
+        this.cacheDirectory = cacheDirectory;
+        this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async ValueTask<AwsCredentials> GetCredentialsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        var token = FindCachedToken();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://portal.sso.{region}.amazonaws.com/federation/credentials?account_id={Uri.EscapeDataString(accountId)}&role_name={Uri.EscapeDataString(roleName)}"
+        );
+        request.Headers.TryAddWithoutValidation("x-amz-sso_bearer_token", token);
+        using var response = await httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(SsoAwsCredentialsProvider),
+                $"IAM Identity Center returned HTTP {(int)response.StatusCode} while retrieving role credentials."
+            );
+        }
+
+        var payload = await response.Content
+            .ReadFromJsonAsync<SsoRoleCredentialsResponse>(cancellationToken)
+            .ConfigureAwait(false);
+        var credentials = payload?.RoleCredentials;
+        if (
+            credentials is null
+            || string.IsNullOrWhiteSpace(credentials.AccessKeyId)
+            || string.IsNullOrWhiteSpace(credentials.SecretAccessKey)
+        )
+        {
+            throw new AwsCredentialsProviderException(
+                nameof(SsoAwsCredentialsProvider),
+                "IAM Identity Center returned an invalid role-credentials response."
+            );
+        }
+
+        return new AwsCredentials(
+            credentials.AccessKeyId,
+            credentials.SecretAccessKey,
+            credentials.SessionToken,
+            DateTimeOffset.FromUnixTimeMilliseconds(credentials.Expiration)
+        );
+    }
+
+    private string FindCachedToken()
+    {
+        if (!Directory.Exists(cacheDirectory))
+        {
+            throw MissingToken();
+        }
+
+        SsoTokenCacheEntry? selected = null;
+        foreach (var path in Directory.EnumerateFiles(cacheDirectory, "*.json"))
+        {
+            try
+            {
+                var entry = System.Text.Json.JsonSerializer.Deserialize<SsoTokenCacheEntry>(
+                    File.ReadAllText(path)
+                );
+                if (
+                    entry is null
+                    || string.IsNullOrWhiteSpace(entry.AccessToken)
+                    || !string.Equals(entry.StartUrl, startUrl, StringComparison.Ordinal)
+                    || !TryParseExpiration(entry.ExpiresAt, out var expiration)
+                    || expiration <= timeProvider.GetUtcNow()
+                )
+                {
+                    continue;
+                }
+                if (
+                    selected is null
+                    || ParseExpiration(entry.ExpiresAt) > ParseExpiration(selected.ExpiresAt)
+                )
+                {
+                    selected = entry;
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // The CLI cache directory can contain unrelated or partially replaced JSON files.
+            }
+            catch (IOException)
+            {
+                // A concurrent CLI refresh may replace a cache file while it is being scanned.
+            }
+        }
+
+        return selected?.AccessToken ?? throw MissingToken();
+    }
+
+    private static bool TryParseExpiration(string? value, out DateTimeOffset expiration) =>
+        DateTimeOffset.TryParse(
+            value?.Replace("UTC", "Z", StringComparison.OrdinalIgnoreCase),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out expiration
+        );
+
+    private static DateTimeOffset ParseExpiration(string? value) =>
+        TryParseExpiration(value, out var expiration) ? expiration : DateTimeOffset.MinValue;
+
+    private AwsCredentialsProviderException MissingToken() =>
+        new(
+            nameof(SsoAwsCredentialsProvider),
+            $"No unexpired IAM Identity Center token for '{startUrl}' was found in '{cacheDirectory}'."
+        );
+
+    private sealed record SsoTokenCacheEntry(
+        [property: JsonPropertyName("startUrl")] string? StartUrl,
+        [property: JsonPropertyName("accessToken")] string? AccessToken,
+        [property: JsonPropertyName("expiresAt")] string? ExpiresAt
+    );
+
+    private sealed record SsoRoleCredentialsResponse(
+        [property: JsonPropertyName("roleCredentials")] SsoRoleCredentials? RoleCredentials
+    );
+
+    private sealed record SsoRoleCredentials(
+        [property: JsonPropertyName("accessKeyId")] string AccessKeyId,
+        [property: JsonPropertyName("secretAccessKey")] string SecretAccessKey,
+        [property: JsonPropertyName("sessionToken")] string? SessionToken,
+        [property: JsonPropertyName("expiration")] long Expiration
+    );
+}

--- a/packages/NSmithy.Aws/SsoAwsCredentialsProvider.cs
+++ b/packages/NSmithy.Aws/SsoAwsCredentialsProvider.cs
@@ -63,8 +63,8 @@ public sealed class SsoAwsCredentialsProvider : IAwsCredentialsProvider
             );
         }
 
-        var payload = await response.Content
-            .ReadFromJsonAsync<SsoRoleCredentialsResponse>(cancellationToken)
+        var payload = await response
+            .Content.ReadFromJsonAsync<SsoRoleCredentialsResponse>(cancellationToken)
             .ConfigureAwait(false);
         var credentials = payload?.RoleCredentials;
         if (

--- a/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
@@ -461,6 +461,9 @@ internal sealed class FlattenedMapXmlMemberReader<
     IXmlValueReader<TValue> valueReader
 ) : IXmlMemberReader<TBuilder>
 {
+    private readonly string keyName = MapKeyName(map);
+    private readonly string valueName = MapValueName(map.TypedValueMember);
+
     public string Name => ElementName(member);
 
     public bool IsRequired => member.IsRequired;
@@ -470,13 +473,13 @@ internal sealed class FlattenedMapXmlMemberReader<
         var mapBuilder = map.CreateTypedBuilder();
         foreach (var child in ChildElements(element, Name))
         {
-            var key = ChildElement(child, "key")?.Value;
+            var key = ChildElement(child, keyName)?.Value;
             if (key is null)
             {
                 continue;
             }
 
-            map.Add(mapBuilder, key, valueReader.Read(ChildElement(child, "value")));
+            map.Add(mapBuilder, key, valueReader.Read(ChildElement(child, valueName)));
         }
 
         member.SetValue(builder, map.Build(mapBuilder));
@@ -544,6 +547,9 @@ internal sealed class MapXmlValueReader<TDictionary, TValue, TBuilder>(
     IXmlValueReader<TValue> valueReader
 ) : IXmlValueReader<TDictionary>
 {
+    private readonly string keyName = MapKeyName(schema);
+    private readonly string valueName = MapValueName(schema.TypedValueMember);
+
     public TDictionary Read(XElement? element)
     {
         var builder = schema.CreateTypedBuilder();
@@ -551,13 +557,13 @@ internal sealed class MapXmlValueReader<TDictionary, TValue, TBuilder>(
         {
             foreach (var entry in element.Elements())
             {
-                var key = ChildElement(entry, "key")?.Value;
+                var key = ChildElement(entry, keyName)?.Value;
                 if (key is null)
                 {
                     continue;
                 }
 
-                schema.Add(builder, key, valueReader.Read(ChildElement(entry, "value")));
+                schema.Add(builder, key, valueReader.Read(ChildElement(entry, valueName)));
             }
         }
 

--- a/packages/NSmithy.Codecs.Xml/XmlWire.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlWire.cs
@@ -249,6 +249,12 @@ internal static class XmlWire
     internal static string ListItemName(IListSchema schema) =>
         XmlTraits.GetXmlName(schema.ElementMember) ?? schema.Element.MemberName ?? "member";
 
+    internal static string MapKeyName(IMapSchema schema) =>
+        XmlTraits.GetXmlName(schema.KeyMember) ?? "key";
+
+    internal static string MapValueName(IMemberSchema valueMember) =>
+        XmlTraits.GetXmlName(valueMember) ?? "value";
+
     internal static string ElementName(IMemberSchema member) =>
         XmlTraits.GetXmlName(member) ?? member.Name;
 

--- a/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
@@ -549,6 +549,8 @@ internal sealed class FlattenedMapXmlMemberPlan<TDictionary, TValue>(
 ) : IXmlMemberPlan<TDictionary>
 {
     private readonly bool isRequired = member.IsRequired;
+    private readonly string keyName = MapKeyName(map);
+    private readonly string valueName = MapValueName(map.TypedValueMember);
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TDictionary? Value) memberDefault = ResolveDefault(
@@ -577,8 +579,8 @@ internal sealed class FlattenedMapXmlMemberPlan<TDictionary, TValue>(
         foreach (var entry in map.GetEntries(value))
         {
             var child = new XElement(ElementName(member));
-            child.Add(new XElement("key", entry.Key));
-            var valueElement = new XElement("value");
+            child.Add(new XElement(keyName, entry.Key));
+            var valueElement = new XElement(valueName);
             valueWriter.Write(valueElement, entry.Value);
             child.Add(valueElement);
             element.Add(child);
@@ -659,6 +661,9 @@ internal sealed class MapXmlValueWriter<TDictionary, TValue>(
     IXmlValueWriter<TValue> valueWriter
 ) : IXmlValueWriter<TDictionary>
 {
+    private readonly string keyName = MapKeyName(schema);
+    private readonly string valueName = MapValueName(schema.TypedValueMember);
+
     public void Write(XElement element, TDictionary value)
     {
         if (value is null)
@@ -669,8 +674,8 @@ internal sealed class MapXmlValueWriter<TDictionary, TValue>(
         foreach (var entry in schema.GetEntries(value))
         {
             var entryElement = new XElement("entry");
-            entryElement.Add(new XElement("key", entry.Key));
-            var valueElement = new XElement("value");
+            entryElement.Add(new XElement(keyName, entry.Key));
+            var valueElement = new XElement(valueName);
             valueWriter.Write(valueElement, entry.Value);
             entryElement.Add(valueElement);
             element.Add(entryElement);

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -1664,12 +1664,23 @@ public sealed class OperationErrorSchema<TError>(
 public sealed class ServiceSchema
 {
     internal ServiceSchema(ShapeId id, IEnumerable<Trait>? traits = null)
+        : this(id, string.Empty, traits) { }
+
+    internal ServiceSchema(ShapeId id, string version, IEnumerable<Trait>? traits = null)
     {
         Id = id;
+        Version = version ?? throw new ArgumentNullException(nameof(version));
         Traits = Schema.BuildTraits(traits);
     }
 
     public ShapeId Id { get; }
+
+    /// <summary>
+    /// The service's Smithy <c>version</c>. Protocols such as AWS Query and EC2 Query serialize
+    /// this value in every request. Manually constructed schemas that use the compatibility
+    /// overload expose an empty version.
+    /// </summary>
+    public string Version { get; }
 
     public IReadOnlyDictionary<ShapeId, Trait> Traits { get; }
 
@@ -1912,6 +1923,12 @@ public static class Schemas
 
     public static ServiceSchema Service(ShapeId id, IEnumerable<Trait>? traits = null) =>
         new(id, traits);
+
+    public static ServiceSchema Service(
+        ShapeId id,
+        string version,
+        IEnumerable<Trait>? traits = null
+    ) => new(id, version, traits);
 
     public static StructProjection<T, TBuilder> Project<T, TBuilder>(
         IStructSchema<T, TBuilder> source,

--- a/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
@@ -1,0 +1,235 @@
+using System.Text;
+using System.Xml.Linq;
+using NSmithy.Codecs.Xml;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Http;
+
+namespace NSmithy.Protocols.AwsQuery;
+
+public sealed class AwsQueryProtocol : QueryProtocol
+{
+    public AwsQueryProtocol()
+        : base(ec2Query: false) { }
+}
+
+public sealed class Ec2QueryProtocol : QueryProtocol
+{
+    public Ec2QueryProtocol()
+        : base(ec2Query: true) { }
+}
+
+public abstract class QueryProtocol(bool ec2Query) : IProtocol
+{
+    private const string FormContentType = "application/x-www-form-urlencoded";
+    private static readonly ShapeId AwsQueryError = ShapeId.Parse("aws.protocols#awsQueryError");
+
+    public IServiceProtocol ForService(ServiceSchema service)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        if (string.IsNullOrWhiteSpace(service.Version))
+        {
+            throw new ArgumentException(
+                "AWS Query protocols require a service schema with a Smithy version.",
+                nameof(service)
+            );
+        }
+        return new ServiceProtocol(
+            service,
+            ec2Query ? QueryProtocolKind.Ec2Query : QueryProtocolKind.AwsQuery
+        );
+    }
+
+    private sealed class ServiceProtocol(ServiceSchema service, QueryProtocolKind kind)
+        : IServiceProtocol
+    {
+        public IClientOperationProtocol<TInput, TOutput> ForClientOperation<TInput, TOutput>(
+            OperationSchema<TInput, TOutput> operation
+        )
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            return new OperationProtocol<TInput, TOutput>(service, operation, kind);
+        }
+
+        public IServerOperationProtocol<TInput, TOutput> ForServerOperation<TInput, TOutput>(
+            OperationSchema<TInput, TOutput> operation
+        ) => throw new NotSupportedException("AWS Query protocols do not support serving operations.");
+    }
+
+    private sealed class OperationProtocol<TInput, TOutput>
+        : IClientOperationProtocol<TInput, TOutput>
+    {
+        private readonly string action;
+        private readonly string version;
+        private readonly Schema<TInput> inputSchema;
+        private readonly Schema<TOutput> outputSchema;
+        private readonly IXmlCodec<TOutput> responseCodec;
+        private readonly bool outputIsSmithyUnit;
+        private readonly bool outputIsUnit;
+        private readonly QueryProtocolKind kind;
+        private readonly Action<SmithyHttpRequest>? requestTransform;
+        private readonly QueryError[] errors;
+
+        public OperationProtocol(
+            ServiceSchema service,
+            OperationSchema<TInput, TOutput> operation,
+            QueryProtocolKind kind
+        )
+        {
+            action = operation.Id.Name;
+            version = service.Version;
+            inputSchema = operation.Input;
+            outputSchema = operation.Output;
+            responseCodec = XmlCodec.FromSchema(operation.Output);
+            outputIsSmithyUnit = typeof(TOutput) == typeof(SmithyUnit);
+            outputIsUnit = outputIsSmithyUnit || Schemas.IsSyntheticUnit(operation.Output);
+            this.kind = kind;
+            requestTransform = SmithyRequestModifiers.Compile(operation);
+            errors = CompileErrors(operation.Errors);
+        }
+
+        public SmithyHttpRequest SerializeRequest(
+            TInput input,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var request = new SmithyHttpRequest(HttpMethod.Post, "/")
+            {
+                Body = new SmithyHttpBody.Bytes(
+                    new QueryFormSerializer(kind).Serialize(action, version, inputSchema, input)
+                ),
+                ContentType = FormContentType,
+            };
+            request.Headers["Accept"] = ["text/xml"];
+            requestTransform?.Invoke(request);
+            return request;
+        }
+
+        public ValueTask<TOutput> DeserializeResponseAsync(
+            SmithyHttpClientResponse response,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            if (outputIsSmithyUnit)
+            {
+                return ValueTask.FromResult((TOutput)(object)SmithyUnit.Value);
+            }
+            if (response.Content.Length == 0 || outputIsUnit)
+            {
+                return ValueTask.FromResult(CreateEmptyOutput(outputSchema));
+            }
+
+            var payload = ExtractResultPayload(response.Content, action, kind);
+            if (payload.Length == 0)
+            {
+                return ValueTask.FromResult(CreateEmptyOutput(outputSchema));
+            }
+            return ValueTask.FromResult(responseCodec.Deserialize(payload));
+        }
+
+        public bool IsErrorResponse(SmithyHttpClientResponse response) =>
+            (int)response.StatusCode >= 400;
+
+        public ValueTask<Exception?> DeserializeErrorAsync(
+            SmithyHttpClientResponse response,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            if (errors.Length == 0 || response.Content.Length == 0)
+            {
+                return ValueTask.FromResult<Exception?>(null);
+            }
+
+            var errorElement = ExtractErrorElement(response.Content, kind);
+            var code = Child(errorElement, "Code")?.Value;
+            var error = code is null
+                ? null
+                : errors.FirstOrDefault(candidate =>
+                    string.Equals(candidate.Code, code, StringComparison.Ordinal)
+                    || string.Equals(candidate.Id.Name, code, StringComparison.Ordinal)
+                    || string.Equals(candidate.Id.ToString(), code, StringComparison.Ordinal)
+                );
+            error ??= errors.FirstOrDefault(candidate =>
+                candidate.HttpStatusCode == (int)response.StatusCode
+            );
+            error ??= errors[0];
+            return ValueTask.FromResult<Exception?>(error.Deserialize(errorElement));
+        }
+
+        private static QueryError[] CompileErrors(IReadOnlyList<IOperationErrorSchema> schemas) =>
+            schemas.Select(error => (QueryError)CompileError((dynamic)error)).ToArray();
+
+        private static QueryError CompileError<TError>(OperationErrorSchema<TError> error)
+            where TError : Exception
+        {
+            var codec = XmlCodec.FromSchema(error.Schema);
+            var code = QueryErrorCode(error.Schema) ?? error.Id.Name;
+            return new QueryError(
+                error.Id,
+                code,
+                error.HttpStatusCode,
+                element => codec.Deserialize(ElementBytes(element))
+            );
+        }
+
+        private static string? QueryErrorCode(Schema schema)
+        {
+            if (schema.GetTrait(AwsQueryError)?.Value is not { Kind: DocumentKind.Object } value)
+            {
+                return null;
+            }
+            return value.AsObject().TryGetValue("code", out var code)
+                && code.Kind == DocumentKind.String
+                ? code.AsString()
+                : null;
+        }
+    }
+
+    private sealed record QueryError(
+        ShapeId Id,
+        string Code,
+        int HttpStatusCode,
+        Func<XElement, Exception> Deserialize
+    );
+
+    private static byte[] ExtractResultPayload(
+        byte[] content,
+        string operationName,
+        QueryProtocolKind kind
+    )
+    {
+        var root = XElement.Parse(Encoding.UTF8.GetString(content));
+        if (kind == QueryProtocolKind.Ec2Query)
+        {
+            return ElementBytes(root);
+        }
+
+        var result = Child(root, operationName + "Result");
+        return result is null ? [] : ElementBytes(result);
+    }
+
+    private static XElement ExtractErrorElement(byte[] content, QueryProtocolKind kind)
+    {
+        var root = XElement.Parse(Encoding.UTF8.GetString(content));
+        var error = kind == QueryProtocolKind.AwsQuery
+            ? Child(root, "Error")
+            : Child(Child(root, "Errors"), "Error");
+        return error
+            ?? throw new InvalidOperationException("Response body was missing its query error element.");
+    }
+
+    private static XElement? Child(XElement? parent, string localName) =>
+        parent
+            ?.Elements()
+            .FirstOrDefault(element =>
+                string.Equals(element.Name.LocalName, localName, StringComparison.Ordinal)
+            );
+
+    private static byte[] ElementBytes(XElement element) =>
+        Encoding.UTF8.GetBytes(element.ToString(SaveOptions.DisableFormatting));
+
+    private static T CreateEmptyOutput<T>(Schema<T> schema) =>
+        schema.Resolved is IStructSchema<T> structure ? structure.BuildEmpty() : default!;
+}

--- a/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
@@ -53,7 +53,10 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
 
         public IServerOperationProtocol<TInput, TOutput> ForServerOperation<TInput, TOutput>(
             OperationSchema<TInput, TOutput> operation
-        ) => throw new NotSupportedException("AWS Query protocols do not support serving operations.");
+        ) =>
+            throw new NotSupportedException(
+                "AWS Query protocols do not support serving operations."
+            );
     }
 
     private sealed class OperationProtocol<TInput, TOutput>
@@ -180,7 +183,8 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
             {
                 return null;
             }
-            return value.AsObject().TryGetValue("code", out var code)
+            return
+                value.AsObject().TryGetValue("code", out var code)
                 && code.Kind == DocumentKind.String
                 ? code.AsString()
                 : null;
@@ -213,11 +217,14 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
     private static XElement ExtractErrorElement(byte[] content, QueryProtocolKind kind)
     {
         var root = XElement.Parse(Encoding.UTF8.GetString(content));
-        var error = kind == QueryProtocolKind.AwsQuery
-            ? Child(root, "Error")
-            : Child(Child(root, "Errors"), "Error");
+        var error =
+            kind == QueryProtocolKind.AwsQuery
+                ? Child(root, "Error")
+                : Child(Child(root, "Errors"), "Error");
         return error
-            ?? throw new InvalidOperationException("Response body was missing its query error element.");
+            ?? throw new InvalidOperationException(
+                "Response body was missing its query error element."
+            );
     }
 
     private static XElement? Child(XElement? parent, string localName) =>

--- a/packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj
+++ b/packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../NSmithy.Codecs.Xml/NSmithy.Codecs.Xml.csproj" />
+    <ProjectReference Include="../NSmithy.Http/NSmithy.Http.csproj" />
+  </ItemGroup>
+</Project>

--- a/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
@@ -93,8 +93,7 @@ internal sealed class QueryFormSerializer(QueryProtocolKind kind)
     )
     {
         var elements = schema.GetElementsObject(value).ToArray();
-        var flattened =
-            kind == QueryProtocolKind.Ec2Query || HasDirectTrait(traits, XmlFlattened);
+        var flattened = kind == QueryProtocolKind.Ec2Query || HasDirectTrait(traits, XmlFlattened);
         if (elements.Length == 0)
         {
             if (kind == QueryProtocolKind.AwsQuery && !flattened)
@@ -110,7 +109,11 @@ internal sealed class QueryFormSerializer(QueryProtocolKind kind)
                 : null;
         for (var index = 0; index < elements.Length; index++)
         {
-            var itemPrefix = Join(prefix, itemName, (index + 1).ToString(CultureInfo.InvariantCulture));
+            var itemPrefix = Join(
+                prefix,
+                itemName,
+                (index + 1).ToString(CultureInfo.InvariantCulture)
+            );
             WriteValue(
                 schema.Element,
                 elements[index],
@@ -260,10 +263,8 @@ internal sealed class QueryFormSerializer(QueryProtocolKind kind)
             ? trait.Value.AsString()
             : null;
 
-    private static bool HasDirectTrait(
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        ShapeId id
-    ) => traits?.ContainsKey(id) == true;
+    private static bool HasDirectTrait(IReadOnlyDictionary<ShapeId, Trait>? traits, ShapeId id) =>
+        traits?.ContainsKey(id) == true;
 
     private static Schema UnwrapNullable(Schema schema) =>
         schema.Resolved is INullableSchema nullable ? nullable.Target.Resolved : schema.Resolved;

--- a/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
@@ -1,0 +1,302 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Protocols.AwsQuery;
+
+internal enum QueryProtocolKind
+{
+    AwsQuery,
+    Ec2Query,
+}
+
+internal sealed class QueryFormSerializer(QueryProtocolKind kind)
+{
+    private static readonly ShapeId Ec2QueryName = ShapeId.Parse("aws.protocols#ec2QueryName");
+    private static readonly ShapeId TimestampFormat = ShapeId.Parse("smithy.api#timestampFormat");
+    private static readonly ShapeId XmlFlattened = ShapeId.Parse("smithy.api#xmlFlattened");
+    private static readonly ShapeId XmlName = ShapeId.Parse("smithy.api#xmlName");
+
+    private readonly List<KeyValuePair<string, string>> parameters = [];
+
+    public byte[] Serialize<T>(string action, string version, Schema<T> schema, T value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        ArgumentNullException.ThrowIfNull(schema);
+
+        parameters.Clear();
+        parameters.Add(new KeyValuePair<string, string>("Action", action));
+        parameters.Add(new KeyValuePair<string, string>("Version", version));
+        WriteValue(schema, value, string.Empty, traits: null);
+
+        return Encoding.UTF8.GetBytes(
+            string.Join(
+                "&",
+                parameters.Select(parameter =>
+                    $"{Uri.EscapeDataString(parameter.Key)}={Uri.EscapeDataString(parameter.Value)}"
+                )
+            )
+        );
+    }
+
+    private void WriteValue(
+        Schema schema,
+        object? value,
+        string prefix,
+        IReadOnlyDictionary<ShapeId, Trait>? traits
+    )
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        schema = UnwrapNullable(schema);
+        switch (schema)
+        {
+            case IStructSchema structure:
+                WriteStruct((dynamic)structure, value, prefix);
+                return;
+            case IListSchema list:
+                WriteList(list, value, prefix, traits);
+                return;
+            case IMapSchema map:
+                WriteMap(map, value, prefix, traits);
+                return;
+            case IUnionSchema:
+                throw Unsupported(schema);
+        }
+
+        if (prefix.Length == 0)
+        {
+            return;
+        }
+
+        parameters.Add(
+            new KeyValuePair<string, string>(prefix, FormatScalar(schema, traits, value))
+        );
+    }
+
+    private void WriteStruct<T>(IStructSchema<T> schema, object value, string prefix)
+    {
+        schema.VisitMembers(new StructWriter<T>(this, (T)value, prefix));
+    }
+
+    private void WriteList(
+        IListSchema schema,
+        object value,
+        string prefix,
+        IReadOnlyDictionary<ShapeId, Trait>? traits
+    )
+    {
+        var elements = schema.GetElementsObject(value).ToArray();
+        var flattened =
+            kind == QueryProtocolKind.Ec2Query || HasDirectTrait(traits, XmlFlattened);
+        if (elements.Length == 0)
+        {
+            if (kind == QueryProtocolKind.AwsQuery && !flattened)
+            {
+                parameters.Add(new KeyValuePair<string, string>(prefix, string.Empty));
+            }
+            return;
+        }
+
+        var itemName =
+            kind == QueryProtocolKind.AwsQuery && !flattened
+                ? DirectStringTrait(schema.ElementMember.MemberTraits, XmlName) ?? "member"
+                : null;
+        for (var index = 0; index < elements.Length; index++)
+        {
+            var itemPrefix = Join(prefix, itemName, (index + 1).ToString(CultureInfo.InvariantCulture));
+            WriteValue(
+                schema.Element,
+                elements[index],
+                itemPrefix,
+                schema.ElementMember.MemberTraits
+            );
+        }
+    }
+
+    private void WriteMap(
+        IMapSchema schema,
+        object value,
+        string prefix,
+        IReadOnlyDictionary<ShapeId, Trait>? traits
+    )
+    {
+        var entries = schema.GetEntriesObject(value).ToArray();
+        if (entries.Length == 0)
+        {
+            return;
+        }
+        if (kind == QueryProtocolKind.Ec2Query)
+        {
+            throw new NotSupportedException("EC2 Query does not support map input shapes.");
+        }
+
+        var flattened = HasDirectTrait(traits, XmlFlattened);
+        var keyName = DirectStringTrait(schema.KeyMember.MemberTraits, XmlName) ?? "key";
+        var valueMember = FindMapValueMember(schema);
+        var valueName = DirectStringTrait(valueMember.MemberTraits, XmlName) ?? "value";
+        for (var index = 0; index < entries.Length; index++)
+        {
+            var entryPrefix = Join(
+                prefix,
+                flattened ? null : "entry",
+                (index + 1).ToString(CultureInfo.InvariantCulture)
+            );
+            parameters.Add(
+                new KeyValuePair<string, string>(Join(entryPrefix, keyName), entries[index].Key)
+            );
+            WriteValue(
+                schema.Value,
+                entries[index].Value,
+                Join(entryPrefix, valueName),
+                valueMember.MemberTraits
+            );
+        }
+    }
+
+    private static IMemberSchema FindMapValueMember(IMapSchema schema) =>
+        (IMemberSchema)((dynamic)schema).TypedValueMember;
+
+    private string MemberName(IMemberSchema member)
+    {
+        if (kind == QueryProtocolKind.AwsQuery)
+        {
+            return DirectStringTrait(member.MemberTraits, XmlName) ?? member.Name;
+        }
+
+        var ec2Name = DirectStringTrait(member.MemberTraits, Ec2QueryName);
+        if (ec2Name is not null)
+        {
+            return ec2Name;
+        }
+
+        return UppercaseFirst(DirectStringTrait(member.MemberTraits, XmlName) ?? member.Name);
+    }
+
+    private static string FormatScalar(
+        Schema schema,
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        object value
+    ) =>
+        schema.Kind switch
+        {
+            ShapeKind.Boolean => (bool)value ? "true" : "false",
+            ShapeKind.Byte => ((sbyte)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.Short => ((short)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.Integer => ((int)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.Long => ((long)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.Float => ((float)value).ToString("R", CultureInfo.InvariantCulture),
+            ShapeKind.Double => ((double)value).ToString("R", CultureInfo.InvariantCulture),
+            ShapeKind.BigInteger => ((BigInteger)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.BigDecimal => ((decimal)value).ToString(CultureInfo.InvariantCulture),
+            ShapeKind.String => (string)value,
+            ShapeKind.Enum => ((IStringEnumValue)value).Value,
+            ShapeKind.IntEnum => ((IIntEnumSchema)schema)
+                .GetIntegerValueObject(value)
+                .ToString(CultureInfo.InvariantCulture),
+            ShapeKind.Blob when value is byte[] bytes => Convert.ToBase64String(bytes),
+            ShapeKind.Timestamp => FormatTimestamp(schema, traits, (DateTimeOffset)value),
+            _ => throw Unsupported(schema),
+        };
+
+    private static string FormatTimestamp(
+        Schema schema,
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        DateTimeOffset value
+    ) =>
+        TraitValue(schema, traits, TimestampFormat) switch
+        {
+            null or "date-time" => FormatRfc3339(value),
+            "epoch-seconds" => FormatEpochSeconds(value),
+            "http-date" => value.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture),
+            var format => throw new NotSupportedException(
+                $"Timestamp format '{format}' is not supported by AWS Query."
+            ),
+        };
+
+    private static string FormatRfc3339(DateTimeOffset value)
+    {
+        var utc = value.ToUniversalTime();
+        return utc.Ticks % TimeSpan.TicksPerSecond == 0
+            ? utc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture)
+            : utc.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatEpochSeconds(DateTimeOffset value)
+    {
+        var unixSeconds = value.ToUnixTimeSeconds();
+        var fractionalTicks = value.ToUniversalTime().Ticks % TimeSpan.TicksPerSecond;
+        if (fractionalTicks == 0)
+        {
+            return unixSeconds.ToString(CultureInfo.InvariantCulture);
+        }
+
+        var fractional = ((decimal)fractionalTicks / TimeSpan.TicksPerSecond).ToString(
+            "0.################",
+            CultureInfo.InvariantCulture
+        );
+        return $"{unixSeconds}{fractional[1..]}";
+    }
+
+    private static string? TraitValue(
+        Schema schema,
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        ShapeId id
+    ) =>
+        DirectStringTrait(traits, id)
+        ?? (schema.GetTrait(id) is { HasValue: true } trait ? trait.Value.AsString() : null);
+
+    private static string? DirectStringTrait(
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        ShapeId id
+    ) =>
+        traits is not null && traits.TryGetValue(id, out var trait) && trait.HasValue
+            ? trait.Value.AsString()
+            : null;
+
+    private static bool HasDirectTrait(
+        IReadOnlyDictionary<ShapeId, Trait>? traits,
+        ShapeId id
+    ) => traits?.ContainsKey(id) == true;
+
+    private static Schema UnwrapNullable(Schema schema) =>
+        schema.Resolved is INullableSchema nullable ? nullable.Target.Resolved : schema.Resolved;
+
+    private static string Join(string first, params string?[] parts)
+    {
+        var values = parts.Where(part => !string.IsNullOrEmpty(part));
+        return first.Length == 0 ? string.Join('.', values) : string.Join('.', [first, .. values]);
+    }
+
+    private static string UppercaseFirst(string value) =>
+        value.Length == 0 ? value : char.ToUpperInvariant(value[0]) + value[1..];
+
+    private static NotSupportedException Unsupported(Schema schema) =>
+        new($"AWS Query does not support schema kind '{schema.Kind}' on shape '{schema.Id}'.");
+
+    private sealed class StructWriter<T>(QueryFormSerializer owner, T value, string prefix)
+        : IMemberVisitor<T>
+    {
+        public void Visit<TValue>(IMemberSchema<T, TValue> member)
+        {
+            var memberValue = member.GetValue(value);
+            if (memberValue is null)
+            {
+                return;
+            }
+
+            owner.WriteValue(
+                member.TargetSchema,
+                memberValue,
+                Join(prefix, owner.MemberName(member)),
+                member.MemberTraits
+            );
+        }
+    }
+}

--- a/tests/Conformance/AwsQuery/AwsQuery.Conformance.csproj
+++ b/tests/Conformance/AwsQuery/AwsQuery.Conformance.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace></RootNamespace>
+    <IsPackable>false</IsPackable>
+    <SmithyBuildFile>smithy-build.json</SmithyBuildFile>
+    <SmithyProjection>awsquery</SmithyProjection>
+    <SmithyBuildOutputPath>$(BaseIntermediateOutputPath)Smithy/</SmithyBuildOutputPath>
+    <SmithyGenerateServer>false</SmithyGenerateServer>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile
+      Include="../AwsJson/Conformance/*.cs"
+      Exclude="../AwsJson/Conformance/AwsJsonAllowlist.cs"
+      Link="Conformance/%(Filename)%(Extension)"
+    />
+    <ProjectReference Include="../../../packages/NSmithy.Client/NSmithy.Client.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Codecs.Xml/NSmithy.Codecs.Xml.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Core/NSmithy.Core.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Http/NSmithy.Http.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj" />
+  </ItemGroup>
+
+  <Import Project="../../../packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets" />
+
+  <Target
+    Name="_CopySmithyModelJsonToOutput"
+    DependsOnTargets="GenerateSmithyCode"
+    BeforeTargets="AssignTargetPaths;CopyFilesToOutputDirectory"
+  >
+    <ItemGroup>
+      <Content
+        Include="$(SmithyBuildOutputPath)source/model/model.json"
+        Link="smithy-model.json"
+        CopyToOutputDirectory="PreserveNewest"
+        Visible="false"
+      />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/tests/Conformance/AwsQuery/Conformance/AwsJsonAllowlist.cs
+++ b/tests/Conformance/AwsQuery/Conformance/AwsJsonAllowlist.cs
@@ -1,0 +1,26 @@
+namespace AwsJson.Conformance;
+
+internal static class AwsJsonAllowlist
+{
+    public const string Protocol = "aws.protocols#awsQuery";
+
+    public static readonly IReadOnlySet<string> ExecutableRequestCases = LoadRequestCases();
+
+    public static readonly IReadOnlySet<string> ExecutableResponseCases = LoadResponseCases();
+
+    private static HashSet<string> LoadRequestCases() =>
+        SmithyTestModel
+            .Load()
+            .EnumerateHttpRequestTests(Protocol)
+            .Where(test => test.AppliesToClient)
+            .Select(test => test.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static HashSet<string> LoadResponseCases() =>
+        SmithyTestModel
+            .Load()
+            .EnumerateHttpResponseTests(Protocol)
+            .Where(test => test.AppliesToClient)
+            .Select(test => test.Id)
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/tests/Conformance/AwsQuery/smithy-build.json
+++ b/tests/Conformance/AwsQuery/smithy-build.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "maven": {
+    "repositories": [{ "url": "https://repo.maven.apache.org/maven2/" }],
+    "dependencies": [
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.73.0"
+    ]
+  },
+  "projections": {
+    "awsquery": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": { "services": ["aws.protocoltests.query#AwsQuery"] }
+        }
+      ],
+      "plugins": {
+        "csharp-codegen": {
+          "service": "aws.protocoltests.query#AwsQuery",
+          "baseNamespace": ""
+        }
+      }
+    }
+  }
+}

--- a/tests/Conformance/Ec2Query/Conformance/AwsJsonAllowlist.cs
+++ b/tests/Conformance/Ec2Query/Conformance/AwsJsonAllowlist.cs
@@ -1,0 +1,26 @@
+namespace AwsJson.Conformance;
+
+internal static class AwsJsonAllowlist
+{
+    public const string Protocol = "aws.protocols#ec2Query";
+
+    public static readonly IReadOnlySet<string> ExecutableRequestCases = LoadRequestCases();
+
+    public static readonly IReadOnlySet<string> ExecutableResponseCases = LoadResponseCases();
+
+    private static HashSet<string> LoadRequestCases() =>
+        SmithyTestModel
+            .Load()
+            .EnumerateHttpRequestTests(Protocol)
+            .Where(test => test.AppliesToClient)
+            .Select(test => test.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static HashSet<string> LoadResponseCases() =>
+        SmithyTestModel
+            .Load()
+            .EnumerateHttpResponseTests(Protocol)
+            .Where(test => test.AppliesToClient)
+            .Select(test => test.Id)
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/tests/Conformance/Ec2Query/Ec2Query.Conformance.csproj
+++ b/tests/Conformance/Ec2Query/Ec2Query.Conformance.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace></RootNamespace>
+    <IsPackable>false</IsPackable>
+    <SmithyBuildFile>smithy-build.json</SmithyBuildFile>
+    <SmithyProjection>ec2query</SmithyProjection>
+    <SmithyBuildOutputPath>$(BaseIntermediateOutputPath)Smithy/</SmithyBuildOutputPath>
+    <SmithyGenerateServer>false</SmithyGenerateServer>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile
+      Include="../AwsJson/Conformance/*.cs"
+      Exclude="../AwsJson/Conformance/AwsJsonAllowlist.cs"
+      Link="Conformance/%(Filename)%(Extension)"
+    />
+    <ProjectReference Include="../../../packages/NSmithy.Client/NSmithy.Client.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Codecs.Xml/NSmithy.Codecs.Xml.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Core/NSmithy.Core.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.Http/NSmithy.Http.csproj" />
+    <ProjectReference Include="../../../packages/NSmithy.MSBuild/NSmithy.MSBuild.csproj" />
+  </ItemGroup>
+
+  <Import Project="../../../packages/NSmithy.MSBuild/Targets/NSmithy.MSBuild.targets" />
+
+  <Target
+    Name="_CopySmithyModelJsonToOutput"
+    DependsOnTargets="GenerateSmithyCode"
+    BeforeTargets="AssignTargetPaths;CopyFilesToOutputDirectory"
+  >
+    <ItemGroup>
+      <Content
+        Include="$(SmithyBuildOutputPath)source/model/model.json"
+        Link="smithy-model.json"
+        CopyToOutputDirectory="PreserveNewest"
+        Visible="false"
+      />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/tests/Conformance/Ec2Query/smithy-build.json
+++ b/tests/Conformance/Ec2Query/smithy-build.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "maven": {
+    "repositories": [{ "url": "https://repo.maven.apache.org/maven2/" }],
+    "dependencies": [
+      "io.github.thomaslaich.nsmithy:smithy-csharp-codegen:0.0.0-SNAPSHOT",
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy:smithy-aws-protocol-tests:1.73.0"
+    ]
+  },
+  "projections": {
+    "ec2query": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": { "services": ["aws.protocoltests.ec2#AwsEc2"] }
+        }
+      ],
+      "plugins": {
+        "csharp-codegen": {
+          "service": "aws.protocoltests.ec2#AwsEc2",
+          "baseNamespace": ""
+        }
+      }
+    }
+  }
+}

--- a/tests/Conformance/RestJson1/Conformance/ConformanceRateTests.cs
+++ b/tests/Conformance/RestJson1/Conformance/ConformanceRateTests.cs
@@ -8,20 +8,35 @@ namespace RestJson1.Conformance;
 /// </summary>
 public sealed class ConformanceRateTests(ITestOutputHelper output)
 {
+    private const string LocalFixtureNamespace = "restjsonone.local#";
     private static readonly SmithyTestModel Model = SmithyTestModel.Load();
 
     [Fact]
     public void ReportConformanceRate()
     {
-        var requests = Model.EnumerateHttpRequestTests(RestJson1Allowlist.Protocol).ToList();
-        var responses = Model.EnumerateHttpResponseTests(RestJson1Allowlist.Protocol).ToList();
+        // The docs report official Smithy/AWS conformance only. Local regression fixtures still
+        // run in the suite, but mixing them into the numerator would inflate the published rate.
+        var requests = Model
+            .EnumerateHttpRequestTests(RestJson1Allowlist.Protocol)
+            .Where(c => IsOfficial(c.ShapeId))
+            .ToList();
+        var responses = Model
+            .EnumerateHttpResponseTests(RestJson1Allowlist.Protocol)
+            .Where(c => IsOfficial(c.ShapeId))
+            .ToList();
+
+        // Auxiliary services in the fixture bundle are not part of the generated RestJson
+        // service. Keep their cases out of both sides of the server-request ratio.
+        var serverRequests = requests
+            .Where(c => c.AppliesToServer && GeneratedService.HasHandler(c.OperationName))
+            .ToList();
 
         // Each side's denominator is the number of cases that actually apply to that side
         // (a server-only case never applies to the client and vice versa). Client and server
         // are reported separately so neither direction masks the other.
         var clientReqTotal = requests.Count(c => c.AppliesToClient);
         var clientRespTotal = responses.Count(c => c.AppliesToClient);
-        var serverReqTotal = requests.Count(c => c.AppliesToServer);
+        var serverReqTotal = serverRequests.Count;
         var serverRespTotal = responses.Count(c => c.AppliesToServer);
 
         // Client still runs a curated allowlist; the server runs every applicable case whose
@@ -39,10 +54,8 @@ public sealed class ConformanceRateTests(ITestOutputHelper output)
             && RestJson1Allowlist.ExecutableResponseCases.Contains(c.Id)
             && !RestJson1Allowlist.KnownResponseParamGaps.Contains(c.Id)
         );
-        var execServerReq = requests.Count(c =>
-            c.AppliesToServer
-            && GeneratedService.HasHandler(c.OperationName)
-            && !RestJson1Allowlist.KnownServerRequestParamGaps.Contains(c.Id)
+        var execServerReq = serverRequests.Count(c =>
+            !RestJson1Allowlist.KnownServerRequestParamGaps.Contains(c.Id)
         );
         var execServerResp = responses.Count(c => c.AppliesToServer);
 
@@ -52,11 +65,11 @@ public sealed class ConformanceRateTests(ITestOutputHelper output)
         // 400 rather than a 500, which the server does not implement yet.
         var malformed = Model
             .EnumerateHttpMalformedRequestTests(RestJson1Allowlist.Protocol)
+            .Where(c => IsOfficial(c.ShapeId))
+            .Where(c => GeneratedService.HasHandler(c.OperationName))
             .ToList();
         var malformedTotal = malformed.Count;
-        var execMalformed = malformed.Count(c =>
-            GeneratedService.HasHandler(c.OperationName) && RestJson1Allowlist.RunsMalformedCase(c)
-        );
+        var execMalformed = malformed.Count(RestJson1Allowlist.RunsMalformedCase);
 
         output.WriteLine(
             $"[{RestJson1Allowlist.Protocol}] "
@@ -70,4 +83,7 @@ public sealed class ConformanceRateTests(ITestOutputHelper output)
 
     private static string Pct(int part, int whole) =>
         whole == 0 ? "n/a" : $"{(double)part / whole * 100:0.0}%";
+
+    private static bool IsOfficial(string shapeId) =>
+        !shapeId.StartsWith(LocalFixtureNamespace, StringComparison.Ordinal);
 }

--- a/tests/NSmithy.Tests/Aws/AwsCredentialsProviderTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsCredentialsProviderTests.cs
@@ -17,7 +17,9 @@ public sealed class AwsCredentialsProviderTests
             ["AWS_SECRET_ACCESS_KEY"] = "secret",
             ["AWS_SESSION_TOKEN"] = "token",
         };
-        var provider = new EnvironmentAwsCredentialsProvider(name => environment.GetValueOrDefault(name));
+        var provider = new EnvironmentAwsCredentialsProvider(name =>
+            environment.GetValueOrDefault(name)
+        );
 
         var credentials = await provider.GetCredentialsAsync();
 
@@ -67,9 +69,20 @@ public sealed class AwsCredentialsProviderTests
         );
         var handler = new RecordingHandler(request =>
         {
-            Assert.Equal("cached-token", request.Headers.GetValues("x-amz-sso_bearer_token").Single());
-            Assert.Contains("account_id=123456789012", request.RequestUri!.Query, StringComparison.Ordinal);
-            Assert.Contains("role_name=Developer", request.RequestUri.Query, StringComparison.Ordinal);
+            Assert.Equal(
+                "cached-token",
+                request.Headers.GetValues("x-amz-sso_bearer_token").Single()
+            );
+            Assert.Contains(
+                "account_id=123456789012",
+                request.RequestUri!.Query,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "role_name=Developer",
+                request.RequestUri.Query,
+                StringComparison.Ordinal
+            );
             return JsonResponse(
                 """
                 {"roleCredentials":{"accessKeyId":"sso-access","secretAccessKey":"sso-secret","sessionToken":"sso-token","expiration":1787598000000}}
@@ -155,8 +168,7 @@ public sealed class AwsCredentialsProviderTests
         var provider = new InstanceMetadataAwsCredentialsProvider(
             httpClient,
             new Uri("http://127.0.0.1/"),
-            getEnvironmentVariable: name =>
-                name == "AWS_EC2_METADATA_V1_DISABLED" ? "true" : null
+            getEnvironmentVariable: name => name == "AWS_EC2_METADATA_V1_DISABLED" ? "true" : null
         );
 
         var exception = await Assert.ThrowsAsync<AwsCredentialsProviderException>(async () =>
@@ -170,14 +182,16 @@ public sealed class AwsCredentialsProviderTests
     public async Task DefaultChainContinuesOnlyPastUnconfiguredProviders()
     {
         var expected = new AwsCredentials("access", "secret");
-        var chain = new DefaultAwsCredentialsProvider(
-            [
-                new StubProvider(
-                    new AwsCredentialsProviderException("first", "not configured", isNotConfigured: true)
-                ),
-                new StubProvider(expected),
-            ]
-        );
+        var chain = new DefaultAwsCredentialsProvider([
+            new StubProvider(
+                new AwsCredentialsProviderException(
+                    "first",
+                    "not configured",
+                    isNotConfigured: true
+                )
+            ),
+            new StubProvider(expected),
+        ]);
 
         var credentials = await chain.GetCredentialsAsync();
 
@@ -239,7 +253,8 @@ public sealed class AwsCredentialsProviderTests
 
     private sealed class TemporaryDirectory : IDisposable
     {
-        public TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("nsmithy-aws-").FullName;
+        public TemporaryDirectory() =>
+            Path = Directory.CreateTempSubdirectory("nsmithy-aws-").FullName;
 
         public string Path { get; }
 

--- a/tests/NSmithy.Tests/Aws/AwsCredentialsProviderTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsCredentialsProviderTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using System.Text;
+using NSmithy.Aws;
+using NSmithy.Client;
+using NSmithy.Core;
+
+namespace NSmithy.Tests.Aws;
+
+public sealed class AwsCredentialsProviderTests
+{
+    [Fact]
+    public async Task EnvironmentProviderReadsSessionCredentials()
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            ["AWS_ACCESS_KEY_ID"] = "access",
+            ["AWS_SECRET_ACCESS_KEY"] = "secret",
+            ["AWS_SESSION_TOKEN"] = "token",
+        };
+        var provider = new EnvironmentAwsCredentialsProvider(name => environment.GetValueOrDefault(name));
+
+        var credentials = await provider.GetCredentialsAsync();
+
+        Assert.Equal("access", credentials.AccessKeyId);
+        Assert.Equal("secret", credentials.SecretAccessKey);
+        Assert.Equal("token", credentials.SessionToken);
+    }
+
+    [Fact]
+    public async Task ProfileProviderMergesConfigAndCredentialsFiles()
+    {
+        using var directory = new TemporaryDirectory();
+        var config = Path.Combine(directory.Path, "config");
+        var credentials = Path.Combine(directory.Path, "credentials");
+        File.WriteAllText(config, "[profile dev]\nregion = eu-west-1\n");
+        File.WriteAllText(
+            credentials,
+            "[dev]\naws_access_key_id = profile-access\naws_secret_access_key = profile-secret\naws_session_token = profile-token\n"
+        );
+        var provider = new ProfileAwsCredentialsProvider(
+            "dev",
+            credentials,
+            config,
+            getEnvironmentVariable: static _ => null
+        );
+
+        var result = await provider.GetCredentialsAsync();
+
+        Assert.Equal("profile-access", result.AccessKeyId);
+        Assert.Equal("profile-secret", result.SecretAccessKey);
+        Assert.Equal("profile-token", result.SessionToken);
+    }
+
+    [Fact]
+    public async Task SsoProviderExchangesAnUnexpiredCliToken()
+    {
+        using var directory = new TemporaryDirectory();
+        File.WriteAllText(
+            Path.Combine(directory.Path, "token.json"),
+            """
+            {
+              "startUrl": "https://example.awsapps.com/start",
+              "accessToken": "cached-token",
+              "expiresAt": "2026-08-24T18:00:00Z"
+            }
+            """
+        );
+        var handler = new RecordingHandler(request =>
+        {
+            Assert.Equal("cached-token", request.Headers.GetValues("x-amz-sso_bearer_token").Single());
+            Assert.Contains("account_id=123456789012", request.RequestUri!.Query, StringComparison.Ordinal);
+            Assert.Contains("role_name=Developer", request.RequestUri.Query, StringComparison.Ordinal);
+            return JsonResponse(
+                """
+                {"roleCredentials":{"accessKeyId":"sso-access","secretAccessKey":"sso-secret","sessionToken":"sso-token","expiration":1787598000000}}
+                """
+            );
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new SsoAwsCredentialsProvider(
+            "123456789012",
+            "Developer",
+            "eu-west-1",
+            "https://example.awsapps.com/start",
+            directory.Path,
+            httpClient,
+            new FixedTimeProvider(new DateTimeOffset(2026, 8, 24, 16, 0, 0, TimeSpan.Zero))
+        );
+
+        var credentials = await provider.GetCredentialsAsync();
+
+        Assert.Equal("sso-access", credentials.AccessKeyId);
+        Assert.Equal("sso-secret", credentials.SecretAccessKey);
+        Assert.Equal("sso-token", credentials.SessionToken);
+        Assert.NotNull(credentials.Expiration);
+    }
+
+    [Fact]
+    public async Task InstanceMetadataProviderUsesImdsV2Token()
+    {
+        var calls = new List<string>();
+        var handler = new RecordingHandler(request =>
+        {
+            calls.Add($"{request.Method} {request.RequestUri!.AbsolutePath}");
+            if (request.Method == HttpMethod.Put)
+            {
+                Assert.Equal(
+                    "21600",
+                    request.Headers.GetValues("X-aws-ec2-metadata-token-ttl-seconds").Single()
+                );
+                return TextResponse("imds-token");
+            }
+            Assert.Equal(
+                "imds-token",
+                request.Headers.GetValues("X-aws-ec2-metadata-token").Single()
+            );
+            return request.RequestUri.AbsolutePath.EndsWith(
+                "/security-credentials/",
+                StringComparison.Ordinal
+            )
+                ? TextResponse("example-role\n")
+                : JsonResponse(
+                    """
+                    {"Code":"Success","AccessKeyId":"imds-access","SecretAccessKey":"imds-secret","Token":"imds-token-value","Expiration":"2026-08-24T18:00:00Z"}
+                    """
+                );
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new InstanceMetadataAwsCredentialsProvider(
+            httpClient,
+            new Uri("http://127.0.0.1/"),
+            getEnvironmentVariable: static _ => null
+        );
+
+        var credentials = await provider.GetCredentialsAsync();
+
+        Assert.Equal("imds-access", credentials.AccessKeyId);
+        Assert.Equal("imds-secret", credentials.SecretAccessKey);
+        Assert.Equal("imds-token-value", credentials.SessionToken);
+        Assert.Equal(
+            [
+                "PUT /latest/api/token",
+                "GET /latest/meta-data/iam/security-credentials/",
+                "GET /latest/meta-data/iam/security-credentials/example-role",
+            ],
+            calls
+        );
+    }
+
+    [Fact]
+    public async Task InstanceMetadataProviderHonorsDisabledV1Fallback()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden));
+        using var httpClient = new HttpClient(handler);
+        var provider = new InstanceMetadataAwsCredentialsProvider(
+            httpClient,
+            new Uri("http://127.0.0.1/"),
+            getEnvironmentVariable: name =>
+                name == "AWS_EC2_METADATA_V1_DISABLED" ? "true" : null
+        );
+
+        var exception = await Assert.ThrowsAsync<AwsCredentialsProviderException>(async () =>
+            await provider.GetCredentialsAsync()
+        );
+
+        Assert.Contains("IMDSv2 token", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DefaultChainContinuesOnlyPastUnconfiguredProviders()
+    {
+        var expected = new AwsCredentials("access", "secret");
+        var chain = new DefaultAwsCredentialsProvider(
+            [
+                new StubProvider(
+                    new AwsCredentialsProviderException("first", "not configured", isNotConfigured: true)
+                ),
+                new StubProvider(expected),
+            ]
+        );
+
+        var credentials = await chain.GetCredentialsAsync();
+
+        Assert.Same(expected, credentials);
+    }
+
+    [Theory]
+    [InlineData("us-east-1", "https://lambda.us-east-1.amazonaws.com/")]
+    [InlineData("cn-north-1", "https://lambda.cn-north-1.amazonaws.com.cn/")]
+    [InlineData("us-gov-west-1", "https://lambda.us-gov-west-1.amazonaws.com/")]
+    [InlineData("us-iso-east-1", "https://lambda.us-iso-east-1.c2s.ic.gov/")]
+    public async Task RegionalEndpointResolverUsesAwsPartitions(string region, string expected)
+    {
+        var resolver = new AwsRegionalEndpointResolver("lambda", region);
+
+        var endpoint = await resolver.ResolveEndpointAsync(
+            new SmithyEndpointParameters(
+                new ShapeId("example", "Service"),
+                new ShapeId("example", "Operation"),
+                null,
+                null
+            )
+        );
+
+        Assert.Equal(expected, endpoint.Uri.AbsoluteUri);
+        Assert.Same(resolver.StaticEndpoint, endpoint);
+    }
+
+    private sealed class StubProvider : IAwsCredentialsProvider
+    {
+        private readonly AwsCredentials? credentials;
+        private readonly Exception? exception;
+
+        public StubProvider(AwsCredentials credentials) => this.credentials = credentials;
+
+        public StubProvider(Exception exception) => this.exception = exception;
+
+        public ValueTask<AwsCredentials> GetCredentialsAsync(
+            CancellationToken cancellationToken = default
+        ) =>
+            exception is null
+                ? ValueTask.FromResult(credentials!)
+                : ValueTask.FromException<AwsCredentials>(exception);
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(respond(request));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("nsmithy-aws-").FullName;
+
+        public string Path { get; }
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+
+    private static HttpResponseMessage TextResponse(string value) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(value, Encoding.UTF8, "text/plain") };
+
+    private static HttpResponseMessage JsonResponse(string value) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(value, Encoding.UTF8, "application/json"),
+        };
+}

--- a/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
@@ -90,10 +90,7 @@ public sealed class AwsSigV4InterceptorTests
         await signer.SignAsync(
             new SmithyContext(),
             request,
-            new AwsCredentials(
-                "AKIAIOSFODNN7EXAMPLE",
-                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-            )
+            new AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
         );
 
         Assert.Equal(
@@ -105,7 +102,10 @@ public sealed class AwsSigV4InterceptorTests
     [Fact]
     public async Task SigningTheSameRequestTwiceIsDeterministic()
     {
-        var request = new SmithyHttpRequest(HttpMethod.Get, "https://service.us-east-1.amazonaws.com/");
+        var request = new SmithyHttpRequest(
+            HttpMethod.Get,
+            "https://service.us-east-1.amazonaws.com/"
+        );
         var signer = new AwsSigV4Signer(
             "service",
             "us-east-1",
@@ -135,10 +135,7 @@ public sealed class AwsSigV4InterceptorTests
 
         var uri = signer.Presign(
             request,
-            new AwsCredentials(
-                "AKIAIOSFODNN7EXAMPLE",
-                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-            ),
+            new AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
             TimeSpan.FromDays(1)
         );
 
@@ -181,7 +178,11 @@ public sealed class AwsSigV4InterceptorTests
         var signer = new AwsSigV4Signer("s3", "us-east-1");
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            signer.Presign(request, new AwsCredentials("access", "secret"), TimeSpan.FromSeconds(seconds))
+            signer.Presign(
+                request,
+                new AwsCredentials("access", "secret"),
+                TimeSpan.FromSeconds(seconds)
+            )
         );
     }
 

--- a/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
+++ b/tests/NSmithy.Tests/Aws/AwsSigV4InterceptorTests.cs
@@ -73,6 +73,118 @@ public sealed class AwsSigV4InterceptorTests
         Assert.Equal(["token"], request.Headers["X-Amz-Security-Token"]);
     }
 
+    [Fact]
+    public async Task SignMatchesAwsPublishedS3GetObjectVector()
+    {
+        var request = new SmithyHttpRequest(
+            HttpMethod.Get,
+            "https://examplebucket.s3.amazonaws.com/test.txt"
+        );
+        request.Headers["Range"] = ["bytes=0-9"];
+        var signer = new AwsSigV4Signer(
+            "s3",
+            "us-east-1",
+            new FixedTimeProvider(new DateTimeOffset(2013, 05, 24, 0, 0, 0, TimeSpan.Zero))
+        );
+
+        await signer.SignAsync(
+            new SmithyContext(),
+            request,
+            new AwsCredentials(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            )
+        );
+
+        Assert.Equal(
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+            Assert.Single(request.Headers["Authorization"])
+        );
+    }
+
+    [Fact]
+    public async Task SigningTheSameRequestTwiceIsDeterministic()
+    {
+        var request = new SmithyHttpRequest(HttpMethod.Get, "https://service.us-east-1.amazonaws.com/");
+        var signer = new AwsSigV4Signer(
+            "service",
+            "us-east-1",
+            new FixedTimeProvider(new DateTimeOffset(2026, 06, 22, 12, 34, 56, TimeSpan.Zero))
+        );
+        var credentials = new AwsCredentials("access", "secret", "token");
+
+        await signer.SignAsync(new SmithyContext(), request, credentials);
+        var first = Assert.Single(request.Headers["Authorization"]);
+        await signer.SignAsync(new SmithyContext(), request, credentials);
+
+        Assert.Equal(first, Assert.Single(request.Headers["Authorization"]));
+    }
+
+    [Fact]
+    public void PresignMatchesAwsPublishedS3Vector()
+    {
+        var request = new SmithyHttpRequest(
+            HttpMethod.Get,
+            "https://examplebucket.s3.amazonaws.com/test.txt"
+        );
+        var signer = new AwsSigV4Signer(
+            "s3",
+            "us-east-1",
+            new FixedTimeProvider(new DateTimeOffset(2013, 05, 24, 0, 0, 0, TimeSpan.Zero))
+        );
+
+        var uri = signer.Presign(
+            request,
+            new AwsCredentials(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            TimeSpan.FromDays(1)
+        );
+
+        Assert.Equal(
+            "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404",
+            uri.AbsoluteUri
+        );
+        Assert.Equal(uri.AbsoluteUri, request.RequestUri);
+    }
+
+    [Fact]
+    public void PresignPreservesNonAuthenticationXAmzQueryParameters()
+    {
+        var request = new SmithyHttpRequest(
+            HttpMethod.Get,
+            "https://service.us-east-1.amazonaws.com/?X-Amz-Custom=value&X-Amz-Signature=stale"
+        );
+        var signer = new AwsSigV4Signer(
+            "service",
+            "us-east-1",
+            new FixedTimeProvider(new DateTimeOffset(2026, 06, 22, 12, 34, 56, TimeSpan.Zero))
+        );
+
+        var uri = signer.Presign(
+            request,
+            new AwsCredentials("access", "secret"),
+            TimeSpan.FromMinutes(5)
+        );
+
+        Assert.Contains("X-Amz-Custom=value", uri.Query, StringComparison.Ordinal);
+        Assert.DoesNotContain("X-Amz-Signature=stale", uri.Query, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(604801)]
+    public void PresignRejectsDurationsOutsideAwsLimits(int seconds)
+    {
+        var request = new SmithyHttpRequest(HttpMethod.Get, "https://s3.amazonaws.com/key");
+        var signer = new AwsSigV4Signer("s3", "us-east-1");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            signer.Presign(request, new AwsCredentials("access", "secret"), TimeSpan.FromSeconds(seconds))
+        );
+    }
+
     private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => utcNow;

--- a/tests/NSmithy.Tests/NSmithy.Tests.csproj
+++ b/tests/NSmithy.Tests/NSmithy.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="../../packages/NSmithy.Codecs.Cbor/NSmithy.Codecs.Cbor.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Codecs.Proto/NSmithy.Codecs.Proto.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Protocols.Grpc/NSmithy.Protocols.Grpc.csproj" />
+    <ProjectReference Include="../../packages/NSmithy.Protocols.AwsQuery/NSmithy.Protocols.AwsQuery.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Client/NSmithy.Client.csproj" />
     <ProjectReference Include="../../packages/NSmithy.Core/NSmithy.Core.csproj" />
     <ProjectReference Include="../../packages/NSmithy.EventStream/NSmithy.EventStream.csproj" />

--- a/tests/NSmithy.Tests/Protocols/AwsQuery/AwsQueryProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/AwsQuery/AwsQueryProtocolTests.cs
@@ -174,7 +174,8 @@ public sealed class AwsQueryProtocolTests
             InputSchema(),
             OutputSchema(),
             withError
-                ? [
+                ?
+                [
                     Schemas.OperationError(
                         new ShapeId("example", "GreetingError"),
                         ErrorSchema(),
@@ -229,15 +230,14 @@ public sealed class AwsQueryProtocolTests
             )
             .Build(
                 static () => new QueryInputBuilder(),
-                static builder =>
-                    new QueryInput(
-                        builder.Text,
-                        builder.When,
-                        builder.Items,
-                        builder.FlatItems,
-                        builder.Tags,
-                        builder.Nested
-                    )
+                static builder => new QueryInput(
+                    builder.Text,
+                    builder.When,
+                    builder.Items,
+                    builder.FlatItems,
+                    builder.Tags,
+                    builder.Nested
+                )
             );
     }
 

--- a/tests/NSmithy.Tests/Protocols/AwsQuery/AwsQueryProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/AwsQuery/AwsQueryProtocolTests.cs
@@ -1,0 +1,304 @@
+using System.Net;
+using System.Text;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Http;
+using NSmithy.Protocols.AwsQuery;
+
+namespace NSmithy.Tests.Protocols.AwsQuery;
+
+public sealed class AwsQueryProtocolTests
+{
+    private static readonly Trait XmlFlattened = new(ShapeId.Parse("smithy.api#xmlFlattened"));
+
+    public sealed record Nested(string? Value);
+
+    public sealed class NestedBuilder
+    {
+        public string? Value { get; set; }
+    }
+
+    public sealed record QueryInput(
+        string? Text = null,
+        DateTimeOffset? When = null,
+        IReadOnlyList<string>? Items = null,
+        IReadOnlyList<string>? FlatItems = null,
+        IReadOnlyDictionary<string, string>? Tags = null,
+        Nested? Nested = null
+    );
+
+    public sealed class QueryInputBuilder
+    {
+        public string? Text { get; set; }
+        public DateTimeOffset? When { get; set; }
+        public IReadOnlyList<string>? Items { get; set; }
+        public IReadOnlyList<string>? FlatItems { get; set; }
+        public IReadOnlyDictionary<string, string>? Tags { get; set; }
+        public Nested? Nested { get; set; }
+    }
+
+    public sealed record GreetingOutput(string? Greeting = null);
+
+    public sealed class GreetingOutputBuilder
+    {
+        public string? Greeting { get; set; }
+    }
+
+    public sealed class GreetingException(string? message) : Exception(message)
+    {
+        public string? Detail { get; init; }
+    }
+
+    public sealed class GreetingErrorBuilder
+    {
+        public string? Message { get; set; }
+        public string? Detail { get; set; }
+    }
+
+    [Fact]
+    public void AwsQuerySerializesOfficialFormLayout()
+    {
+        var operation = Operation("SendGreeting");
+        var protocol = Bind<AwsQueryProtocol>(operation);
+        var input = new QueryInput(
+            Text: "hello world",
+            When: DateTimeOffset.Parse("2015-01-25T08:00:00Z"),
+            Items: ["a", "b"],
+            FlatItems: ["c", "d"],
+            Tags: new Dictionary<string, string> { ["first"] = "1", ["second"] = "2" },
+            Nested: new Nested("inside")
+        );
+
+        var request = protocol.SerializeRequest(input);
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/", request.RequestUri);
+        Assert.Equal("application/x-www-form-urlencoded", request.ContentType);
+        Assert.Equal("text/xml", request.Headers["Accept"].Single());
+        Assert.Equal(
+            "Action=SendGreeting&Version=2020-01-08&Text=hello%20world&When=2015-01-25T08%3A00%3A00Z&Items.member.1=a&Items.member.2=b&FlatItems.1=c&FlatItems.2=d&Tags.entry.1.key=first&Tags.entry.1.value=1&Tags.entry.2.key=second&Tags.entry.2.value=2&Nested.Value=inside",
+            BodyText(request)
+        );
+    }
+
+    [Fact]
+    public void Ec2QueryUppercasesNamesAndAlwaysFlattensLists()
+    {
+        var operation = Operation("SendGreeting");
+        var protocol = Bind<Ec2QueryProtocol>(operation);
+        var input = new QueryInput(Text: "hello", Items: ["a", "b"], Nested: new Nested("v"));
+
+        var request = protocol.SerializeRequest(input);
+
+        Assert.Equal(
+            "Action=SendGreeting&Version=2020-01-08&Text=hello&Items.1=a&Items.2=b&Nested.Value=v",
+            BodyText(request)
+        );
+    }
+
+    [Fact]
+    public async Task AwsQueryDeserializesTheResultWrapper()
+    {
+        var protocol = Bind<AwsQueryProtocol>(Operation("SendGreeting"));
+        var response = Response(
+            HttpStatusCode.OK,
+            """
+            <SendGreetingResponse xmlns="https://example.com/">
+              <SendGreetingResult><Greeting>Hello</Greeting></SendGreetingResult>
+              <ResponseMetadata><RequestId>abc</RequestId></ResponseMetadata>
+            </SendGreetingResponse>
+            """
+        );
+
+        var output = await protocol.DeserializeResponseAsync(response);
+
+        Assert.Equal("Hello", output.Greeting);
+    }
+
+    [Fact]
+    public async Task Ec2QueryDeserializesTheResponseRootWithoutAResultWrapper()
+    {
+        var protocol = Bind<Ec2QueryProtocol>(Operation("SendGreeting"));
+        var response = Response(
+            HttpStatusCode.OK,
+            """
+            <SendGreetingResponse xmlns="https://example.com/">
+              <Greeting>Hello</Greeting><requestId>abc</requestId>
+            </SendGreetingResponse>
+            """
+        );
+
+        var output = await protocol.DeserializeResponseAsync(response);
+
+        Assert.Equal("Hello", output.Greeting);
+    }
+
+    [Fact]
+    public async Task QueryProtocolsDeserializeTheirDistinctErrorEnvelopes()
+    {
+        var operation = Operation("SendGreeting", withError: true);
+        var awsProtocol = Bind<AwsQueryProtocol>(operation);
+        var ec2Protocol = Bind<Ec2QueryProtocol>(operation);
+
+        var awsError = await awsProtocol.DeserializeErrorAsync(
+            Response(
+                HttpStatusCode.BadRequest,
+                "<ErrorResponse><Error><Code>GreetingError</Code><Message>bad</Message><Detail>aws</Detail></Error></ErrorResponse>"
+            )
+        );
+        var ec2Error = await ec2Protocol.DeserializeErrorAsync(
+            Response(
+                HttpStatusCode.BadRequest,
+                "<Response><Errors><Error><Code>GreetingError</Code><Message>bad</Message><Detail>ec2</Detail></Error></Errors></Response>"
+            )
+        );
+
+        Assert.Equal("aws", Assert.IsType<GreetingException>(awsError).Detail);
+        Assert.Equal("ec2", Assert.IsType<GreetingException>(ec2Error).Detail);
+    }
+
+    private static IClientOperationProtocol<QueryInput, GreetingOutput> Bind<TProtocol>(
+        OperationSchema<QueryInput, GreetingOutput> operation
+    )
+        where TProtocol : IProtocol, new() =>
+        new TProtocol()
+            .ForService(Schemas.Service(new ShapeId("example", "Service"), "2020-01-08"))
+            .ForClientOperation(operation);
+
+    private static OperationSchema<QueryInput, GreetingOutput> Operation(
+        string name,
+        bool withError = false
+    ) =>
+        Schemas.Operation(
+            new ShapeId("example", name),
+            InputSchema(),
+            OutputSchema(),
+            withError
+                ? [
+                    Schemas.OperationError(
+                        new ShapeId("example", "GreetingError"),
+                        ErrorSchema(),
+                        400
+                    ),
+                ]
+                : []
+        );
+
+    private static StructSchema<QueryInput, QueryInputBuilder> InputSchema()
+    {
+        var stringList = Schemas.List(new ShapeId("example", "StringList"), Schemas.String);
+        var stringMap = Schemas.Map(new ShapeId("example", "StringMap"), Schemas.String);
+        return Schemas
+            .Structure<QueryInput, QueryInputBuilder>(new ShapeId("example", "QueryInput"))
+            .Optional(
+                "Text",
+                static value => value.Text,
+                static (builder, value) => builder.Text = value,
+                Schemas.NullableReference(Schemas.String)
+            )
+            .Optional(
+                "When",
+                static value => value.When,
+                static (builder, value) => builder.When = value,
+                Schemas.Nullable(Schemas.Timestamp)
+            )
+            .Optional(
+                "Items",
+                static value => value.Items,
+                static (builder, value) => builder.Items = value,
+                Schemas.NullableReference(stringList)
+            )
+            .Optional(
+                "FlatItems",
+                static value => value.FlatItems,
+                static (builder, value) => builder.FlatItems = value,
+                Schemas.NullableReference(stringList),
+                [XmlFlattened]
+            )
+            .Optional(
+                "Tags",
+                static value => value.Tags,
+                static (builder, value) => builder.Tags = value,
+                Schemas.NullableReference(stringMap)
+            )
+            .Optional(
+                "Nested",
+                static value => value.Nested,
+                static (builder, value) => builder.Nested = value,
+                Schemas.NullableReference(NestedSchema())
+            )
+            .Build(
+                static () => new QueryInputBuilder(),
+                static builder =>
+                    new QueryInput(
+                        builder.Text,
+                        builder.When,
+                        builder.Items,
+                        builder.FlatItems,
+                        builder.Tags,
+                        builder.Nested
+                    )
+            );
+    }
+
+    private static StructSchema<Nested, NestedBuilder> NestedSchema() =>
+        Schemas
+            .Structure<Nested, NestedBuilder>(new ShapeId("example", "Nested"))
+            .Optional(
+                "Value",
+                static value => value.Value,
+                static (builder, value) => builder.Value = value,
+                Schemas.NullableReference(Schemas.String)
+            )
+            .Build(static () => new NestedBuilder(), static builder => new Nested(builder.Value));
+
+    private static StructSchema<GreetingOutput, GreetingOutputBuilder> OutputSchema() =>
+        Schemas
+            .Structure<GreetingOutput, GreetingOutputBuilder>(
+                new ShapeId("example", "GreetingOutput")
+            )
+            .Optional(
+                "Greeting",
+                static value => value.Greeting,
+                static (builder, value) => builder.Greeting = value,
+                Schemas.NullableReference(Schemas.String)
+            )
+            .Build(
+                static () => new GreetingOutputBuilder(),
+                static builder => new GreetingOutput(builder.Greeting)
+            );
+
+    private static StructSchema<GreetingException, GreetingErrorBuilder> ErrorSchema() =>
+        Schemas
+            .Structure<GreetingException, GreetingErrorBuilder>(
+                new ShapeId("example", "GreetingError")
+            )
+            .Optional(
+                "Message",
+                static value => value.Message,
+                static (builder, value) => builder.Message = value,
+                Schemas.NullableReference(Schemas.String)
+            )
+            .Optional(
+                "Detail",
+                static value => value.Detail,
+                static (builder, value) => builder.Detail = value,
+                Schemas.NullableReference(Schemas.String)
+            )
+            .Build(
+                static () => new GreetingErrorBuilder(),
+                static builder => new GreetingException(builder.Message) { Detail = builder.Detail }
+            );
+
+    private static string BodyText(SmithyHttpRequest request) =>
+        Encoding.UTF8.GetString(Assert.IsType<SmithyHttpBody.Bytes>(request.Body).Content);
+
+    private static SmithyHttpClientResponse Response(HttpStatusCode code, string body) =>
+        new(
+            code,
+            null,
+            Encoding.UTF8.GetBytes(body),
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase),
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        );
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -41,7 +41,7 @@ export default defineConfig({
 				starlightLlmsTxt({
 					projectName: 'NSmithy',
 					description:
-						'NSmithy generates C# models, typed HTTP clients, and ASP.NET Core minimal-API servers from Smithy models at build time — no separate codegen step and no JRE required by consumers.',
+						'NSmithy generates C# models, typed HTTP clients, and ASP.NET Core minimal-API servers from Smithy models at build time. Consumers need no separate codegen step or JRE.',
 				}),
 			],
 			social: [
@@ -54,8 +54,8 @@ export default defineConfig({
 			components: {
 				ThemeSelect: './src/components/StarlightThemeToggle.astro',
 			},
-			// Shared code-block styling (src/styles/code.css) + landing/docs theme
-			// alignment — fonts and a near-black dark mode (src/styles/docs-theme.css).
+			// Shared code-block styling (src/styles/code.css), plus landing/docs theme
+			// alignment, fonts, and a near-black dark mode (src/styles/docs-theme.css).
 			customCss: ['./src/styles/code.css', './src/styles/docs-theme.css'],
 			expressiveCode: {
 				// Match TypeHintCode's highlighter (github-dark / github-light) so
@@ -104,15 +104,17 @@ export default defineConfig({
 						{ label: 'Overview', slug: 'protocols/overview' },
 						{ label: 'REST JSON', slug: 'protocols/rest-json' },
 						{ label: 'RPC v2 CBOR', slug: 'protocols/rpc-v2-cbor' },
-						{ label: 'gRPC', slug: 'protocols/grpc' },
 						{
 							label: 'AWS Protocols',
 							items: [
 								{ label: 'Overview', slug: 'protocols/aws-overview' },
 								{ label: 'AWS JSON', slug: 'protocols/aws-json' },
+								{ label: 'AWS Query', slug: 'protocols/aws-query' },
+								{ label: 'AWS EC2 Query', slug: 'protocols/aws-ec2-query' },
 								{ label: 'AWS restXml', slug: 'protocols/rest-xml' },
 							],
 						},
+						{ label: 'gRPC', slug: 'protocols/grpc' },
 						{ label: 'Protocol Status', slug: 'protocols/status' },
 					],
 				},

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -23,36 +23,20 @@ The priorities below are what remains.
 
 ### 1. Expand AWS protocol coverage and AWS readiness
 
-- Expand AWS protocol coverage beyond the initial AWS JSON client support,
-  especially AWS Query and EC2 Query.
+- Keep the fully conformant AWS Query and EC2 Query client surfaces green while
+  expanding real-service coverage.
 - Continue hardening `aws.protocols#restJson1`, `aws.protocols#restXml`, and
   `smithy.protocols#rpcv2Cbor` as preview surfaces.
-- Mature AWS authentication beyond the early-preview SigV4 signing — endpoint
-  resolution, profile/SSO/IMDS credential chains, presigning, and golden-vector
-  coverage against AWS's SigV4 test suite.
+- Build on regional endpoint resolution, profile/SSO/IMDS credentials,
+  presigning, and published AWS golden vectors with modeled endpoint rule sets,
+  additional credential sources, and SigV4a.
 - Grow the LocalStack integration coverage beyond the initial example into a
   broader suite that validates generated AWS clients against realistic protocol,
   signing, and endpoint behavior.
 - Keep the scope driven by conformance and observed runtime behavior rather
   than by protocol checklists.
 
-### 2. Harden streaming operations
-
-NSmithy has two experimental event-streaming surfaces: native gRPC (client,
-server, and bidirectional streaming) and `rpcv2Cbor` event streams over
-`vnd.amazon.eventstream` message framing, sharing the `NSmithy.EventStream`
-framing layer. The next step is to harden these paths and keep the abstractions
-usable across additional streaming protocols.
-
-This work includes:
-
-- Adding end-to-end tests that cover backpressure, cancellation, errors, and
-  stream completion behavior across both surfaces.
-- Adding interop tests with `Grpc.Net` peers generated from the emitted `.proto`.
-- Extending streaming support beyond event streams, especially streaming blob
-  payloads.
-
-### 3. Expand to async protocols
+### 2. Expand to async protocols
 
 NSmithy's current protocol work is mostly request/response oriented. A separate
 near-term goal is to validate that the runtime and generator model can also
@@ -67,7 +51,7 @@ This work includes:
 - Using these protocols to pressure-test the existing transport, codec, and
   client/server seams beyond HTTP-centric assumptions.
 
-### 4. Support Smithy AI traits and MCP generation
+### 3. Support Smithy AI traits and MCP generation
 
 Support Smithy's AI-oriented traits so that .NET and protocol artifacts can be
 generated for tool-driven and agent-driven workflows, rather than treating the

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -33,6 +33,7 @@ need Gradle and can stay in the .NET build system.
 
 NSmithy currently supports `alloy#simpleRestJson`, `aws.protocols#restJson1`,
 `aws.protocols#awsJson1_1`, `aws.protocols#awsJson1_0`,
-`aws.protocols#restXml`, `smithy.protocols#rpcv2Cbor`, and `alloy#grpc`.
+`aws.protocols#awsQuery`, `aws.protocols#ec2Query`, `aws.protocols#restXml`,
+`smithy.protocols#rpcv2Cbor`, and `alloy#grpc`.
 
 See the [Quick Start](/smithy-dotnet/getting-started/quick-start/) to build your first service.

--- a/website/src/content/docs/guides/client-configuration/authentication.md
+++ b/website/src/content/docs/guides/client-configuration/authentication.md
@@ -65,10 +65,12 @@ validates the header sent by `HttpApiKeyAuthScheme`.
 AWS SigV4 support is early preview. It is useful for narrow smoke tests and
 LocalStack-style examples, but it is not a replacement for the AWS SDK for .NET.
 
-Callers must provide the endpoint, signing service name, region, and credentials.
-NSmithy does not yet provide AWS SDK-style endpoint resolution, profile/SSO/IMDS
-credential chains, retries, paginators, presigning, or golden-vector coverage
-against AWS's SigV4 test suite.
+NSmithy now provides standard regional endpoint resolution, environment and
+shared-profile credentials (including cached IAM Identity Center sessions),
+IMDSv2 role credentials, presigning, and golden coverage against AWS's published
+S3 signing vectors. Modeled per-service endpoint rule sets, assume-role and web
+identity providers, ECS container credentials, SigV4a, and the full production
+hardening of the official AWS SDK are still outside this preview.
 :::
 
 Add `NSmithy.Aws` and configure `AwsSigV4AuthScheme`:
@@ -77,13 +79,14 @@ Add `NSmithy.Aws` and configure `AwsSigV4AuthScheme`:
 using NSmithy.Aws;
 
 var region = Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
-var endpoint = new Uri($"https://lambda.{region}.amazonaws.com");
-var credentials = new EnvironmentAwsCredentialsProvider();
+var endpoint = new AwsRegionalEndpointResolver("lambda", region);
+var credentials = new DefaultAwsCredentialsProvider();
 
 using var lambda = new LambdaClient(
-    endpoint,
-    new()
+    new HttpClient(),
+    new LambdaClientConfig
     {
+        EndpointResolver = endpoint,
         AuthSchemes = { new AwsSigV4AuthScheme("lambda", region, credentials) },
     });
 ```
@@ -94,7 +97,16 @@ Available credential providers:
 | --- | --- |
 | `StaticAwsCredentialsProvider` | Explicit `AwsCredentials` instance |
 | `EnvironmentAwsCredentialsProvider` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` |
+| `ProfileAwsCredentialsProvider` | Static shared profiles or cached IAM Identity Center/SSO sessions |
+| `SsoAwsCredentialsProvider` | Explicit IAM Identity Center account/role using the AWS CLI token cache |
+| `InstanceMetadataAwsCredentialsProvider` | EC2 role credentials over IMDSv2 (optional IMDSv1 fallback) |
+| `DefaultAwsCredentialsProvider` | Environment → shared profile/SSO → IMDS |
+
+For presigned requests, construct an `AwsSigV4Presigner`, serialize the generated
+operation request, and call `PresignAsync`. Durations are limited to AWS's range
+of one second through seven days.
 
 For production AWS integrations, prefer the official
 [AWS SDK for .NET](https://github.com/aws/aws-sdk-net) until NSmithy's AWS auth,
-endpoint resolution, retries, and pagination support mature.
+modeled endpoint rules, additional credential sources, retries, and pagination
+support mature.

--- a/website/src/content/docs/guides/client-configuration/authentication.md
+++ b/website/src/content/docs/guides/client-configuration/authentication.md
@@ -62,8 +62,9 @@ validates the header sent by `HttpApiKeyAuthScheme`.
 ## AWS SigV4
 
 :::caution[Early preview]
-AWS SigV4 support is early preview. It is useful for narrow smoke tests and
-LocalStack-style examples, but it is not a replacement for the AWS SDK for .NET.
+For most applications that call AWS from .NET, use the official AWS SDK for
+.NET. NSmithy's AWS integration support is intended for focused integrations,
+emulators, and protocol validation, not as a complete SDK replacement.
 
 NSmithy now provides standard regional endpoint resolution, environment and
 shared-profile credentials (including cached IAM Identity Center sessions),
@@ -106,7 +107,6 @@ For presigned requests, construct an `AwsSigV4Presigner`, serialize the generate
 operation request, and call `PresignAsync`. Durations are limited to AWS's range
 of one second through seven days.
 
-For production AWS integrations, prefer the official
-[AWS SDK for .NET](https://github.com/aws/aws-sdk-net) until NSmithy's AWS auth,
-modeled endpoint rules, additional credential sources, retries, and pagination
-support mature.
+See [AWS Protocols](/smithy-dotnet/protocols/aws-overview/) for the supported AWS
+runtime features and the remaining gaps. NSmithy also provides standard retries
+and generated paginators for modeled `@paginated` operations.

--- a/website/src/content/docs/protocols/aws-ec2-query.md
+++ b/website/src/content/docs/protocols/aws-ec2-query.md
@@ -1,0 +1,136 @@
+---
+title: AWS EC2 Query
+description: Form-encoded EC2 Query requests and XML responses using aws.protocols#ec2Query.
+---
+
+`aws.protocols#ec2Query` is the EC2-specific variant of [AWS
+Query](../aws-query/). It uses the same form request and XML response pattern,
+but changes member names, collection keys, success envelopes, and errors.
+NSmithy generates typed clients. Server generation and streaming are not
+available.
+
+Use EC2 Query only to call EC2 or an emulator that reproduces its Query
+endpoint.
+
+See [Protocol Status](../status/) for maturity and current conformance numbers.
+
+## Protocol behavior
+
+| Area | EC2 Query |
+| --- | --- |
+| Route | `POST /` |
+| Request | `application/x-www-form-urlencoded` |
+| Operation | `Action={Operation}` |
+| Version | `Version={service version}` |
+| Response | XML members directly under the response root |
+| Errors | `Response > Errors > Error` XML envelope |
+| HTTP bindings | Not used |
+| Streaming | Not supported |
+
+EC2 Query does not support document shapes or request maps. Request member names
+are capitalized by default, and lists are flattened with one-based indexes.
+
+## Modeling
+
+Apply `@ec2Query` and `@xmlNamespace` to the service. Use `@ec2QueryName`
+when a request key differs from the modeled member name.
+
+```smithy
+$version: "2"
+
+namespace example.compute
+
+use aws.protocols#ec2Query
+use aws.protocols#ec2QueryName
+
+@ec2Query
+@xmlNamespace(uri: "https://compute.example.com/doc/2026-01-01/")
+service ComputeService {
+    version: "2026-01-01"
+    operations: [DescribeRegions]
+}
+
+operation DescribeRegions {
+    input := {
+        @ec2QueryName("RegionName")
+        regionNames: RegionNameList
+    }
+    output := {
+        @xmlName("regionInfo")
+        regions: RegionList
+    }
+}
+
+list RegionNameList {
+    member: String
+}
+
+list RegionList {
+    @xmlName("item")
+    member: Region
+}
+
+structure Region {
+    @xmlName("regionName")
+    name: String
+}
+```
+
+If `@ec2QueryName` is absent, `@xmlName` supplies the request name and its
+first character is capitalized.
+
+## On the wire
+
+```http
+POST / HTTP/1.1
+Host: compute.example.com
+Content-Type: application/x-www-form-urlencoded
+Accept: text/xml
+
+Action=DescribeRegions&Version=2026-01-01&RegionName.1=eu-west-1
+
+HTTP/1.1 200 OK
+Content-Type: text/xml
+
+<DescribeRegionsResponse xmlns="https://compute.example.com/doc/2026-01-01/">
+  <regionInfo>
+    <item><regionName>eu-west-1</regionName></item>
+  </regionInfo>
+  <requestId>abc</requestId>
+</DescribeRegionsResponse>
+```
+
+Unlike AWS Query, successful output members are read directly from the response
+root instead of an `{Operation}Result` wrapper.
+
+## Dependencies
+
+Add the AWS trait package to `smithy-build.json`:
+
+```json
+"software.amazon.smithy:smithy-aws-traits:1.73.0"
+```
+
+The client uses `NSmithy.Client` and `NSmithy.Protocols.AwsQuery`. The same
+protocol package provides both AWS Query implementations and includes the XML
+codec transitively.
+
+## Calling AWS
+
+AWS endpoints normally require SigV4, regional endpoint resolution, and
+credentials. See
+[Authentication](/smithy-dotnet/guides/client-configuration/authentication/)
+for the NSmithy setup and [AWS Protocols](../aws-overview/) for current runtime
+gaps.
+
+## Example
+
+The [AWS LocalStack
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/aws-localstack)
+uses an EC2 Query client to call EC2 `DescribeRegions`. EC2 Query does not
+support streaming, so there is no streaming example.
+
+## Specification and tests
+
+- [EC2 Query specification](https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html)
+- [Official EC2 Query protocol tests](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/ec2Query)

--- a/website/src/content/docs/protocols/aws-json.md
+++ b/website/src/content/docs/protocols/aws-json.md
@@ -1,39 +1,35 @@
 ---
 title: AWS JSON
-description: aws.protocols#awsJson1_1 and aws.protocols#awsJson1_0 — client-only JSON RPC for AWS-compatible services.
+description: Client support for the aws.protocols#awsJson1_0 and aws.protocols#awsJson1_1 JSON RPC protocols.
 ---
 
-`aws.protocols#awsJson1_1` and `aws.protocols#awsJson1_0` are AWS JSON-RPC
-protocols. NSmithy generates typed clients for both through
-`AwsJson11Protocol` and `AwsJson10Protocol`. Status: **Early preview,
-client-only**.
+`aws.protocols#awsJson1_0` and `aws.protocols#awsJson1_1` are JSON RPC
+protocols used by AWS services such as DynamoDB. NSmithy generates typed clients
+for both. Server generation and event streaming are not available.
 
-The currently verified slice covers `X-Amz-Target`, AWS JSON content types,
-empty input/output handling, special floating-point values, and common
-client-side error discriminator formats. `awsJson1_0` has runtime support but no
-separate conformance project yet.
+Use AWS JSON to call an existing AWS JSON RPC service or a compatible emulator.
+For a new service, prefer [restJson1](../rest-json/),
+[rpcv2Cbor](../rpc-v2-cbor/), or [gRPC](../grpc/).
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for current conformance
-numbers.
+See [Protocol Status](../status/) for maturity and current conformance numbers.
 
-## Maven Dependency
+## Protocol behavior
 
-```json
-"software.amazon.smithy:smithy-aws-traits:1.73.0"
-```
-
-## NuGet Packages
-
-| Purpose | Packages |
+| Area | AWS JSON |
 | --- | --- |
-| Client | `NSmithy.Client`, `NSmithy.Protocols.AwsJson` |
-
-`NSmithy.Protocols.AwsJson` pulls in `NSmithy.Codecs.Json` (the JSON codec)
-transitively.
+| Route | `POST /` |
+| Operation | `X-Amz-Target: {Service}.{Operation}` |
+| Body | JSON |
+| JSON 1.0 content type | `application/x-amz-json-1.0` |
+| JSON 1.1 content type | `application/x-amz-json-1.1` |
+| Errors | `X-Amzn-Errortype`, `__type`, `code`, or HTTP status fallback |
+| HTTP bindings | Not used |
+| NSmithy streaming | Not implemented |
 
 ## Modeling
 
-Apply the AWS JSON protocol trait to the service:
+Apply one AWS JSON protocol trait to the service. Operations do not use `@http`
+because the protocol always posts to the root path.
 
 ```smithy
 $version: "2"
@@ -62,15 +58,13 @@ operation GetCity {
 
 @error("client")
 structure NoSuchResource {
-    @required
-    resourceType: String
+    message: String
 }
 ```
 
-## On the Wire
+Use `aws.protocols#awsJson1_0` and `@awsJson1_0` for a JSON 1.0 service.
 
-AWS JSON is RPC-style: every call is a `POST /`, the operation is selected by the
-`X-Amz-Target` header, and input/output are JSON:
+## On the wire
 
 ```http
 POST / HTTP/1.1
@@ -87,18 +81,43 @@ Content-Type: application/x-amz-json-1.1
 {"name":"Seattle"}
 ```
 
-`X-Amz-Target` is `{Service}.{Operation}` (`awsJson1_0` uses the
-`application/x-amz-json-1.0` content type). Errors are discriminated by the
-`X-Amzn-Errortype` header or a `__type` field in the body.
+The service and operation names select the target. Empty inputs serialize as an
+empty JSON object. Clients accept empty output bodies when the modeled output can
+be constructed without response members.
 
-## Usage
+For errors, NSmithy accepts the modeled type from `X-Amzn-Errortype`, `__type`,
+or `code`. It removes common namespace and qualifier forms before matching a
+generated error. If a response has no discriminator, the client can fall back to
+the modeled HTTP status code.
 
-The generated client selects the declared protocol by default and is used
-exactly like every other NSmithy client — see the [Protocols
-Overview](/smithy-dotnet/protocols/overview/) for the client code. Only the
-`@awsJson1_1` (or `@awsJson1_0`) trait is specific to this protocol.
+## Dependencies
 
-AWS JSON support is client-only. NSmithy does not generate AWS JSON servers and
-does not yet provide AWS SDK-style endpoint resolution, credential chains,
-retries, or pagination helpers. Explicit SigV4 signing exists in early preview;
-see [Authentication](/smithy-dotnet/guides/client-configuration/authentication/).
+Add the AWS trait package to `smithy-build.json`:
+
+```json
+"software.amazon.smithy:smithy-aws-traits:1.73.0"
+```
+
+The client uses `NSmithy.Client`, `NSmithy.Codecs.Json`, and
+`NSmithy.Protocols.AwsJson`.
+
+## Calling AWS
+
+AWS endpoints normally require SigV4, regional endpoint resolution, and
+credentials. See
+[Authentication](/smithy-dotnet/guides/client-configuration/authentication/)
+for the NSmithy setup and [AWS Protocols](../aws-overview/) for current runtime
+gaps.
+
+## Example
+
+The [AWS LocalStack
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/aws-localstack)
+uses an AWS JSON 1.0 client to call DynamoDB `ListTables`. NSmithy does not
+implement AWS JSON streaming yet, so there is no streaming example.
+
+## Specification and tests
+
+- [AWS JSON 1.0 specification](https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html)
+- [AWS JSON 1.1 specification](https://smithy.io/2.0/aws/protocols/aws-json-1_1-protocol.html)
+- [Official AWS JSON protocol tests](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/awsJson1_1)

--- a/website/src/content/docs/protocols/aws-overview.md
+++ b/website/src/content/docs/protocols/aws-overview.md
@@ -15,14 +15,14 @@ it is documented as a top-level protocol rather than under this AWS section.)
 
 ## Use the Official AWS SDK for .NET Instead
 
-If your goal is to call AWS services in production with `restXml` or AWS JSON,
+If your goal is to call AWS services in production with an AWS protocol,
 you should use the **[AWS SDK for .NET](https://github.com/aws/aws-sdk-net)**
 instead:
 
 - It is officially supported and maintained by AWS.
 - It covers the full breadth of AWS services.
 - It includes authentication (SigV4/SigV4a), retries, endpoint resolution,
-  pagination helpers, and presigned URLs.
+  pagination helpers, and the complete set of service-specific endpoint rules.
 
 ## AWS restJson1 Is Different
 
@@ -40,17 +40,19 @@ For AWS restJson1, NSmithy targets more than proof-of-concept use:
   reasonable choice for services modelled with `restJson1` outside of AWS.
 - **AWS services in production** — the goal is for NSmithy-generated `restJson1`
   clients to be usable against real AWS services. Explicit SigV4 signing exists
-  in early preview, but AWS SDK-style endpoint resolution, credential chains,
-  retries, and pagination helpers are not there yet.
+  in preview with regional endpoint resolution, profile/SSO/IMDS credentials,
+  and presigning, but service-specific endpoint rules, the full credential
+  chain, retries, and pagination helpers are not there yet.
 
 Until those pieces exist, use the official SDK when targeting AWS directly.
 
 ## AWS SigV4 Is Early Preview
 
 `NSmithy.Aws` includes explicit SigV4 signing through `AwsSigV4AuthScheme`.
-Callers provide the endpoint, signing service name, region, and credentials
-provider. This is enough for LocalStack examples and narrow smoke tests, but it
-is not a production AWS auth stack.
+Callers provide the signing service name and region. The package includes a
+standard regional endpoint resolver, a default environment/profile/SSO/IMDS
+credential chain, and presigning. This is enough for LocalStack and focused AWS
+integrations, but it is not yet the complete production stack of the official SDK.
 
 See [Authentication](/smithy-dotnet/guides/client-configuration/authentication/) for configuration
 details and current limitations.
@@ -63,5 +65,11 @@ NSmithy includes early client runtime support for `aws.protocols#awsJson1_1` and
 special floating-point values, and client-side error discrimination.
 
 There is no AWS JSON server generation, and production AWS concerns such as
-AWS SDK-style credential resolution, endpoint resolution, retries, and pagination
-helpers are still outside the generated client.
+modeled endpoint rule sets, additional credential sources, retries, and
+pagination helpers are still outside the generated client.
+
+## AWS Query Protocols Are Client-Only
+
+`aws.protocols#awsQuery` and `aws.protocols#ec2Query` have generated client
+support and pass every applicable request and response case in Smithy's official
+AWS protocol fixtures. They intentionally do not generate servers.

--- a/website/src/content/docs/protocols/aws-overview.md
+++ b/website/src/content/docs/protocols/aws-overview.md
@@ -1,75 +1,94 @@
 ---
-title: AWS Protocols Overview
-description: Important context before using NSmithy's AWS protocol support.
+title: AWS Protocols
+description: Choose an AWS wire protocol and understand the runtime features needed to call AWS services.
 ---
 
-NSmithy's AWS protocol support exists primarily as a **proof of concept** — a
-vehicle for validating the generator's protocol abstraction, codec layer, and
-conformance test infrastructure against real AWS protocol definitions. This is
-especially true for `aws.protocols#restXml` and the AWS JSON protocols.
+NSmithy supports several wire protocols used by AWS services. AWS JSON, AWS
+Query, EC2 Query, and restXml are primarily useful for calling those services or
+compatible emulators such as LocalStack. restJson1 is the exception: it is also
+a practical protocol for APIs outside AWS.
 
-AWS restJson1 is the exception — see below.
+Protocol support is separate from the rest of the AWS SDK runtime. A successful
+production AWS client also needs authentication, endpoint rules, retries,
+credentials, and service-level conveniences.
 
-(`smithy.protocols#rpcv2Cbor` is a Smithy-standard binary protocol, not AWS-specific;
-it is documented as a top-level protocol rather than under this AWS section.)
+## Supported AWS protocols
 
-## Use the Official AWS SDK for .NET Instead
+| Protocol | Generated surfaces | Typical use |
+| --- | --- | --- |
+| [restJson1](../rest-json/) | Client and server | REST APIs, event streams, and AWS-compatible services |
+| [awsJson1_0 and awsJson1_1](../aws-json/) | Client | JSON RPC services such as DynamoDB |
+| [awsQuery](../aws-query/) | Client | Existing AWS Query services such as SQS |
+| [ec2Query](../aws-ec2-query/) | Client | EC2 Query services |
+| [restXml](../rest-xml/) | Client | XML services such as S3 |
 
-If your goal is to call AWS services in production with an AWS protocol,
-you should use the **[AWS SDK for .NET](https://github.com/aws/aws-sdk-net)**
-instead:
+See [Protocol Status](../status/) for maturity and conformance numbers.
 
-- It is officially supported and maintained by AWS.
-- It covers the full breadth of AWS services.
-- It includes authentication (SigV4/SigV4a), retries, endpoint resolution,
-  pagination helpers, and the complete set of service-specific endpoint rules.
+## New services
 
-## AWS restJson1 Is Different
+`restJson1` is useful beyond AWS and is a strong default for a new REST API.
+It has broad Smithy tooling support, standard HTTP bindings, raw and streaming
+payloads, Amazon Event Stream, request compression, checksums, and
+AWS-compatible error handling.
 
-`aws.protocols#restJson1` is not AWS-specific in practice — it is a
-well-defined REST/JSON wire format usable by any HTTP service, whether or not
-it runs on AWS. Many teams use it to define internal or public APIs that follow
-the same protocol as AWS services. For that reason it is documented as a
-top-level protocol, alongside `simpleRestJson`, on the [REST
-JSON](/smithy-dotnet/protocols/rest-json/) page rather than under this AWS
-section.
+The other AWS protocols exist mainly for compatibility with established
+services. Smithy deprecates AWS Query for new service design.
 
-For AWS restJson1, NSmithy targets more than proof-of-concept use:
+## Calling AWS from .NET
 
-- **Non-AWS services** — generated clients and servers work today and are a
-  reasonable choice for services modelled with `restJson1` outside of AWS.
-- **AWS services in production** — the goal is for NSmithy-generated `restJson1`
-  clients to be usable against real AWS services. Explicit SigV4 signing exists
-  in preview with regional endpoint resolution, profile/SSO/IMDS credentials,
-  and presigning, but service-specific endpoint rules, the full credential
-  chain, retries, and pagination helpers are not there yet.
+If you want to use AWS from .NET, you most likely want the official [AWS SDK
+for .NET](https://github.com/aws/aws-sdk-net). It is the supported client for the
+full AWS service catalog and includes the complete set of service-specific
+features.
 
-Until those pieces exist, use the official SDK when targeting AWS directly.
+NSmithy is not intended to replace the AWS SDK. It does, however, cover a useful
+part of the AWS client stack:
 
-## AWS SigV4 Is Early Preview
+- SigV4 signing and presigning
+- Standard regional endpoint resolution
+- Environment, shared-profile, SSO, and IMDS credentials
+- Standard retries with jitter, retry quotas, `Retry-After`, and modeled
+  `@retryable` errors
+- Generated page and item paginators for modeled `@paginated` operations
+- Clients for the supported AWS protocols when supplied with a Smithy model
 
-`NSmithy.Aws` includes explicit SigV4 signing through `AwsSigV4AuthScheme`.
-Callers provide the signing service name and region. The package includes a
-standard regional endpoint resolver, a default environment/profile/SSO/IMDS
-credential chain, and presigning. This is enough for LocalStack and focused AWS
-integrations, but it is not yet the complete production stack of the official SDK.
+NSmithy does not yet provide:
 
-See [Authentication](/smithy-dotnet/guides/client-configuration/authentication/) for configuration
-details and current limitations.
+- SigV4a
+- Modeled service-specific endpoint rule sets
+- The complete credential provider chain, including assume-role, web identity,
+  and ECS container credentials
+- AWS service-specific retry, paginator, and utility behavior
+- Maintained coverage for the full AWS service catalog or official AWS support
 
-## AWS JSON Is Client-Only
+This makes NSmithy useful for focused integrations, emulators, and clients built
+from your own Smithy models. See
+[Authentication](/smithy-dotnet/guides/client-configuration/authentication/),
+[Retry](/smithy-dotnet/guides/client-configuration/retry/), and
+[Pagination](/smithy-dotnet/guides/client-configuration/pagination/) for details.
 
-NSmithy includes early client runtime support for `aws.protocols#awsJson1_1` and
-`aws.protocols#awsJson1_0`. The current conformance project exercises an initial
-`awsJson1_1` slice: target/header construction, empty input/output behavior,
-special floating-point values, and client-side error discrimination.
+## AWS as a proving ground
 
-There is no AWS JSON server generation, and production AWS concerns such as
-modeled endpoint rule sets, additional credential sources, retries, and
-pagination helpers are still outside the generated client.
+AWS is also a demanding test bed for NSmithy. The official AWS protocol test
+suites exercise a wide range of HTTP bindings, data shapes, error responses,
+and edge cases. LocalStack and real service calls add interoperability coverage
+beyond the fixtures.
 
-## AWS Query Protocols Are Client-Only
+Supporting these protocols helps find weaknesses in serialization, transport,
+authentication, and generated clients. Those improvements also harden the same
+runtime used for non-AWS Smithy services, especially `restJson1` services.
 
-`aws.protocols#awsQuery` and `aws.protocols#ec2Query` have generated client
-support and pass every applicable request and response case in Smithy's official
-AWS protocol fixtures. They intentionally do not generate servers.
+## Examples
+
+The [AWS LocalStack
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/aws-localstack)
+uses generated clients for all five supported AWS HTTP protocols:
+
+- DynamoDB over AWS JSON 1.0
+- S3 over restXml
+- Lambda over restJson1
+- SQS over AWS Query
+- EC2 over EC2 Query
+
+For restJson1 event streams, see the [streaming
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/restjson1-streaming).

--- a/website/src/content/docs/protocols/aws-query.md
+++ b/website/src/content/docs/protocols/aws-query.md
@@ -1,0 +1,125 @@
+---
+title: AWS Query
+description: Form-encoded requests and XML responses using aws.protocols#awsQuery.
+---
+
+`aws.protocols#awsQuery` is an RPC protocol that sends form-encoded requests
+and receives XML responses. NSmithy generates typed clients. Server generation
+and streaming are not available.
+
+:::caution[Existing services only]
+Smithy deprecates AWS Query for new services. Use it for existing AWS services
+and compatible local emulators.
+:::
+
+See [Protocol Status](../status/) for maturity and current conformance numbers.
+
+## Protocol behavior
+
+| Area | AWS Query |
+| --- | --- |
+| Route | `POST /` |
+| Request | `application/x-www-form-urlencoded` |
+| Operation | `Action={Operation}` |
+| Version | `Version={service version}` |
+| Response | XML with an `{Operation}Result` wrapper |
+| Errors | AWS Query XML error envelope and optional `@awsQueryError` |
+| HTTP bindings | Not used |
+| Streaming | Not supported |
+
+AWS Query does not support document shapes. Lists and maps use dotted form keys,
+and XML traits control names and collection flattening.
+
+## Modeling
+
+Apply `@awsQuery` and `@xmlNamespace` to the service:
+
+```smithy
+$version: "2"
+
+namespace example.queue
+
+use aws.protocols#awsQuery
+
+@awsQuery
+@xmlNamespace(uri: "https://queue.example.com/doc/2026-01-01/")
+service QueueService {
+    version: "2026-01-01"
+    operations: [ListQueues]
+}
+
+operation ListQueues {
+    input := {
+        namePrefix: String
+    }
+    output := {
+        @xmlFlattened
+        @xmlName("QueueUrl")
+        queueUrls: QueueUrlList
+    }
+}
+
+list QueueUrlList {
+    member: String
+}
+```
+
+`@xmlName` changes form keys and XML element names. `@xmlFlattened` removes
+the normal list or map wrapper. An error structure can use
+`aws.protocols#awsQueryError` to set its wire error code and HTTP status.
+
+## On the wire
+
+```http
+POST / HTTP/1.1
+Host: queue.example.com
+Content-Type: application/x-www-form-urlencoded
+Accept: text/xml
+
+Action=ListQueues&Version=2026-01-01&namePrefix=jobs
+
+HTTP/1.1 200 OK
+Content-Type: text/xml
+
+<ListQueuesResponse xmlns="https://queue.example.com/doc/2026-01-01/">
+  <ListQueuesResult>
+    <QueueUrl>https://queue.example.com/jobs-1</QueueUrl>
+  </ListQueuesResult>
+  <ResponseMetadata><RequestId>abc</RequestId></ResponseMetadata>
+</ListQueuesResponse>
+```
+
+Lists use `member` segments by default. Maps use numbered `entry`, `key`,
+and `value` segments. Successful output members are nested inside
+`{Operation}Result`.
+
+## Dependencies
+
+Add the AWS trait package to `smithy-build.json`:
+
+```json
+"software.amazon.smithy:smithy-aws-traits:1.73.0"
+```
+
+The client uses `NSmithy.Client` and `NSmithy.Protocols.AwsQuery`. The
+protocol package includes the XML codec transitively.
+
+## Calling AWS
+
+AWS endpoints normally require SigV4, regional endpoint resolution, and
+credentials. See
+[Authentication](/smithy-dotnet/guides/client-configuration/authentication/)
+for the NSmithy setup and [AWS Protocols](../aws-overview/) for current runtime
+gaps.
+
+## Example
+
+The [AWS LocalStack
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/aws-localstack)
+uses an AWS Query client to call SQS `ListQueues`. AWS Query does not support
+streaming, so there is no streaming example.
+
+## Specification and tests
+
+- [AWS Query specification](https://smithy.io/2.0/aws/protocols/aws-query-protocol.html)
+- [Official AWS Query protocol tests](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/awsQuery)

--- a/website/src/content/docs/protocols/grpc.md
+++ b/website/src/content/docs/protocols/grpc.md
@@ -1,44 +1,34 @@
 ---
 title: gRPC
-description: alloy.proto#grpc — generate native gRPC client and server surfaces from a Smithy model, with no protoc or Grpc.Tools.
+description: Generate native gRPC clients and servers from alloy.proto#grpc without protoc or Grpc.Tools.
 ---
 
-`alloy.proto#grpc` generates native gRPC client and server surfaces directly
-from a Smithy model. NSmithy implements the gRPC wire contract itself — a
-schema-driven protobuf codec (`NSmithy.Codecs.Proto`) plus a gRPC transport
-binding (`NSmithy.Protocols.Grpc`) — so there is no `protoc`, `Grpc.Tools`, or
-`Grpc.Net` dependency. The generated surfaces match the same protocol-agnostic
-handler and client interfaces used by the HTTP protocols. Status:
-**Experimental**.
+`alloy.proto#grpc` generates native gRPC clients and ASP.NET Core servers from a
+Smithy model. NSmithy provides its own protobuf codec and gRPC transport, so an
+NSmithy service does not need `protoc`, `Grpc.Tools`, `Google.Protobuf`, or
+`Grpc.Net`.
 
-Because the bytes on the wire are standard protobuf over gRPC/HTTP/2, an NSmithy
-peer interoperates with a `Grpc.Net` peer in either direction. A `.proto` file can
-still be emitted (see [Generating a `.proto`](#generating-a-proto-for-external-peers))
-when you need to build a non-NSmithy peer the conventional way.
+The wire contract is standard protobuf over gRPC and HTTP/2. NSmithy peers can
+interoperate with conventional gRPC implementations through a generated
+`.proto` file.
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for current maturity
-details.
+See [Protocol Status](../status/) for maturity and test coverage.
 
-## Maven Dependency
+## Protocol behavior
 
-```json
-"com.disneystreaming.alloy:alloy-core:0.3.38"
-```
-
-## NuGet Packages
-
-| Purpose | Packages |
+| Area | gRPC |
 | --- | --- |
-| gRPC server (ASP.NET Core) | `NSmithy.Server.AspNetCore`, `NSmithy.Protocols.Grpc` |
-| gRPC client | `NSmithy.Client`, `NSmithy.Protocols.Grpc` |
-
-`NSmithy.Protocols.Grpc` pulls in `NSmithy.Codecs.Proto` (the protobuf codec)
-transitively. No protobuf toolchain is required.
+| Route | `/{namespace}.{Service}/{Operation}` |
+| Body | Protobuf |
+| Framing | Standard gRPC message frames over HTTP/2 |
+| Errors | `grpc-status` plus Smithy error metadata |
+| Streaming | Server, client, and bidirectional event streams |
+| Smithy requirement | `@protoIndex` on protobuf fields |
 
 ## Modeling
 
-Apply `@grpc` to the service and `@protoIndex` to every member in an operation's
-input or output:
+Apply `@grpc` to the service and give each protobuf field a stable
+`@protoIndex`:
 
 ```smithy
 $version: "2"
@@ -68,54 +58,15 @@ operation GetCity {
 }
 ```
 
-`@protoIndex` assigns the proto field number. It is currently required on every
-member that appears in a proto message — omitting it is a model error.
-`@protoNumType` selects integer wire types (`sint`/`uint`/`fixed`/`sfixed`).
-
-## On the Wire
-
-NSmithy uses standard gRPC framing — length-prefixed protobuf over HTTP/2 — and
-interoperates with any gRPC peer. Each member's `@protoIndex` is its protobuf
-field number.
-
-A unary `GetCity { cityId: "123" }` call posts to
-`/{namespace}.{Service}/{Method}`:
-
-```
-POST /example.weather.Weather/GetCity HTTP/2
-content-type: application/grpc+proto
-te: trailers
-
-<gRPC frame><protobuf message>
-```
-
-Each message is a gRPC frame — a 1-byte compression flag, a 4-byte big-endian
-length, then the protobuf payload. For `cityId: "123"`:
-
-```
-00              compression flag (0 = uncompressed)
-00 00 00 05     message length = 5 bytes (big-endian)
-0a              field 1, wire type 2 (LEN)   ← cityId, @protoIndex(1)
-03              string length = 3
-31 32 33        "123"
-```
-
-The response returns the output in the same framing and signals the result with
-the `grpc-status` trailer (`0` = OK). Modeled errors return HTTP 200 with a
-non-zero `grpc-status`; NSmithy carries the Smithy error shape id in the
-`grpc-message` / `x-smithy-grpc-error` trailer for typed dispatch.
+`@protoIndex` is the protobuf field number and is part of the stable wire
+contract. Omitting it from an input or output member is a model error.
+`@protoNumType` selects integer encodings such as `sint32`, `uint64`, or
+`fixed32`.
 
 ## Server
 
-gRPC is the one protocol where the hosting and client code differs from the
-[shared example](/smithy-dotnet/protocols/overview/): it needs HTTP/2
-transport and a gRPC-specific client protocol. The generated handler interface
-itself works the same way — you implement one method per operation.
-
-Configure Kestrel to serve HTTP/2 on a dedicated port. Cleartext gRPC requires
-HTTP/2; mixing HTTP/1.1 REST and cleartext gRPC on the same port is unreliable
-without TLS/ALPN. There is no `AddGrpc()` call — the generated `MapWeatherService`
-maps the gRPC method routes itself:
+gRPC requires HTTP/2. Configure a dedicated cleartext HTTP/2 port for local
+development, then map the generated service:
 
 ```csharp
 using Example.Weather;
@@ -124,28 +75,24 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.ConfigureKestrel(options =>
 {
-    options.ListenLocalhost(5001, o => o.Protocols = HttpProtocols.Http2);
+    options.ListenLocalhost(5001, listener =>
+        listener.Protocols = HttpProtocols.Http2);
 });
 builder.Services.AddWeatherServiceHandler<WeatherHandler>();
 
 var app = builder.Build();
 app.MapWeatherService();
 app.Run();
-
-internal sealed class WeatherHandler : IWeatherServiceHandler
-{
-    public Task<GetCityOutput> GetCityAsync(
-        GetCityInput input, CancellationToken ct = default) =>
-        Task.FromResult(new GetCityOutput("Seattle"));
-}
 ```
+
+There is no `AddGrpc()` call. The generated mapping registers the gRPC method
+routes directly. Cleartext REST and gRPC should use separate ports unless TLS
+and ALPN negotiate the HTTP version.
 
 ## Client
 
-The generated `WeatherClient` is a native NSmithy client over an HTTP/2
-`HttpClient` — no `GrpcChannel`. Pass `GrpcProtocol` to select gRPC. With the
-endpoint constructor shown here, the client creates the `HttpClient` and
-automatically requests exact HTTP/2:
+The generated client uses an HTTP/2 `HttpClient`. Select `GrpcProtocol` in the
+client configuration:
 
 ```csharp
 using Example.Weather;
@@ -156,39 +103,16 @@ var client = new WeatherClient(
     new() { Protocol = new GrpcProtocol() });
 
 var city = await client.GetCityAsync(new GetCityInput("SEA"));
-Console.WriteLine(city.Name); // Seattle
 ```
 
-The generated `AddWeatherClient(...)` DI helper also applies exact HTTP/2
-automatically. For a service that declares an HTTP protocol alongside `@grpc`,
-the same client speaks either: set `Protocol = new GrpcProtocol()` for gRPC, or
-leave `Protocol` unset for the default (primary) protocol.
-
-When you pass a caller-owned `HttpClient` directly, the generated client uses it
-as configured. Set the required version and policy yourself:
-
-```csharp
-httpClient.DefaultRequestVersion = System.Net.HttpVersion.Version20;
-httpClient.DefaultVersionPolicy =
-    System.Net.Http.HttpVersionPolicy.RequestVersionExact;
-```
-
-See [Client Configuration](/smithy-dotnet/guides/client-configuration/) for the
-constructor and DI ownership rules.
+The endpoint constructor and generated dependency injection helper request exact
+HTTP/2 automatically. A caller-owned `HttpClient` must set
+`DefaultRequestVersion` to HTTP/2 and `DefaultVersionPolicy` to
+`RequestVersionExact`.
 
 ## Streaming
 
-Native gRPC supports event streaming operations whose streaming member targets an
-event union. Generated clients and handlers use the modeled operation
-input/output shapes; the streaming member inside those shapes is
-`IAsyncEnumerable<TEvent>`:
-
-- server streaming returns an output shape with an `IAsyncEnumerable<TEvent>` member
-- client streaming accepts an input shape with an `IAsyncEnumerable<TEvent>` member
-- bidirectional streaming uses input and output shapes with stream members
-
-Model a streaming operation by targeting a `@streaming` union. Each event member
-carries a `@protoIndex`, the same as any other gRPC member:
+Model an event stream with an `@streaming` union:
 
 ```smithy
 @streaming
@@ -197,7 +121,6 @@ union ChatEvent {
     message: MessageEvent
 }
 
-/// Server-streaming: one request, many events.
 operation WatchRoom {
     input := {
         @required
@@ -210,65 +133,46 @@ operation WatchRoom {
 }
 ```
 
-The handler returns the modeled output and supplies an async event sequence:
+Generated input and output shapes expose streaming members as
+`IAsyncEnumerable<TEvent>`. An output stream provides server streaming, an
+input stream provides client streaming, and streams on both sides provide
+bidirectional streaming.
 
-```csharp
-public Task<WatchRoomOutput> WatchRoomAsync(
-    WatchRoomInput input,
-    CancellationToken ct = default) =>
-    Task.FromResult(new WatchRoomOutput(WatchRoomEventsAsync(input, ct)));
+Streaming blob payloads are separate from gRPC event streaming and are not
+implemented.
 
-private static async IAsyncEnumerable<ChatEvent> WatchRoomEventsAsync(
-    WatchRoomInput input,
-    [EnumeratorCancellation] CancellationToken ct = default)
-{
-    for (var i = 1; i <= 3; i++)
-    {
-        await Task.Delay(25, ct);
-        yield return ChatEvent.FromMessage(
-            new MessageEvent(User: "server", Text: $"{input.Room}: update {i}"));
-    }
-}
+## Interoperability and `.proto` generation
+
+NSmithy can emit a `.proto` file from the Smithy model through `SmithyGrpc` or
+`smithy-proto-codegen`. Use that file with `protoc` or `Grpc.Tools` when the
+other peer uses a conventional gRPC stack. The Smithy model remains the source
+of truth.
+
+The supported protobuf surface includes scalars, `@protoNumType`, lists, maps,
+`@sparse`, string and integer enums, unions, `@protoInlinedOneOf`,
+`Timestamp`, and `Document`.
+
+## Dependencies
+
+Add the Alloy model package to `smithy-build.json`:
+
+```json
+"com.disneystreaming.alloy:alloy-core:0.3.38"
 ```
 
-The client consumes the stream with `await foreach`:
+| Surface | Packages |
+| --- | --- |
+| Client | `NSmithy.Client`, `NSmithy.Protocols.Grpc` |
+| Server | `NSmithy.Server.AspNetCore`, `NSmithy.Protocols.Grpc` |
 
-```csharp
-var output = await client.WatchRoomAsync(new WatchRoomInput("general"), ct);
-await foreach (var evt in output.Events.WithCancellation(ct))
-{
-    if (evt is ChatEvent.Message m)
-        Console.WriteLine($"{m.Value.User}: {m.Value.Text}");
-}
-```
+`NSmithy.Protocols.Grpc` includes the NSmithy protobuf codec transitively.
 
-Client-streaming and bidirectional operations follow the same shape — the
-streaming member is an `IAsyncEnumerable<TEvent>` property on the modeled input,
-output, or both. See the runnable
-[`examples/grpc-streaming`](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/grpc-streaming)
-project for all three.
+## Examples
 
-Streaming payload blobs are not implemented yet. The streaming support here is
-for event streams, matching the common gRPC shape.
+- [Unary gRPC library service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/grpc)
+- [Streaming and Grpc.Net interoperability](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/grpc-streaming)
 
-## Interoperating with `Grpc.Net`
+## Protocol source
 
-NSmithy needs no `Grpc.Net` — but because it speaks the standard gRPC HTTP/2 wire
-contract, a `Grpc.Net` client or server interoperates with an NSmithy peer, and
-you can use `Grpc.Net` on one side if you prefer.
-
-You never hand-author a `.proto`. Setting `SmithyGrpc` (or running
-`smithy-proto-codegen`) generates the `.proto` **from the Smithy model**; feed
-that generated file to `protoc`/`Grpc.Tools` to build the `Grpc.Net` peer. The
-model stays the single source of truth for both sides.
-
-## Current Limitations
-
-- `@protoIndex` is required on every input and output member.
-- Streaming support is event-stream oriented and still early; streaming payload
-  blobs, stream errors, and cancellation behavior need more coverage.
-- The full unary surface — scalars and `@protoNumType`, lists/maps, `@sparse`
-  maps, string and int enums, unions and `@protoInlinedOneOf`, `Timestamp`, and
-  `Document` — is supported.
-- Cleartext development requires separate HTTP/1.1 and HTTP/2 ports.
-- Smallest conformance test surface of any supported protocol.
+- [Alloy repository](https://github.com/disneystreaming/alloy)
+- [Native gRPC design](https://github.com/thomaslaich/smithy-dotnet/blob/main/designs/native-grpc.md)

--- a/website/src/content/docs/protocols/overview.md
+++ b/website/src/content/docs/protocols/overview.md
@@ -59,6 +59,8 @@ wiring is required.
 | `aws.protocols#restJson1` | `@restJson1` | .NET client, ASP.NET Core server | Preview |
 | `aws.protocols#awsJson1_1` | `@awsJson1_1` | .NET client | Early preview |
 | `aws.protocols#awsJson1_0` | `@awsJson1_0` | .NET client | Early preview |
+| `aws.protocols#awsQuery` | `@awsQuery` | .NET client | Preview |
+| `aws.protocols#ec2Query` | `@ec2Query` | .NET client | Preview |
 | `aws.protocols#restXml` | `@restXml` | .NET client | Early preview |
 | `smithy.protocols#rpcv2Cbor` | `@rpcv2Cbor` | .NET client, ASP.NET Core server | Preview |
 | `alloy.proto#grpc` | `@grpc` | gRPC client, ASP.NET Core gRPC server | Experimental |

--- a/website/src/content/docs/protocols/overview.md
+++ b/website/src/content/docs/protocols/overview.md
@@ -1,44 +1,52 @@
 ---
-title: Overview
-description: How Smithy protocols map to generated .NET surfaces in NSmithy — and why your client and server code never change when the protocol does.
+title: Protocols
+description: Choose a Smithy protocol and understand what it changes in generated .NET clients and servers.
 ---
 
-A Smithy protocol trait on a service definition controls two things:
+A protocol defines the HTTP route, headers, body encoding, error format, and
+streaming transport for a Smithy service. NSmithy reads the protocol trait and
+generates the matching .NET runtime bindings.
 
-- **Wire format** — how requests and responses are serialized (JSON, XML, CBOR,
-  Protobuf)
-- **HTTP binding** — how operations, inputs, and outputs map to HTTP methods,
-  URIs, headers, and bodies
+The protocol does not change your application model. Generated clients expose
+typed operations, and generated servers expose typed handler interfaces,
+regardless of the wire format.
 
-NSmithy reads the protocol trait and generates the matching client and server
-surfaces.
+## Choose a protocol
 
-## Your code does not change with the protocol
+| Protocol | Generated surfaces | Choose it for |
+| --- | --- | --- |
+| [`aws.protocols#restJson1`](../rest-json/) | Client and server | General REST APIs, broad tooling support, streaming, and AWS-compatible behavior |
+| [`smithy.protocols#rpcv2Cbor`](../rpc-v2-cbor/) | Client and server | Compact binary RPC with CBOR and event streaming |
+| [`aws.protocols#awsJson1_1`](../aws-json/) | Client | Existing AWS JSON RPC services |
+| [`aws.protocols#awsJson1_0`](../aws-json/) | Client | Existing AWS JSON 1.0 services |
+| [`aws.protocols#awsQuery`](../aws-query/) | Client | Existing AWS Query services |
+| [`aws.protocols#ec2Query`](../aws-ec2-query/) | Client | Existing EC2 Query services |
+| [`aws.protocols#restXml`](../rest-xml/) | Client | Existing AWS XML services such as S3 |
+| [`alloy#simpleRestJson`](../rest-json/) | Client and server | Alloy and Smithy4s interoperability |
+| [`alloy.proto#grpc`](../grpc/) | Client and server | Standard gRPC and protobuf interoperability |
 
-The protocol trait never reaches your application code. You implement one
-generated handler interface and call one typed client; swapping the protocol
-trait on the service swaps the wire format without touching either side. What
-changes per protocol is layered on top:
+For most new HTTP APIs, start with `restJson1`. Use `rpcv2Cbor` for compact
+binary Smithy RPC between compatible peers. Use gRPC when standard protobuf and
+gRPC interoperability matter. The AWS Query, AWS JSON, and restXml protocols
+are primarily for existing AWS services and emulators.
 
-- the **service's protocol trait** (`@simpleRestJson`, `@restJson1`,
-  `@rpcv2Cbor`, `@grpc`, …), and
-- for HTTP protocols, the **HTTP binding traits** on operations (`@http`,
-  `@httpLabel`, …); gRPC uses `@protoIndex` instead.
+See [Protocol Status](../status/) for maturity and current conformance numbers.
 
-The protocol pages below cover only what is specific to each protocol — its
-trait, modeling rules, and wire format.
+## What changes with the protocol
 
-### Server
+- Request routes, methods, and required headers
+- JSON, XML, CBOR, or protobuf body encoding
+- Error discriminators and response envelopes
+- Streaming framing and HTTP version requirements
+- The protocol runtime and codec packages used by generated code
 
-You implement one generated handler interface (`IWeatherServiceHandler`, a method
-per operation); the generated ASP.NET Core adapter registers it and maps its
-routes. Throwing a generated error type serializes it with the correct status
-code and body for whichever protocol the service declares. See
-[Servers](/smithy-dotnet/servers/) for the full walkthrough and [Hosting &amp;
-Multiple Protocols](/smithy-dotnet/servers/hosting/) for exposing one service
-over several protocols at once.
+REST protocols also use Smithy HTTP binding traits such as `@http`,
+`@httpLabel`, `@httpQuery`, and `@httpHeader`. RPC protocols derive their routes
+from the service and operation names.
 
-### Client
+## What stays the same
+
+The generated client keeps the same typed operation surface:
 
 ```csharp
 using Example.Weather;
@@ -48,22 +56,19 @@ var city = await client.GetCityAsync(new GetCityInput("SEA"));
 Console.WriteLine(city.Name);
 ```
 
-The generated client uses the service's declared protocol by default — no codec
-wiring is required.
+Generated servers use a handler interface with one method per operation. The
+adapter handles routing, serialization, validation, and modeled errors before
+or after the handler call.
 
-## Supported Protocols
+Changing a service protocol does not require changes to handler code or client
+call sites if the model stays within the feature set shared by both protocols.
 
-| Protocol | Trait | Generated surfaces | Status |
-| --- | --- | --- | --- |
-| `alloy#simpleRestJson` | `@simpleRestJson` | .NET client, ASP.NET Core server | Preview |
-| `aws.protocols#restJson1` | `@restJson1` | .NET client, ASP.NET Core server | Preview |
-| `aws.protocols#awsJson1_1` | `@awsJson1_1` | .NET client | Early preview |
-| `aws.protocols#awsJson1_0` | `@awsJson1_0` | .NET client | Early preview |
-| `aws.protocols#awsQuery` | `@awsQuery` | .NET client | Preview |
-| `aws.protocols#ec2Query` | `@ec2Query` | .NET client | Preview |
-| `aws.protocols#restXml` | `@restXml` | .NET client | Early preview |
-| `smithy.protocols#rpcv2Cbor` | `@rpcv2Cbor` | .NET client, ASP.NET Core server | Preview |
-| `alloy.proto#grpc` | `@grpc` | gRPC client, ASP.NET Core gRPC server | Experimental |
+## Services with multiple protocols
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for conformance numbers,
-maturity details, and guidance on which protocol to choose.
+A service can declare more than one supported protocol. Generated clients can
+select a non-default protocol through their configuration, and generated servers
+can map several protocol surfaces to the same handler.
+
+See [Hosting and Multiple Protocols](/smithy-dotnet/servers/hosting/) for route
+mapping and [Client Configuration](/smithy-dotnet/guides/client-configuration/)
+for protocol selection.

--- a/website/src/content/docs/protocols/rest-json.md
+++ b/website/src/content/docs/protocols/rest-json.md
@@ -1,64 +1,63 @@
 ---
 title: REST JSON
-description: alloy#simpleRestJson and aws.protocols#restJson1 — JSON over HTTP with Smithy REST bindings. Client and server support.
+description: Compare alloy#simpleRestJson and aws.protocols#restJson1, two JSON over HTTP protocols with Smithy REST bindings.
 ---
 
-NSmithy supports two JSON-over-HTTP protocols with Smithy HTTP bindings, and
-generates a typed .NET client and an ASP.NET Core minimal-API server for each:
+NSmithy supports two REST JSON protocols. Both generate a typed .NET client and
+an ASP.NET Core minimal API server, and both use Smithy HTTP binding traits.
+Their simplest operations can look identical on the wire, but the protocols are
+not equivalent.
 
-| Trait | Namespace | Status |
+## Which protocol should I use?
+
+Choose `restJson1` for most new services. It has a broader wire contract, a
+larger interoperability surface, protocol-defined streaming, and AWS-compatible
+error handling.
+
+Choose `simpleRestJson` when you need compatibility with
+[Alloy](https://github.com/disneystreaming/alloy) or
+[Smithy4s](https://disneystreaming.github.io/smithy4s/), or when your model uses
+Alloy JSON features such as `@discriminated` and `@jsonUnknown`.
+
+| Protocol | Trait | Best fit |
 | --- | --- | --- |
-| `@simpleRestJson` | `alloy#simpleRestJson` | Preview |
-| `@restJson1` | `aws.protocols#restJson1` | Preview |
+| AWS restJson1 | `aws.protocols#restJson1` | General REST APIs, broad Smithy tooling support, streaming, or AWS-compatible services |
+| simpleRestJson | `alloy#simpleRestJson` | Alloy and Smithy4s interoperability, with a deliberately smaller JSON-only wire contract |
 
-The two are the same shape on the wire — JSON body, Smithy HTTP binding traits,
-an error type carried in a response header. They differ only in ecosystem and a
-few AWS-specific behaviors.
+Coverage and maturity are tracked on the [Protocol
+Status](/smithy-dotnet/protocols/status/) page.
 
-## Choosing between them
+## Key differences
 
-- **`simpleRestJson`** — the [alloy](https://github.com/disneystreaming/alloy)
-  variant. Choose it when your consumers are primarily .NET or Scala
-  (via [Smithy4s](https://disneystreaming.github.io/smithy4s/)).
-- **`restJson1`** — AWS's REST/JSON protocol, but useful for non-AWS services
-  too. Choose it when you want broad Smithy ecosystem compatibility or OpenAPI
-  generation through `smithy-openapi`. It also supports capabilities
-  `simpleRestJson` does not: event streaming (the `vnd.amazon.eventstream`
-  framing), raw string/blob payloads, `@requestCompression`,
-  `@httpChecksumRequired`, and AWS-style error deserialization.
+| Area | simpleRestJson | restJson1 |
+| --- | --- | --- |
+| HTTP bindings | Standard Smithy REST bindings | Standard Smithy REST bindings |
+| Structured bodies | JSON | JSON |
+| `@httpPayload` | JSON values, including JSON-encoded strings | JSON structures and documents, plus raw strings and blobs with media-type-aware content types |
+| Streaming | Not defined by the Alloy protocol | Streaming blobs and Amazon Event Stream input, output, and duplex operations |
+| Request body controls | JSON body rules | `@requestCompression` and `@httpChecksumRequired` |
+| Error type | `X-Error-Type`, with `__type` accepted by clients | `X-Amzn-Errortype`, plus compatible `__type` and `code` body fields |
+| Error compatibility | Normalizes common namespace and qualifier forms | Accepts more discriminator locations and normalizes AWS namespace and qualifier forms |
+| JSON traits | Alloy traits including `@discriminated` and `@jsonUnknown` | Standard Smithy and AWS JSON rules |
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for current conformance
-numbers.
-
-## Maven Dependency
-
-| Protocol | Dependency |
-| --- | --- |
-| `simpleRestJson` | `com.disneystreaming.alloy:alloy-core:0.3.38` |
-| `restJson1` | `software.amazon.smithy:smithy-aws-traits:1.73.0` |
-
-## NuGet Packages
-
-| Purpose | Package |
-| --- | --- |
-| Client | `NSmithy.Client` |
-| Server (ASP.NET Core) | `NSmithy.Server.AspNetCore` + `Microsoft.AspNetCore.App` |
+The shared part is useful but small: ordinary structure members are serialized
+as JSON, and the standard HTTP traits decide what moves into the URI, query
+string, headers, status code, or payload. restJson1 adds the transport behavior
+needed by a wider range of services.
 
 ## Modeling
 
-Apply the protocol trait to the service and Smithy's standard HTTP binding
-traits on operations and members. The model is identical apart from the trait
-and its `use` statement — swap `alloy#simpleRestJson` / `@simpleRestJson` for
-`aws.protocols#restJson1` / `@restJson1` to switch protocols:
+Apply the protocol trait to the service and `@http` to each operation. The
+example uses `restJson1`:
 
 ```smithy
 $version: "2"
 
 namespace example.weather
 
-use alloy#simpleRestJson
+use aws.protocols#restJson1
 
-@simpleRestJson
+@restJson1
 service Weather {
     version: "2026-01-01"
     operations: [GetCity]
@@ -86,20 +85,26 @@ structure NoSuchResource {
 }
 ```
 
-Members without an explicit HTTP binding are serialized in the JSON body. The
-HTTP binding traits control where each other member lives:
+For `simpleRestJson`, replace the import and service trait with
+`alloy#simpleRestJson` and `@simpleRestJson`. That swap is safe while the model
+uses only the shared feature set.
 
-| Trait | Binds member to |
+Members without an explicit HTTP binding are serialized in the JSON body.
+
+| Trait | Location |
 | --- | --- |
 | `@httpLabel` | URI path segment |
-| `@httpQuery("key")` | query string parameter |
-| `@httpHeader("name")` | request or response header |
-| `@httpPayload` | raw request/response body |
+| `@httpQuery` | Query string |
+| `@httpQueryParams` | Open-ended query string parameters |
+| `@httpHeader` | Request or response header |
+| `@httpPrefixHeaders` | Headers with a modeled prefix |
+| `@httpResponseCode` | Response status code |
+| `@httpPayload` | Entire request or response body |
 
-## On the Wire
+## Ordinary requests
 
-`GetCity` binds `cityId` to the URI path label; the response comes back as a JSON
-body. The request and response are byte-for-byte the same across both protocols:
+For an operation that only uses the shared feature set, both protocols produce
+the same request and response:
 
 ```http
 GET /cities/123 HTTP/1.1
@@ -112,32 +117,75 @@ Content-Type: application/json
 {"name":"Seattle"}
 ```
 
-Members without an HTTP binding are carried in the JSON body. Errors are
-discriminated by a response header — the one difference on the wire:
+This equivalence does not extend to raw payloads, event streams, request body
+modifiers, or error discrimination.
 
-| Protocol | Error header |
+## restJson1 payloads and streaming
+
+restJson1 supports more than JSON object bodies:
+
+- String payloads use raw UTF-8 text and `text/plain` by default.
+- Blob payloads use raw bytes and `application/octet-stream` by default.
+- `@mediaType` overrides the content type for an opaque payload.
+- `@streaming` blob payloads flow through the client and server without being
+  buffered in memory.
+- Event stream inputs, outputs, and duplex operations use Amazon Event Stream
+  framing with `application/vnd.amazon.eventstream`.
+- `@requestCompression` and `@httpChecksumRequired` can compress or checksum a
+  buffered request body.
+
+## Error handling
+
+A simpleRestJson error carries its modeled shape name in `X-Error-Type`.
+
+restJson1 servers write `X-Amzn-Errortype`. Clients also accept the error type
+from `__type` or `code` in a JSON response body. NSmithy removes namespace and
+qualifier forms used by AWS services before matching the value to a generated
+error type. This makes restJson1 clients tolerant of the error formats found
+across AWS and AWS-compatible services.
+
+## Dependencies
+
+Add the model package for the selected protocol to `smithy-build.json`:
+
+| Protocol | Maven dependency |
 | --- | --- |
-| `simpleRestJson` | `X-Error-Type` |
-| `restJson1` | `X-Amzn-Errortype` |
+| simpleRestJson | `com.disneystreaming.alloy:alloy-core:0.3.38` |
+| restJson1 | `software.amazon.smithy:smithy-aws-traits:1.73.0` |
 
-## Usage
+| Surface | Packages |
+| --- | --- |
+| Client | `NSmithy.Client`, `NSmithy.Codecs.Json`, `NSmithy.Protocols.RestJson` |
+| Server | `NSmithy.Server.AspNetCore` |
 
-NSmithy generates one `IWeatherServiceHandler` interface with a method per
-operation, plus a typed `WeatherClient`. Implement the handler once; the
-generated ASP.NET Core adapter handles routing, serialization, and error
-dispatch. This handler-and-client shape is the same across every protocol — the
-protocol trait never reaches your code. See the [Protocols
-Overview](/smithy-dotnet/protocols/overview/) for the canonical example and
-[Servers](/smithy-dotnet/servers/) for the full server walkthrough.
+The server package includes the REST JSON protocol and JSON codec transitively.
 
-## AWS restJson1 notes
+## Generated API
 
-`restJson1` lives under `aws.protocols`, but it is not AWS-specific in practice —
-it is a well-defined REST/JSON wire format usable by any HTTP service. For
-production calls to real AWS services, explicit SigV4 signing exists in early
-preview (see
-[Authentication](/smithy-dotnet/guides/client-configuration/authentication/)),
-but AWS SDK-style endpoint resolution, credential chains, retries, and pagination
-helpers are not there yet — use the official AWS SDK for .NET until they mature.
-See the [AWS Protocols Overview](/smithy-dotnet/protocols/aws-overview/) for more
-context.
+Both protocols generate the same application-facing API: a typed client and one
+handler interface per service. The selected protocol controls routing,
+serialization, streaming, and error dispatch without changing handler code.
+See the [Protocols Overview](/smithy-dotnet/protocols/overview/) for the client
+and server pattern.
+
+## Calling AWS services
+
+restJson1 is useful outside AWS. When calling AWS itself, the request normally
+also needs SigV4 signing, regional endpoint resolution, credentials, retries,
+and service-specific endpoint rules. NSmithy provides early SigV4 support and a
+standard credential chain, but it does not yet cover the complete AWS SDK
+runtime. See [Authentication](/smithy-dotnet/guides/client-configuration/authentication/)
+and the [AWS Protocols Overview](/smithy-dotnet/protocols/aws-overview/).
+
+## Examples
+
+- [Unary restJson1 weather service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/restjson1)
+- [Streaming restJson1 chat service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/restjson1-streaming)
+- [simpleRestJson pizza service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/simplerestjson)
+
+## Specifications and tests
+
+- [AWS restJson1 specification](https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html)
+- [Official restJson1 protocol test models](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/restJson1)
+- [Alloy repository](https://github.com/disneystreaming/alloy)
+- [Smithy4s simpleRestJson documentation](https://disneystreaming.github.io/smithy4s/docs/protocols/simple-rest-json/overview/)

--- a/website/src/content/docs/protocols/rest-xml.md
+++ b/website/src/content/docs/protocols/rest-xml.md
@@ -1,38 +1,37 @@
 ---
 title: AWS restXml
-description: aws.protocols#restXml — XML over HTTP. Client-only, early preview.
+description: XML over HTTP client support for aws.protocols#restXml.
 ---
 
-`aws.protocols#restXml` is the XML-over-HTTP protocol used by AWS services such
-as S3 and Route 53. NSmithy generates a typed client that encodes request bodies
-as XML and decodes XML responses. Status: **Early preview, client-only**.
+`aws.protocols#restXml` is the XML over HTTP protocol used by AWS services such
+as S3 and Route 53. NSmithy generates typed clients with Smithy HTTP bindings,
+XML request bodies, and XML response bodies. Server generation and event
+streaming are not available.
 
-The passing slice is weighted toward response deserialization. Request binding
-coverage is still narrow and is expected to grow behind the conformance
-allowlist.
+Use restXml to call an existing AWS XML service or a compatible emulator. For a
+new service, prefer [restJson1](../rest-json/),
+[rpcv2Cbor](../rpc-v2-cbor/), or [gRPC](../grpc/).
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for current conformance
-numbers.
+See [Protocol Status](../status/) for maturity and current conformance numbers.
 
-## Maven Dependency
+## Protocol behavior
 
-```json
-"software.amazon.smithy:smithy-aws-traits:1.56.0"
-```
-
-## NuGet Packages
-
-| Purpose | Packages |
+| Area | restXml |
 | --- | --- |
-| Client | `NSmithy.Client`, `NSmithy.Protocols.RestXml` |
+| Route and method | Defined by `@http` |
+| Body | XML |
+| Content type | `application/xml` |
+| Member bindings | Standard Smithy HTTP binding traits |
+| Errors | Modeled code in an XML `Error` or `ErrorResponse` body |
+| Server | Not generated |
+| NSmithy streaming | Not implemented |
 
-`NSmithy.Protocols.RestXml` pulls in `NSmithy.Codecs.Xml` (the XML codec)
-transitively.
+restXml does not support document shapes.
 
 ## Modeling
 
-Apply `@restXml` to the service and `@http` to each operation, the same as
-`simpleRestJson`. Use `@xmlName` to override the XML element name for a member:
+Apply `@restXml` to the service and `@http` to each operation. XML traits
+control element names, namespaces, and collection layout.
 
 ```smithy
 $version: "2"
@@ -60,27 +59,19 @@ operation GetCity {
         @xmlName("Name")
         name: String
     }
-    errors: [NoSuchResource]
-}
-
-@error("client")
-structure NoSuchResource {
-    @required
-    resourceType: String
 }
 ```
 
-`@xmlName` overrides the element name in the serialized XML. Without it the
-member name is used as-is.
+Members without an HTTP binding are serialized in the XML body. `@xmlName`
+changes an element name, `@xmlNamespace` declares a namespace, `@xmlAttribute`
+moves a value to an attribute, and `@xmlFlattened` removes the normal collection
+wrapper.
 
-HTTP binding traits (`@httpLabel`, `@httpQuery`, `@httpHeader`, `@httpPayload`)
-work the same way as in the [REST JSON](/smithy-dotnet/protocols/rest-json/)
-protocols — members without an explicit binding go into the XML body.
+The standard REST binding traits place values in URI labels, query parameters,
+headers, prefix headers, response status codes, or a complete `@httpPayload`
+body.
 
-## On the Wire
-
-`GetCity` binds `cityId` to the URI path label; the response body is XML. The
-`@xmlName("Name")` on the output member sets its element name:
+## On the wire
 
 ```http
 GET /cities/123 HTTP/1.1
@@ -93,17 +84,36 @@ Content-Type: application/xml
 <GetCityOutput><Name>Seattle</Name></GetCityOutput>
 ```
 
-Members without an HTTP binding are carried in the XML body.
+A modeled error is selected from the `Code` element. NSmithy accepts both a
+direct `Error` body and the common `ErrorResponse > Error` envelope.
 
-## Usage
+## Dependencies
 
-The XML codec is wired up automatically by the generated client, which is used
-exactly like every other NSmithy client — see the [Protocols
-Overview](/smithy-dotnet/protocols/overview/). Only the `@restXml` trait and the
-XML wire format are specific to this protocol. NSmithy does not generate restXml
-servers.
+Add the AWS trait package to `smithy-build.json`:
 
-Explicit SigV4 signing exists in early preview; see
-[Authentication](/smithy-dotnet/guides/client-configuration/authentication/). For production calls to
-AWS XML services such as S3, prefer the official AWS SDK for .NET until NSmithy's
-AWS auth, endpoint resolution, retries, and pagination support mature.
+```json
+"software.amazon.smithy:smithy-aws-traits:1.73.0"
+```
+
+The client uses `NSmithy.Client`, `NSmithy.Codecs.Xml`, and
+`NSmithy.Protocols.RestXml`.
+
+## Calling AWS
+
+AWS endpoints normally require SigV4, regional endpoint resolution, and
+credentials. See
+[Authentication](/smithy-dotnet/guides/client-configuration/authentication/)
+for the NSmithy setup and [AWS Protocols](../aws-overview/) for current runtime
+gaps.
+
+## Example
+
+The [AWS LocalStack
+example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/aws-localstack)
+uses a restXml client to call S3 `ListBuckets`. NSmithy does not implement
+restXml streaming yet, so there is no streaming example.
+
+## Specification and tests
+
+- [AWS restXml specification](https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html)
+- [Official restXml protocol tests](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/restXml)

--- a/website/src/content/docs/protocols/rpc-v2-cbor.md
+++ b/website/src/content/docs/protocols/rpc-v2-cbor.md
@@ -1,32 +1,34 @@
 ---
 title: RPC v2 CBOR
-description: smithy.protocols#rpcv2Cbor — binary CBOR encoding over HTTP. Client and server support.
+description: Binary CBOR RPC over HTTP using smithy.protocols#rpcv2Cbor, with unary and streaming client and server support.
 ---
 
-`smithy.protocols#rpcv2Cbor` is Smithy's binary protocol. Messages are encoded
-as [CBOR](https://cbor.io/) and carried over HTTP POST requests on a fixed
-path derived from the service and operation names. Status: **Preview**.
+`smithy.protocols#rpcv2Cbor` is a compact binary RPC protocol defined by Smithy.
+NSmithy generates typed clients and ASP.NET Core servers for unary and event
+stream operations.
 
-See [Protocol Status](/smithy-dotnet/protocols/status/) for current conformance
-numbers.
+Use it when you control both peers and want smaller binary messages without
+adding protobuf field numbers to the model. Use [REST JSON](../rest-json/) when
+HTTP resources, routes, and broad REST tooling are more important.
 
-## Maven Dependency
+See [Protocol Status](../status/) for maturity and current conformance numbers.
 
-No extra Maven dependency beyond the codegen plugin — `smithy.protocols` shapes
-are bundled with the Smithy CLI.
+## Protocol behavior
 
-## NuGet Packages
-
-| Purpose | Packages |
+| Area | rpcv2Cbor |
 | --- | --- |
-| Client | `NSmithy.Client`, `NSmithy.Codecs.Cbor`, `NSmithy.Protocols.RpcV2Cbor` |
-| Server (ASP.NET Core) | `NSmithy.Server.AspNetCore`, `NSmithy.Codecs.Cbor`, `NSmithy.Protocols.RpcV2Cbor` |
+| Route | `POST /service/{Service}/operation/{Operation}` |
+| Body | Binary CBOR |
+| Content type | `application/cbor` |
+| Operation header | `Smithy-Protocol: rpc-v2-cbor` |
+| Errors | Modeled type in the CBOR `__type` member |
+| Streaming | Input, output, and duplex event streams |
+| HTTP bindings | Not used |
 
 ## Modeling
 
-Apply `@rpcv2Cbor` to the service. Operations do not carry `@http` traits —
-the protocol maps each operation to a fixed
-`POST /service/{Service}/operation/{Operation}` path automatically:
+Apply `@rpcv2Cbor` to the service. The protocol derives routes automatically,
+so operations do not use `@http`:
 
 ```smithy
 $version: "2"
@@ -60,11 +62,13 @@ structure NoSuchResource {
 }
 ```
 
-## On the Wire
+No additional Maven dependency is needed. The `smithy.protocols` shapes are
+bundled with the Smithy CLI.
 
-rpcv2Cbor is RPC-style over a fixed path with a CBOR body. The bodies below are
-shown in CBOR diagnostic notation; on the wire they are binary CBOR (structures
-are encoded as indefinite-length maps):
+## On the wire
+
+Every operation is a POST to a path derived from the service and operation
+names:
 
 ```http
 POST /service/Weather/operation/GetCity HTTP/1.1
@@ -73,27 +77,41 @@ Smithy-Protocol: rpc-v2-cbor
 Content-Type: application/cbor
 Accept: application/cbor
 
-{"cityId": "123"}      # CBOR, diagnostic notation
+<CBOR {"cityId": "123"}>
 
 HTTP/1.1 200 OK
 Smithy-Protocol: rpc-v2-cbor
 Content-Type: application/cbor
 
-{"name": "Seattle"}    # CBOR, diagnostic notation
+<CBOR {"name": "Seattle"}>
 ```
 
-The path is always `/service/{Service}/operation/{Operation}` — operations carry
-no `@http` traits. Errors carry a `__type` discriminator in the CBOR body.
+The notation above describes the decoded values. The actual body contains CBOR
+bytes.
 
-## Usage
+## Streaming
 
-The generated handler and client are identical to every other protocol — see the
-[Protocols Overview](/smithy-dotnet/protocols/overview/) for the canonical
-example. The CBOR codec is wired up automatically; the only thing specific to
-this protocol is the `@rpcv2Cbor` trait and the binary wire format on the fixed
-operation path.
+A streaming operation places an `@streaming` union in its input, output, or
+both. Generated shapes expose the stream as `IAsyncEnumerable<TEvent>`.
 
-## Example
+rpcv2Cbor carries event messages in a framed stream and encodes modeled event
+payloads as CBOR. NSmithy supports server streaming, client streaming, and
+bidirectional streaming. Initial non-streaming members stay on the modeled input
+or output around the event stream.
 
-A complete working server+client example is available in
-[`examples/rpcv2cbor`](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/rpcv2cbor).
+## Packages
+
+| Surface | Packages |
+| --- | --- |
+| Client | `NSmithy.Client`, `NSmithy.Codecs.Cbor`, `NSmithy.Protocols.RpcV2Cbor` |
+| Server | `NSmithy.Server.AspNetCore`, `NSmithy.Codecs.Cbor`, `NSmithy.Protocols.RpcV2Cbor` |
+
+## Examples
+
+- [Unary rpcv2Cbor weather service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/rpcv2cbor)
+- [Streaming rpcv2Cbor chat service](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/rpcv2cbor-streaming)
+
+## Specification and tests
+
+- [Smithy RPC v2 CBOR specification](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html)
+- [Official rpcv2Cbor protocol tests](https://github.com/smithy-lang/smithy/tree/main/smithy-protocol-tests/model/rpcv2Cbor)

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -20,6 +20,8 @@ server is never counted toward client coverage and vice versa.
 | `aws.protocols#restJson1` | both | Preview | 246/250 (98.4%) | 209/228 (91.7%) |
 | `aws.protocols#awsJson1_1` | client | Early preview | requests 6/57 (10.5%), responses 18/61 (29.5%) | — |
 | `aws.protocols#awsJson1_0` | client | Early preview | runtime support; no conformance project yet | — |
+| `aws.protocols#awsQuery` | client | Preview | requests 38/38 (100%), responses 39/39 (100%) | — |
+| `aws.protocols#ec2Query` | client | Preview | requests 30/30 (100%), responses 29/29 (100%) | — |
 | `aws.protocols#restXml` | client | Early preview | requests 4/113 (3.5%), responses 39/86 (45.3%) | — |
 | `smithy.protocols#rpcv2Cbor` | both | Preview | 61/68 (89.7%) | 57/60 (95.0%) |
 | `alloy.proto#grpc` | both | Experimental | tested via examples¹ | tested via examples¹ |
@@ -57,6 +59,9 @@ Notes:
 - AWS restXml is client-only and now runs a verified slice of the official AWS
   protocol tests, mostly response deserialization plus a small request-binding
   subset.
+- AWS Query and EC2 Query are client-only and run every applicable official
+  request and response case, including collection flattening, XML wrappers,
+  custom error codes, endpoint paths, and request compression.
 - `smithy.protocols#rpcv2Cbor`, `alloy#simpleRestJson`, and `aws.protocols#restJson1`
   all exercise both the client and the generated server against their applicable
   cases. `alloy#simpleRestJson` is the only one currently at 100% on both
@@ -72,8 +77,9 @@ Notes:
   capabilities simpleRestJson lacks such as event streaming.
 - Use `smithy.protocols#rpcv2Cbor` for binary CBOR-encoded services; client and
   server generation are both available.
-- Use AWS JSON or AWS restXml when you want to evaluate AWS-compatible client
-  generation and are comfortable with a smaller preview slice.
+- Use AWS Query or EC2 Query for generated AWS-compatible clients with complete
+  official client conformance coverage. AWS JSON and AWS restXml still have a
+  smaller verified preview slice.
 - Treat `alloy.proto#grpc` as experimental: it has the smallest test surface and
   the most explicit model requirements (see the footnote above).
 
@@ -86,9 +92,3 @@ In practice, earlier-stage protocols may still have one or more of these traits:
 - less conformance-suite coverage
 - more implementation details that are still expected to move
 - more explicit project wiring or modeling constraints
-
-## Not Supported Yet
-
-These protocols are not current NSmithy targets:
-
-- EC2 Query and AWS Query

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -1,94 +1,83 @@
 ---
 title: Protocol Status
-description: Where protocol support stands in the current NSmithy preview.
+description: Maturity and official conformance coverage for every NSmithy protocol.
 ---
 
-NSmithy is still preview-stage. "Supported" here means there is working
-generator and runtime support for a usable slice, not that the protocol is
-complete or fully conformant across the Smithy surface.
+This page is the source of truth for protocol maturity and conformance. The
+individual protocol pages describe behavior without repeating status labels or
+test totals.
 
-## Current Status
+## Current status
 
-Conformance is reported separately for the generated **client** and **server**,
-each counted against the official cases that actually apply to that direction
-(`appliesTo`) in the pinned protocol-test models. A case that only applies to a
-server is never counted toward client coverage and vice versa.
-
-| Protocol | Surfaces | Stage | Client | Server |
+| Protocol | Surfaces | Stage | Client conformance | Server conformance |
 | --- | --- | --- | --- | --- |
-| `alloy#simpleRestJson` | both | Preview | 43/43 (100%) | 43/43 (100%) |
-| `aws.protocols#restJson1` | both | Preview | 246/250 (98.4%) | 209/228 (91.7%) |
-| `aws.protocols#awsJson1_1` | client | Early preview | requests 6/57 (10.5%), responses 18/61 (29.5%) | — |
-| `aws.protocols#awsJson1_0` | client | Early preview | runtime support; no conformance project yet | — |
-| `aws.protocols#awsQuery` | client | Preview | requests 38/38 (100%), responses 39/39 (100%) | — |
-| `aws.protocols#ec2Query` | client | Preview | requests 30/30 (100%), responses 29/29 (100%) | — |
-| `aws.protocols#restXml` | client | Early preview | requests 4/113 (3.5%), responses 39/86 (45.3%) | — |
-| `smithy.protocols#rpcv2Cbor` | both | Preview | 61/68 (89.7%) | 57/60 (95.0%) |
-| `alloy.proto#grpc` | both | Experimental | tested via examples¹ | tested via examples¹ |
+| [`aws.protocols#restJson1`](../rest-json/) | Client and server | Preview | Requests 137/142 (96.5%), responses 106/108 (98.1%) | Requests 118/134 (88.1%), responses 92/92 (100%), malformed 655/655 (100%) |
+| [`aws.protocols#awsJson1_1`](../aws-json/) | Client | Early preview | Requests 6/57 (10.5%), responses 18/62 (29.0%) | N/A |
+| [`aws.protocols#awsJson1_0`](../aws-json/) | Client | Early preview | Runtime support, no conformance project | N/A |
+| [`aws.protocols#awsQuery`](../aws-query/) | Client | Preview | Requests 38/38 (100%), responses 39/39 (100%) | N/A |
+| [`aws.protocols#ec2Query`](../aws-ec2-query/) | Client | Preview | Requests 30/30 (100%), responses 29/29 (100%) | N/A |
+| [`aws.protocols#restXml`](../rest-xml/) | Client | Early preview | Requests 4/113 (3.5%), responses 39/86 (45.3%) | N/A |
+| [`smithy.protocols#rpcv2Cbor`](../rpc-v2-cbor/) | Client and server | Preview | Requests 27/29 (93.1%), responses 34/43 (79.1%) | Requests 32/37 (86.5%), responses 25/27 (92.6%) |
+| [`alloy#simpleRestJson`](../rest-json/) | Client and server | Preview | Requests 23/23 (100%), responses 20/20 (100%) | Requests 23/23 (100%), responses 20/20 (100%) |
+| [`alloy.proto#grpc`](../grpc/) | Client and server | Experimental | End-to-end examples | End-to-end examples |
 
-¹ `alloy.proto#grpc` is not covered by Smithy's HTTP conformance suite; it is
-validated through end-to-end examples instead, and has the least maturity, the
-smallest test surface, and more explicit model requirements such as
-`alloy.proto#protoIndex`.
+## How the numbers are counted
 
-Notes:
+Each fraction is:
 
-- `alloy#simpleRestJson`'s protocol tests all declare `appliesTo: both`; both the
-  client and the generated ASP.NET Core server now run every applicable case.
-- AWS restJson1 exercises both surfaces against nearly every applicable case.
-  The handful of unmet cases are curated out of the client allowlist; on the
-  server, cases whose operation has no generated handler (auxiliary services like
-  Glacier that ship fixtures but aren't part of the `RestJson` service) are out
-  of scope rather than counted as failures.
-- These figures dropped in several places against the previous release, and none
-  of it is a regression. The suites previously compared a response's status,
-  headers and parse success but never the deserialized values, because the
-  assertion matched fixture keys against generated constructor parameter names and
-  silently skipped every member. With that repaired, 30 cases across the protocols
-  now fail honestly rather than passing vacuously. They are listed in each
-  project's `KnownParamGaps` and subtracted from the counts above, and cluster in
-  query-string binding, streaming blobs, content encoding and float special
-  values.
-- restJson1's server additionally runs all 655 of Smithy's
-  `httpMalformedRequestTests` cases, which assert what a server owes for a request
-  it cannot accept. See [Validation](/smithy-dotnet/servers/validation/).
-- AWS JSON support is client-only. The current conformance project targets
-  `aws.protocols#awsJson1_1`; the runtime also exposes `AwsJson10Protocol` for
-  `aws.protocols#awsJson1_0`, but there is not yet a separate `awsJson1_0`
-  conformance project.
-- AWS restXml is client-only and now runs a verified slice of the official AWS
-  protocol tests, mostly response deserialization plus a small request-binding
-  subset.
-- AWS Query and EC2 Query are client-only and run every applicable official
-  request and response case, including collection flattening, XML wrappers,
-  custom error codes, endpoint paths, and request compression.
-- `smithy.protocols#rpcv2Cbor`, `alloy#simpleRestJson`, and `aws.protocols#restJson1`
-  all exercise both the client and the generated server against their applicable
-  cases. `alloy#simpleRestJson` is the only one currently at 100% on both
+```text
+passing executable official cases / official cases applicable to that surface
+```
+
+Client and server totals are separate because Smithy test cases declare an
+`appliesTo` direction. A server-only case does not enter the client denominator,
+and a client-only case does not enter the server denominator.
+
+Cases listed in a conformance project's known-gap set remain in the denominator
+but not the numerator. Local regression fixtures run in the suites but do not
+count as official conformance.
+
+## Coverage notes
+
+- restJson1 client response coverage includes all official modeled-error cases.
+  The client passes 13/14 applicable error cases, and the server passes 3/3. The
+  remaining client case uses an `X-Amzn-Errortype` URI with a different
+  namespace.
+- The restJson1 server passes all 655 applicable
+  `httpMalformedRequestTests`. These cases verify structured responses for
+  requests that cannot be deserialized or validated.
+- Auxiliary fixture services without a generated handler are excluded from the
+  restJson1 server denominator. Local response regression cases are also
+  excluded from the official totals.
+- simpleRestJson passes every case in Alloy's protocol suite on both generated
   surfaces.
+- AWS Query and EC2 Query pass every applicable official client request and
+  response case.
+- The AWS JSON conformance project currently targets `awsJson1_1`.
+  `AwsJson10Protocol` has runtime support but no separate project.
+- gRPC is not part of Smithy's HTTP protocol test suite. Its codec and transport
+  tests cover complex messages, numeric encodings, collections, oneofs,
+  documents, errors, trailers, and all three streaming modes. Grpc.Net
+  interoperability is demonstrated by runnable examples but is not yet an
+  automated cross-implementation test matrix.
 
-## Recommended Use
+See [Validation](/smithy-dotnet/servers/validation/) for malformed request
+behavior.
 
-- Use simpleRestJson when your consumers are primarily .NET or Scala
-  (via [Smithy4s](https://disneystreaming.github.io/smithy4s/)).
-- Use AWS restJson1 when you need generated AWS-style REST/JSON clients or
-  ASP.NET Core server surfaces, broad cross-ecosystem compatibility (most
-  official Smithy generators target it), OpenAPI/Scalar generation, or
-  capabilities simpleRestJson lacks such as event streaming.
-- Use `smithy.protocols#rpcv2Cbor` for binary CBOR-encoded services; client and
-  server generation are both available.
-- Use AWS Query or EC2 Query for generated AWS-compatible clients with complete
-  official client conformance coverage. AWS JSON and AWS restXml still have a
-  smaller verified preview slice.
-- Treat `alloy.proto#grpc` as experimental: it has the smallest test surface and
-  the most explicit model requirements (see the footnote above).
+## Maturity labels
 
-## What "Early Stage" Means Here
+- **Preview:** useful end-to-end support with meaningful conformance coverage.
+  Some protocol features or convenience APIs are still incomplete.
+- **Early preview:** a narrower verified slice. Check the conformance totals and
+  known limitations before adopting it.
+- **Experimental:** the API and supported model surface can still change.
 
-In practice, earlier-stage protocols may still have one or more of these traits:
+## Reproducing the report
 
-- narrower protocol binding coverage
-- fewer end-to-end examples
-- less conformance-suite coverage
-- more implementation details that are still expected to move
-- more explicit project wiring or modeling constraints
+Each conformance project has a
+`ConformanceRateTests.ReportConformanceRate` test. Run it after `just codegen`
+and copy the emitted totals to this page.
+
+The fixtures come from the pinned Smithy and Alloy protocol-test model JARs.
+The upstream restJson1 sources are in the [Smithy
+repository](https://github.com/smithy-lang/smithy/tree/main/smithy-aws-protocol-tests/model/restJson1).

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -22,12 +22,10 @@ official Smithy / AWS protocol tests (`tests/Conformance`):
   design; early conformance coverage for `awsJson1_1`.
 - **AWS restXml (`aws.protocols#restXml`)** — client only by design (see the server note
   below); narrower coverage than the JSON paths.
+- **AWS Query (`aws.protocols#awsQuery`) / EC2 Query (`aws.protocols#ec2Query`)** —
+  client only by design; all applicable official client conformance cases pass.
 - **`alloy.proto#grpc`** — native client and server (see below); the least
   mature path.
-
-Not yet implemented (planned as **clients** — servers are not, see below):
-
-- EC2 Query and AWS Query
 
 ## Streaming Support Is Narrow
 
@@ -38,7 +36,7 @@ server streaming, client streaming, and bidirectional streaming as
 
 Streaming is still limited:
 
-- Event streaming is implemented for native gRPC only.
+- Event streaming is implemented for native gRPC and `rpcv2Cbor`.
 - Streaming payload blobs are not implemented; blob payloads are still buffered
   as `byte[]`.
 - Other protocols still use unary request/response operation surfaces.
@@ -63,8 +61,8 @@ implement a service in: `alloy#simpleRestJson`, `aws.protocols#restJson1`,
 
 The AWS-facing protocols — `aws.protocols#restXml`, AWS JSON, and AWS / EC2
 Query — are **client-only by design**. NSmithy generates clients for the
-implemented protocols to call AWS-compatible services; servers for those
-protocols are not planned.
+protocols to call AWS-compatible services; servers for those protocols are not
+planned.
 
 Other constraints:
 

--- a/website/src/content/docs/servers/index.md
+++ b/website/src/content/docs/servers/index.md
@@ -136,7 +136,7 @@ response format, and what is not covered yet.
 ## Which protocols generate a server
 
 Server generation exists for `simpleRestJson`, `restJson1`, `rpcv2Cbor`, and
-`gRPC`. `awsJson1_1`/`awsJson1_0` and `restXml` are **client-only** today. See
+`gRPC`. AWS JSON, AWS Query, EC2 Query, and restXml are **client-only** today. See
 [Protocol Status](/smithy-dotnet/protocols/status/) for the current matrix.
 
 gRPC needs HTTP/2 transport and its own listener — see


### PR DESCRIPTION
## Summary

- add client-side AWS Query and EC2 Query protocols with complete applicable official conformance coverage
- add regional endpoints, default environment/profile/SSO/IMDS credentials, SigV4 presigning, and published AWS signing vectors
- expand the generated LocalStack example across AWS JSON, restJson1, restXml, AWS Query, and EC2 Query
- fix XML map key/value name handling and refresh AWS protocol, authentication, limitations, and roadmap docs

This makes substantial progress on #113 without closing it. Modeled service endpoint rule sets, additional credential sources, SigV4a, and further preview-protocol hardening remain follow-up work.

## Verification

- just fmt
- just check-format
- just build
- just test
- just pack
- just refresh-examples
- just smoke-templates
- live LocalStack run covering all five modeled protocol families