### PR TITLE
feat: reach full restJson1 conformance

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -38,6 +38,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class ClientGenerator implements Runnable {
 
+  private static final ShapeId GLACIER_SERVICE = ShapeId.from("com.amazonaws.glacier#Glacier");
+
   private final GenerationContext context;
   private final CSharpWriter writer;
   private final ServiceShape service;
@@ -363,7 +365,15 @@ public final class ClientGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write("public $LConfig() { }", typeName);
+          if (service.getId().equals(GLACIER_SERVICE)) {
+            writer.write("public $LConfig()", typeName);
+            writer.openBlock(
+                "{",
+                "}",
+                () -> writer.write("Interceptors.Add(new NSmithy.Aws.GlacierInterceptor());"));
+          } else {
+            writer.write("public $LConfig() { }", typeName);
+          }
           writer.write("");
           writer.write("public $LConfig($LConfig source) : base(source) { }", typeName, typeName);
         });

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -230,6 +230,35 @@ final class ClientGeneratorTest {
       }
       """;
 
+  private static final String GLACIER_MODEL =
+      """
+      $version: "2"
+
+      namespace com.amazonaws.glacier
+
+      use aws.protocols#restJson1
+
+      @restJson1
+      service Glacier {
+          version: "2012-06-01"
+          operations: [UploadArchive]
+      }
+
+      @http(method: "POST", uri: "/{accountId}/vaults/{vaultName}/archives")
+      operation UploadArchive {
+          input := {
+              @required
+              @httpLabel
+              accountId: String
+
+              @required
+              @httpLabel
+              vaultName: String
+          }
+          output := {}
+      }
+      """;
+
   private static final String REST_STREAMING_MODEL =
       """
       $version: "2"
@@ -574,6 +603,19 @@ final class ClientGeneratorTest {
             "public StreamingServiceClientConfig(StreamingServiceClientConfig source) :"
                 + " base(source) { }"),
         generated);
+  }
+
+  @Test
+  void glacierClientConfigInstallsServiceCustomization() throws Exception {
+    String generated =
+        renderClient(
+            REST_PROTOCOL_TRAITS,
+            GLACIER_MODEL,
+            "com.amazonaws.glacier#Glacier",
+            "Auxiliary.Com.Amazonaws.Glacier");
+
+    assertTrue(
+        generated.contains("Interceptors.Add(new NSmithy.Aws.GlacierInterceptor());"), generated);
   }
 
   private String renderClient() throws Exception {

--- a/packages/NSmithy.Aws/GlacierInterceptor.cs
+++ b/packages/NSmithy.Aws/GlacierInterceptor.cs
@@ -2,14 +2,16 @@ using System.Security.Cryptography;
 using NSmithy.Client;
 using NSmithy.Http;
 
-namespace RestJson1.Conformance;
+namespace NSmithy.Aws;
 
 /// <summary>
-/// Supplies the service-specific customizations required by the Glacier protocol fixtures. These
-/// behaviors are not modeled as Smithy traits, so applications provide them through the public
-/// interceptor seam rather than baking AWS service knowledge into the RestJson1 protocol.
+/// Applies the service-specific request customizations required by Amazon Glacier.
 /// </summary>
-internal sealed class GlacierConformanceInterceptor : IClientInterceptor
+/// <remarks>
+/// Glacier's version header, default account identifier, and upload checksums are SDK behaviors
+/// that are not represented by traits in the service model.
+/// </remarks>
+public sealed class GlacierInterceptor : IClientInterceptor
 {
     private const int TreeHashChunkSize = 1024 * 1024;
 
@@ -22,8 +24,7 @@ internal sealed class GlacierConformanceInterceptor : IClientInterceptor
         request.Headers["X-Amz-Glacier-Version"] = ["2012-06-01"];
 
         var operation = context.Get(SmithyContextKeys.OperationName);
-        if (operation == "UploadArchive")
-            NormalizeEmptyAccountId(request);
+        NormalizeEmptyAccountId(request);
 
         if (operation is "UploadArchive" or "UploadMultipartPart")
         {
@@ -71,7 +72,10 @@ internal sealed class GlacierConformanceInterceptor : IClientInterceptor
 
     private static void NormalizeEmptyAccountId(SmithyHttpRequest request)
     {
-        if (Uri.TryCreate(request.RequestUri, UriKind.Absolute, out var absolute))
+        if (
+            Uri.TryCreate(request.RequestUri, UriKind.Absolute, out var absolute)
+            && absolute.Scheme is "http" or "https"
+        )
         {
             var path = absolute.AbsolutePath;
             if (path.StartsWith("/vaults/", StringComparison.Ordinal))

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -171,7 +171,10 @@ public static class RestProtocol
                 throw new MissingRequiredMemberException(member.Name);
         }
         if (binding.QueryParamsMember is { } qpMember)
-            qpMember.SetObject(builder, ReadQueryParams(qpMember, query, binding.BoundQueryNames));
+            // On clients, explicitly bound @httpQuery members take precedence over entries in an
+            // @httpQueryParams map. On servers the map represents the request as received and must
+            // include every query parameter, including names that are also explicitly bound.
+            qpMember.SetObject(builder, ReadQueryParams(qpMember, query));
         if (binding.InputPayloadReader is { } readPayload)
             readPayload(BodyBytesOrNull(request.Body), BodyStreamOrNull(request.Body), builder);
         else if (
@@ -1281,6 +1284,7 @@ public static class RestProtocol
         {
             if (
                 !header.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                || (prefix.Length == 0 && IsTransportManagedHeader(header.Key))
                 || header.Value.Count == 0
             )
             {
@@ -1299,15 +1303,14 @@ public static class RestProtocol
 
     private static object ReadQueryParams(
         IStructMemberSchema member,
-        Dictionary<string, IReadOnlyList<string>> query,
-        HashSet<string> excludedNames
+        Dictionary<string, IReadOnlyList<string>> query
     )
     {
         var mapSchema = RequireMap(member);
         var builder = mapSchema.CreateBuilder();
         foreach (var entry in query)
         {
-            if (entry.Value.Count == 0 || excludedNames.Contains(entry.Key))
+            if (entry.Value.Count == 0)
             {
                 continue;
             }
@@ -1321,6 +1324,10 @@ public static class RestProtocol
 
         return mapSchema.BuildObject(builder);
     }
+
+    private static bool IsTransportManagedHeader(string name) =>
+        name.Equals("Host", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase);
 
     private static string AppendQuery<TInput>(
         string requestUri,

--- a/tests/Conformance/RestJson1/Conformance/GlacierConformanceInterceptor.cs
+++ b/tests/Conformance/RestJson1/Conformance/GlacierConformanceInterceptor.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using NSmithy.Client;
+using NSmithy.Http;
+
+namespace RestJson1.Conformance;
+
+/// <summary>
+/// Supplies the service-specific customizations required by the Glacier protocol fixtures. These
+/// behaviors are not modeled as Smithy traits, so applications provide them through the public
+/// interceptor seam rather than baking AWS service knowledge into the RestJson1 protocol.
+/// </summary>
+internal sealed class GlacierConformanceInterceptor : IClientInterceptor
+{
+    private const int TreeHashChunkSize = 1024 * 1024;
+
+    public async ValueTask<SmithyHttpRequest> OnBeforeSigningAsync(
+        SmithyContext context,
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        request.Headers["X-Amz-Glacier-Version"] = ["2012-06-01"];
+
+        var operation = context.Get(SmithyContextKeys.OperationName);
+        if (operation == "UploadArchive")
+            NormalizeEmptyAccountId(request);
+
+        if (operation is "UploadArchive" or "UploadMultipartPart")
+        {
+            var body = await BufferBodyAsync(request, cancellationToken).ConfigureAwait(false);
+            if (body.Length > 0)
+            {
+                request.Headers.TryAdd("X-Amz-Content-Sha256", [ToLowerHex(SHA256.HashData(body))]);
+                request.Headers.TryAdd("X-Amz-Sha256-Tree-Hash", [ComputeTreeHash(body)]);
+            }
+        }
+
+        return request;
+    }
+
+    private static async Task<byte[]> BufferBodyAsync(
+        SmithyHttpRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        switch (request.Body)
+        {
+            case SmithyHttpBody.Bytes bytes:
+                return bytes.Content;
+            case SmithyHttpBody.Streaming streaming:
+                using (var buffered = new MemoryStream())
+                {
+                    await streaming
+                        .Content.CopyToAsync(buffered, cancellationToken)
+                        .ConfigureAwait(false);
+                    var content = buffered.ToArray();
+                    request.Body = new SmithyHttpBody.Streaming(
+                        new MemoryStream(content, writable: false),
+                        content.Length
+                    );
+                    return content;
+                }
+            default:
+                if (ReferenceEquals(request.Body, SmithyHttpBody.Empty))
+                    return [];
+                throw new NotSupportedException(
+                    "Glacier checksum customization does not support event-stream bodies."
+                );
+        }
+    }
+
+    private static void NormalizeEmptyAccountId(SmithyHttpRequest request)
+    {
+        if (Uri.TryCreate(request.RequestUri, UriKind.Absolute, out var absolute))
+        {
+            var path = absolute.AbsolutePath;
+            if (path.StartsWith("/vaults/", StringComparison.Ordinal))
+            {
+                var builder = new UriBuilder(absolute) { Path = "/-" + path };
+                request.RequestUri = builder.Uri.AbsoluteUri;
+            }
+            else if (path.StartsWith("//vaults/", StringComparison.Ordinal))
+            {
+                var builder = new UriBuilder(absolute) { Path = "/-" + path[1..] };
+                request.RequestUri = builder.Uri.AbsoluteUri;
+            }
+            return;
+        }
+
+        if (request.RequestUri.StartsWith("/vaults/", StringComparison.Ordinal))
+            request.RequestUri = "/-" + request.RequestUri;
+        else if (request.RequestUri.StartsWith("//vaults/", StringComparison.Ordinal))
+            request.RequestUri = "/-" + request.RequestUri[1..];
+    }
+
+    private static string ComputeTreeHash(byte[] content)
+    {
+        var hashes = new List<byte[]>();
+        for (var offset = 0; offset < content.Length; offset += TreeHashChunkSize)
+        {
+            var length = Math.Min(TreeHashChunkSize, content.Length - offset);
+            hashes.Add(SHA256.HashData(content.AsSpan(offset, length)));
+        }
+
+        while (hashes.Count > 1)
+        {
+            var next = new List<byte[]>((hashes.Count + 1) / 2);
+            for (var i = 0; i < hashes.Count; i += 2)
+            {
+                if (i + 1 == hashes.Count)
+                {
+                    next.Add(hashes[i]);
+                    continue;
+                }
+
+                var pair = new byte[hashes[i].Length + hashes[i + 1].Length];
+                hashes[i].CopyTo(pair, 0);
+                hashes[i + 1].CopyTo(pair, hashes[i].Length);
+                next.Add(SHA256.HashData(pair));
+            }
+            hashes = next;
+        }
+
+        return ToLowerHex(hashes[0]);
+    }
+
+    private static string ToLowerHex(byte[] hash) => Convert.ToHexString(hash).ToLowerInvariant();
+}

--- a/tests/Conformance/RestJson1/Conformance/HttpResponseRunner.cs
+++ b/tests/Conformance/RestJson1/Conformance/HttpResponseRunner.cs
@@ -278,13 +278,7 @@ internal static class ConformanceClients
         // live on the per-client {Service}ClientConfig; build one reflectively only when needed.
         httpClient.BaseAddress = endpoint;
         object? config = null;
-        if (
-            idempotencyTokenProvider is not null
-            || clientType.FullName?.StartsWith(
-                "Auxiliary.Com.Amazonaws.Glacier.",
-                StringComparison.Ordinal
-            ) == true
-        )
+        if (idempotencyTokenProvider is not null)
         {
             var configType =
                 clientType.Assembly.GetType(clientType.FullName + "Config")
@@ -292,21 +286,9 @@ internal static class ConformanceClients
                     $"Config type {clientType.FullName}Config not found."
                 );
             config = Activator.CreateInstance(configType)!;
-            if (idempotencyTokenProvider is not null)
-            {
-                configType
-                    .GetProperty("IdempotencyTokenProvider")!
-                    .SetValue(config, idempotencyTokenProvider);
-            }
-            if (
-                clientType.FullName?.StartsWith(
-                    "Auxiliary.Com.Amazonaws.Glacier.",
-                    StringComparison.Ordinal
-                ) == true
-            )
-            {
-                ((SmithyClientConfig)config).Interceptors.Add(new GlacierConformanceInterceptor());
-            }
+            configType
+                .GetProperty("IdempotencyTokenProvider")!
+                .SetValue(config, idempotencyTokenProvider);
         }
         return Activator.CreateInstance(clientType, [httpClient, config])!;
     }

--- a/tests/Conformance/RestJson1/Conformance/HttpResponseRunner.cs
+++ b/tests/Conformance/RestJson1/Conformance/HttpResponseRunner.cs
@@ -278,7 +278,13 @@ internal static class ConformanceClients
         // live on the per-client {Service}ClientConfig; build one reflectively only when needed.
         httpClient.BaseAddress = endpoint;
         object? config = null;
-        if (idempotencyTokenProvider is not null)
+        if (
+            idempotencyTokenProvider is not null
+            || clientType.FullName?.StartsWith(
+                "Auxiliary.Com.Amazonaws.Glacier.",
+                StringComparison.Ordinal
+            ) == true
+        )
         {
             var configType =
                 clientType.Assembly.GetType(clientType.FullName + "Config")
@@ -286,9 +292,21 @@ internal static class ConformanceClients
                     $"Config type {clientType.FullName}Config not found."
                 );
             config = Activator.CreateInstance(configType)!;
-            configType
-                .GetProperty("IdempotencyTokenProvider")!
-                .SetValue(config, idempotencyTokenProvider);
+            if (idempotencyTokenProvider is not null)
+            {
+                configType
+                    .GetProperty("IdempotencyTokenProvider")!
+                    .SetValue(config, idempotencyTokenProvider);
+            }
+            if (
+                clientType.FullName?.StartsWith(
+                    "Auxiliary.Com.Amazonaws.Glacier.",
+                    StringComparison.Ordinal
+                ) == true
+            )
+            {
+                ((SmithyClientConfig)config).Interceptors.Add(new GlacierConformanceInterceptor());
+            }
         }
         return Activator.CreateInstance(clientType, [httpClient, config])!;
     }
@@ -309,7 +327,9 @@ internal static class ConformanceClients
 /// </summary>
 internal static class ResponseAssertions
 {
-    private static ShapeKind? GetSchemaKind(Type type)
+    private static readonly ShapeId HttpPayloadTraitId = ShapeId.Parse("smithy.api#httpPayload");
+
+    private static Schema? GetSchema(Type type)
     {
         // The functional schema lives on the generated companion `{Type}Schema` class.
         var schemaType = type.Assembly.GetType(type.FullName + "Schema");
@@ -317,8 +337,10 @@ internal static class ResponseAssertions
             "Schema",
             BindingFlags.Public | BindingFlags.Static
         );
-        return (schemaProp?.GetValue(null) as Schema)?.Kind;
+        return schemaProp?.GetValue(null) as Schema;
     }
+
+    private static ShapeKind? GetSchemaKind(Type type) => GetSchema(type)?.Kind;
 
     public static void AssertEquivalent(JsonNode? expected, object actual, string ownerLabel)
     {
@@ -330,7 +352,33 @@ internal static class ResponseAssertions
         AssertEqual(expected, actual, ownerLabel);
     }
 
-    private static void AssertEqual(JsonNode? expected, object? actual, string path)
+    public static async Task AssertEquivalentAsync(
+        JsonNode? expected,
+        object actual,
+        string ownerLabel
+    )
+    {
+        if (expected is null)
+            return;
+
+        if (
+            expected is JsonObject expectedObject
+            && GetSchemaKind(actual.GetType()) == ShapeKind.Structure
+        )
+        {
+            await AssertStructureAsync(expectedObject, actual, ownerLabel).ConfigureAwait(false);
+            return;
+        }
+
+        AssertEqual(expected, actual, ownerLabel);
+    }
+
+    private static void AssertEqual(
+        JsonNode? expected,
+        object? actual,
+        string path,
+        bool rawBlob = false
+    )
     {
         if (expected is null)
         {
@@ -446,7 +494,11 @@ internal static class ResponseAssertions
         {
             var base64 = (string?)expected;
             byte[] expectedBytes;
-            if (string.IsNullOrEmpty(base64))
+            if (rawBlob)
+            {
+                expectedBytes = System.Text.Encoding.UTF8.GetBytes(base64 ?? string.Empty);
+            }
+            else if (string.IsNullOrEmpty(base64))
             {
                 expectedBytes = [];
             }
@@ -509,6 +561,7 @@ internal static class ResponseAssertions
     private static void AssertStructure(JsonObject expected, object actual, string path)
     {
         var type = actual.GetType();
+        var schema = GetSchema(type) as IStructSchema;
         var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
             .OrderByDescending(c => c.GetParameters().Length)
             .First();
@@ -541,7 +594,46 @@ internal static class ResponseAssertions
                 continue;
             }
 
-            AssertEqual(expected[memberName], actualValue, $"{path}.{memberName}");
+            var rawBlob =
+                schema?.GetMember(memberName)?.MemberTraits.ContainsKey(HttpPayloadTraitId) == true;
+            AssertEqual(expected[memberName], actualValue, $"{path}.{memberName}", rawBlob);
+        }
+    }
+
+    private static async Task AssertStructureAsync(JsonObject expected, object actual, string path)
+    {
+        var type = actual.GetType();
+        var schema = GetSchema(type) as IStructSchema;
+        var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .First();
+        foreach (var p in ctor.GetParameters())
+        {
+            var propName = p.Name!;
+            var prop =
+                type.GetProperty(propName, BindingFlags.Public | BindingFlags.Instance)
+                ?? type.GetProperty(
+                    char.ToUpperInvariant(propName[0]) + propName[1..],
+                    BindingFlags.Public | BindingFlags.Instance
+                )
+                ?? throw new InvalidOperationException(
+                    $"[{path}] Cannot resolve property {propName} on {type.FullName}."
+                );
+            var memberName = ResolveExpectedKey(expected, propName);
+            if (memberName is null)
+                continue;
+
+            var actualValue = prop.GetValue(actual);
+            if (actualValue is Stream stream)
+            {
+                using var drained = new MemoryStream();
+                await stream.CopyToAsync(drained).ConfigureAwait(false);
+                actualValue = drained.ToArray();
+            }
+
+            var rawBlob =
+                schema?.GetMember(memberName)?.MemberTraits.ContainsKey(HttpPayloadTraitId) == true;
+            AssertEqual(expected[memberName], actualValue, $"{path}.{memberName}", rawBlob);
         }
     }
 

--- a/tests/Conformance/RestJson1/Conformance/RestJson1Allowlist.cs
+++ b/tests/Conformance/RestJson1/Conformance/RestJson1Allowlist.cs
@@ -50,24 +50,7 @@ internal static class RestJson1Allowlist
     public static readonly IReadOnlySet<string> KnownServerRequestParamGaps = new HashSet<string>(
         StringComparer.Ordinal
     )
-    {
-        "RestJsonAllQueryStringTypes",
-        "RestJsonHttpEmptyPrefixHeadersRequestServer",
-        "RestJsonOmitsEmptyListQueryValues",
-        "RestJsonQueryStringEscaping",
-        "RestJsonServersPutAllQueryParamsInMap",
-        "RestJsonServersQueryParamsStringListMap",
-        "RestJsonStreamingTraitsRequireLengthWithBlob",
-        "RestJsonStreamingTraitsWithBlob",
-        "RestJsonStreamingTraitsWithMediaTypeWithBlob",
-        "RestJsonSupportsInfinityFloatQueryValues",
-        "RestJsonSupportsNaNFloatQueryValues",
-        "RestJsonSupportsNegativeInfinityFloatQueryValues",
-        "RestJsonTestPayloadBlob",
-        "RestJsonZeroAndFalseQueryValues",
-        "SDKAppendedGzipAfterProvidedEncoding_restJson1",
-        "SDKAppliedContentEncoding_restJson1",
-    };
+    { };
 
     public static readonly IReadOnlySet<string> ExecutableRequestCases = new HashSet<string>(
         StringComparer.Ordinal
@@ -108,6 +91,7 @@ internal static class RestJson1Allowlist
         "RestJsonSerializeMapUnionValue",
         "RestJsonSerializeStructureUnionValue",
         "RestJsonSerializeRenamedStructureUnionValue",
+        "RestJsonSerializeNestedUnionValue",
         "RestJsonInputAndOutputWithStringHeaders",
         "RestJsonInputAndOutputWithNumericHeaders",
         "RestJsonInputAndOutputWithBooleanHeaders",
@@ -212,6 +196,10 @@ internal static class RestJson1Allowlist
         "SDKAppendedGzipAfterProvidedEncoding_restJson1",
         "RestJsonRecursiveStructuresValidate",
         "ApiGatewayAccept",
+        "GlacierAccountId",
+        "GlacierChecksums",
+        "GlacierMultipartChecksums",
+        "GlacierVersionHeader",
     };
 
     public static readonly IReadOnlySet<string> ExecutableResponseCases = new HashSet<string>(
@@ -255,6 +243,7 @@ internal static class RestJson1Allowlist
         "RestJsonDeserializeMapUnionValue",
         "RestJsonDeserializeStructureUnionValue",
         "RestJsonDeserializeIgnoreType",
+        "RestJsonDeserializeNestedUnionValue",
         "RestJsonInputAndOutputWithStringHeaders",
         "RestJsonInputAndOutputWithNumericHeaders",
         "RestJsonInputAndOutputWithBooleanHeaders",
@@ -300,6 +289,7 @@ internal static class RestJson1Allowlist
         "RestJsonFooErrorUsingXAmznErrorType",
         "RestJsonFooErrorUsingXAmznErrorTypeWithUri",
         "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace",
+        "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndDifferentNamespace",
         "RestJsonFooErrorWithDunderType",
         "RestJsonFooErrorWithDunderTypeAndNamespace",
         "RestJsonFooErrorWithDunderTypeUriAndNamespace",

--- a/tests/Conformance/RestJson1/Conformance/ServerHttpRequestRunner.cs
+++ b/tests/Conformance/RestJson1/Conformance/ServerHttpRequestRunner.cs
@@ -17,7 +17,23 @@ internal static class ServerHttpRequestRunner
                 {
                     capturedMethod = method;
                     capturedInput = args?.FirstOrDefault(arg => arg is not CancellationToken);
-                    return CreateSuccessfulResult(method);
+                    return CreateSuccessfulResult(
+                        method,
+                        async () =>
+                        {
+                            if (testCase.Params is null)
+                                return;
+
+                            Assert.NotNull(capturedInput);
+                            await ResponseAssertions
+                                .AssertEquivalentAsync(
+                                    testCase.Params,
+                                    capturedInput!,
+                                    testCase.OperationName
+                                )
+                                .ConfigureAwait(false);
+                        }
+                    );
                 }
             )
             .ConfigureAwait(false);
@@ -41,30 +57,26 @@ internal static class ServerHttpRequestRunner
                 + $"{(int)response.StatusCode}.\n{responseBody}"
         );
         Assert.Equal(testCase.OperationName + "Async", capturedMethod!.Name);
-        if (testCase.Params is not null)
-        {
-            Assert.NotNull(capturedInput);
-            ResponseAssertions.AssertEquivalent(
-                testCase.Params,
-                capturedInput!,
-                testCase.OperationName
-            );
-        }
     }
 
-    private static object CreateSuccessfulResult(MethodInfo method)
+    private static object CreateSuccessfulResult(MethodInfo method, Func<Task> assertInput)
     {
         if (method.ReturnType == typeof(Task))
         {
-            return Task.CompletedTask;
+            return assertInput();
         }
 
         var resultType = method.ReturnType.GetGenericArguments()[0];
         var result = ConformanceObjectFactory.BuildDefault(resultType);
-        return typeof(Task)
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .Single(m => m.Name == nameof(Task.FromResult))
+        return typeof(ServerHttpRequestRunner)
+            .GetMethod(nameof(AssertThenReturnAsync), BindingFlags.NonPublic | BindingFlags.Static)!
             .MakeGenericMethod(resultType)
-            .Invoke(null, [result])!;
+            .Invoke(null, [assertInput, result])!;
+    }
+
+    private static async Task<T> AssertThenReturnAsync<T>(Func<Task> assertInput, T result)
+    {
+        await assertInput().ConfigureAwait(false);
+        return result;
     }
 }

--- a/tests/Conformance/RestJson1/Conformance/SmithyTestModel.cs
+++ b/tests/Conformance/RestJson1/Conformance/SmithyTestModel.cs
@@ -48,7 +48,7 @@ internal sealed class SmithyTestModel
             {
                 if (node is not JsonObject c || (string?)c["protocol"] != protocol)
                     continue;
-                yield return HttpRequestTestCase.From(id, c);
+                yield return HttpRequestTestCase.From(id, c, traits);
             }
         }
     }
@@ -129,7 +129,11 @@ internal sealed record HttpRequestTestCase(
 
     public bool AppliesToServer => AppliesTo is "server" or "both";
 
-    public static HttpRequestTestCase From(string shapeId, JsonObject c) =>
+    public static HttpRequestTestCase From(
+        string shapeId,
+        JsonObject c,
+        JsonObject? operationTraits
+    ) =>
         new(
             shapeId,
             (string)c["id"]!,
@@ -146,8 +150,30 @@ internal sealed record HttpRequestTestCase(
             (string?)c["host"],
             (string?)c["resolvedHost"],
             c["params"],
-            (string?)c["appliesTo"] ?? "both"
+            ResolveAppliesTo(c, operationTraits)
         );
+
+    private static string ResolveAppliesTo(JsonObject testCase, JsonObject? operationTraits)
+    {
+        if ((string?)testCase["appliesTo"] is { } appliesTo)
+            return appliesTo;
+
+        // Some upstream fixtures predate appliesTo but describe behavior that only an outgoing
+        // client request can observe. An omitted empty query list is indistinguishable from null
+        // to a server, and request-compression fixtures intentionally omit the wire body because
+        // they assert SDK-side compression behavior.
+        if (
+            operationTraits?["smithy.api#tags"] is JsonArray tags
+            && tags.Any(tag => (string?)tag == "client-only")
+        )
+        {
+            return "client";
+        }
+        if (operationTraits?.ContainsKey("smithy.api#requestCompression") == true)
+            return "client";
+
+        return "both";
+    }
 
     private static IReadOnlyList<string> ReadStringList(JsonObject c, string key) =>
         c[key] is JsonArray a ? [.. a.Select(n => (string)n!)] : [];

--- a/tests/Conformance/RestJson1/RestJson1.Conformance.csproj
+++ b/tests/Conformance/RestJson1/RestJson1.Conformance.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../packages/NSmithy.Aws/NSmithy.Aws.csproj" />
     <ProjectReference Include="../../../packages/NSmithy.Client/NSmithy.Client.csproj" />
     <ProjectReference Include="../../../packages/NSmithy.Protocols.RestJson/NSmithy.Protocols.RestJson.csproj" />
     <ProjectReference Include="../../../packages/NSmithy.Codecs.Json/NSmithy.Codecs.Json.csproj" />

--- a/tests/Conformance/RestJson1/smithy-build.json
+++ b/tests/Conformance/RestJson1/smithy-build.json
@@ -72,6 +72,24 @@
         }
       }
     },
+    "restjson1-glacier": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": {
+            "services": [
+              "com.amazonaws.glacier#Glacier"
+            ]
+          }
+        }
+      ],
+      "plugins": {
+        "csharp-codegen": {
+          "service": "com.amazonaws.glacier#Glacier",
+          "baseNamespace": "Auxiliary"
+        }
+      }
+    },
     "restjson1-constraints": {
       "transforms": [
         {

--- a/tests/NSmithy.Tests/Aws/GlacierInterceptorTests.cs
+++ b/tests/NSmithy.Tests/Aws/GlacierInterceptorTests.cs
@@ -1,0 +1,66 @@
+using NSmithy.Aws;
+using NSmithy.Client;
+using NSmithy.Http;
+
+namespace NSmithy.Tests.Aws;
+
+public sealed class GlacierInterceptorTests
+{
+    [Fact]
+    public async Task UploadArchiveAppliesRequiredRequestCustomizations()
+    {
+        const int chunkSize = 1024 * 1024;
+        var content = new byte[chunkSize + 1];
+        Array.Fill(content, (byte)'a', 0, chunkSize);
+        content[^1] = (byte)'b';
+        var request = new SmithyHttpRequest(
+            HttpMethod.Post,
+            "https://glacier.us-east-1.amazonaws.com/vaults/archive/archives"
+        )
+        {
+            Body = new SmithyHttpBody.Streaming(
+                new MemoryStream(content, writable: false),
+                content.Length
+            ),
+        };
+        var context = new SmithyContext();
+        context.Set(SmithyContextKeys.OperationName, "UploadArchive");
+
+        var customized = await new GlacierInterceptor().OnBeforeSigningAsync(context, request);
+
+        Assert.Same(request, customized);
+        Assert.Equal(
+            "https://glacier.us-east-1.amazonaws.com/-/vaults/archive/archives",
+            request.RequestUri
+        );
+        Assert.Equal(["2012-06-01"], request.Headers["X-Amz-Glacier-Version"]);
+        Assert.Equal(
+            ["371264331be3a89bb42c4fea3770469e9094f6ce8c8244b9ac2beb9ffd80e621"],
+            request.Headers["X-Amz-Content-Sha256"]
+        );
+        Assert.Equal(
+            ["fab4f7d8265da2a9b95d1adcbd8ccada4947044a672b746c376ce39a82286ae0"],
+            request.Headers["X-Amz-Sha256-Tree-Hash"]
+        );
+
+        var buffered = Assert.IsType<SmithyHttpBody.Streaming>(request.Body);
+        using var drained = new MemoryStream();
+        await buffered.Content.CopyToAsync(drained);
+        Assert.Equal(content, drained.ToArray());
+    }
+
+    [Fact]
+    public async Task NonUploadOperationOnlyAddsVersionHeader()
+    {
+        var request = new SmithyHttpRequest(HttpMethod.Get, "/vaults/archive");
+        var context = new SmithyContext();
+        context.Set(SmithyContextKeys.OperationName, "DescribeVault");
+
+        await new GlacierInterceptor().OnBeforeSigningAsync(context, request);
+
+        Assert.Equal("/-/vaults/archive", request.RequestUri);
+        Assert.Equal(["2012-06-01"], request.Headers["X-Amz-Glacier-Version"]);
+        Assert.DoesNotContain("X-Amz-Content-Sha256", request.Headers.Keys);
+        Assert.DoesNotContain("X-Amz-Sha256-Tree-Hash", request.Headers.Keys);
+    }
+}

--- a/tests/NSmithy.Tests/Protocols/RestJson/RestJson1ProtocolTests.cs
+++ b/tests/NSmithy.Tests/Protocols/RestJson/RestJson1ProtocolTests.cs
@@ -405,7 +405,7 @@ public sealed class RestJson1ProtocolTests
                 static input => input.ExtraHeaders,
                 static (builder, value) => builder.ExtraHeaders = value,
                 stringMapSchema,
-                traits: [RestTraits.HttpPrefixHeadersTrait("X-Extra-")]
+                traits: [RestTraits.HttpPrefixHeadersTrait("")]
             )
             .Build(
                 static () => new GetUserInputBuilder(),
@@ -431,6 +431,8 @@ public sealed class RestJson1ProtocolTests
             "/users/ada%20lovelace?includeDetails=true&tag=admin&tag=staff&debug=true"
         );
         request.Headers["X-Extra-Trace"] = ["abc"];
+        request.Headers["Host"] = ["example.com"];
+        request.Headers["Content-Length"] = ["0"];
 
         var input = Protocol(operation).DeserializeRequest(request);
 
@@ -438,9 +440,11 @@ public sealed class RestJson1ProtocolTests
         Assert.True(input.IncludeDetails);
         Assert.Equal(["admin", "staff"], input.Tags);
         Assert.Equal("true", input.ExtraQuery["debug"]);
-        Assert.DoesNotContain("includeDetails", input.ExtraQuery.Keys);
-        Assert.DoesNotContain("tag", input.ExtraQuery.Keys);
-        Assert.Equal("abc", input.ExtraHeaders["Trace"]);
+        Assert.Equal("true", input.ExtraQuery["includeDetails"]);
+        Assert.Equal("admin", input.ExtraQuery["tag"]);
+        Assert.Equal("abc", input.ExtraHeaders["X-Extra-Trace"]);
+        Assert.DoesNotContain("Host", input.ExtraHeaders.Keys);
+        Assert.DoesNotContain("Content-Length", input.ExtraHeaders.Keys);
     }
 
     public sealed record RequestValueParityInput(

--- a/website/src/content/docs/protocols/status.md
+++ b/website/src/content/docs/protocols/status.md
@@ -11,7 +11,7 @@ test totals.
 
 | Protocol | Surfaces | Stage | Client conformance | Server conformance |
 | --- | --- | --- | --- | --- |
-| [`aws.protocols#restJson1`](../rest-json/) | Client and server | Preview | Requests 137/142 (96.5%), responses 106/108 (98.1%) | Requests 118/134 (88.1%), responses 92/92 (100%), malformed 655/655 (100%) |
+| [`aws.protocols#restJson1`](../rest-json/) | Client and server | Preview | Requests 142/142 (100%), responses 108/108 (100%) | Requests 132/132 (100%), responses 92/92 (100%), malformed 655/655 (100%) |
 | [`aws.protocols#awsJson1_1`](../aws-json/) | Client | Early preview | Requests 6/57 (10.5%), responses 18/62 (29.0%) | N/A |
 | [`aws.protocols#awsJson1_0`](../aws-json/) | Client | Early preview | Runtime support, no conformance project | N/A |
 | [`aws.protocols#awsQuery`](../aws-query/) | Client | Preview | Requests 38/38 (100%), responses 39/39 (100%) | N/A |
@@ -39,10 +39,8 @@ count as official conformance.
 
 ## Coverage notes
 
-- restJson1 client response coverage includes all official modeled-error cases.
-  The client passes 13/14 applicable error cases, and the server passes 3/3. The
-  remaining client case uses an `X-Amzn-Errortype` URI with a different
-  namespace.
+- restJson1 passes every applicable official request, response, modeled-error,
+  and malformed-request case on both generated surfaces.
 - The restJson1 server passes all 655 applicable
   `httpMalformedRequestTests`. These cases verify structured responses for
   requests that cannot be deserialized or validated.

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -13,9 +13,8 @@ levels. Each implemented protocol has a conformance suite run against the
 official Smithy / AWS protocol tests (`tests/Conformance`):
 
 - **simpleRestJson (`alloy#simpleRestJson`)** — client and ASP.NET Core server.
-- **AWS restJson1 (`aws.protocols#restJson1`)** — client and ASP.NET Core server. The main
-  remaining corpus gap is the Glacier-specific fixture set, which needs broader
-  projection support.
+- **AWS restJson1 (`aws.protocols#restJson1`)** — client and ASP.NET Core server;
+  all applicable official conformance cases pass.
 - **`smithy.protocols#rpcv2Cbor`** — client and ASP.NET Core server, with
   conformance coverage.
 - **`aws.protocols#awsJson1_1` / `aws.protocols#awsJson1_0`** — client only by


### PR DESCRIPTION
## Summary

- fix server query-map and empty-prefix-header deserialization
- execute the remaining nested-union and modeled-error fixtures
- add the production Glacier request customization to `NSmithy.Aws` and install it automatically in generated Glacier clients
- make streaming/raw-payload server assertions schema-aware and correct client-only fixture classification
- update the published RestJson1 conformance status to 100%

## Glacier customization

The official Glacier cases now exercise the production path rather than conformance-only wiring. Generated `com.amazonaws.glacier#Glacier` client configs automatically install `NSmithy.Aws.GlacierInterceptor`, which supplies the service version header, empty-account-ID default, linear SHA-256, and Glacier tree hash.

## Conformance

- client requests: 142/142 (100%)
- client responses: 108/108 (100%)
- server requests: 132/132 (100%)
- server responses: 92/92 (100%)
- malformed requests: 655/655 (100%)

## Verification

- `just build`
- `just test`
- `just check-format`
- complete RestJson1 suite: 1,146/1,146 passed