### PR TITLE
feat: support Smithy AI prompt traits

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -104,8 +104,10 @@ val codegenBundle: Configuration by configurations.creating
 
 dependencies {
     val smithyVer = property("smithyVersion") as String
+    val smithyAiTraitsVer = property("smithyAiTraitsVersion") as String
     codegenBundle("io.github.thomaslaich.nsmithy:smithy-csharp-codegen:${project.version}")
     codegenBundle("io.github.thomaslaich.nsmithy:smithy-proto-codegen:${project.version}")
+    codegenBundle("software.amazon.smithy.java:smithy-ai-traits:$smithyAiTraitsVer")
     codegenBundle("software.amazon.smithy:smithy-aws-traits:$smithyVer")
     codegenBundle("software.amazon.smithy:smithy-protocol-traits:$smithyVer")
     codegenBundle("software.amazon.smithy:smithy-docgen:$smithyVer")

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 smithyVersion=1.73.0
+smithyAiTraitsVersion=1.6.0

--- a/codegen/smithy-csharp-codegen/build.gradle.kts
+++ b/codegen/smithy-csharp-codegen/build.gradle.kts
@@ -11,6 +11,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
 
 val smithyVersion: String by project
+val smithyAiTraitsVersion: String by project
 
 plugins {
     id("com.vanniktech.maven.publish")
@@ -21,6 +22,11 @@ dependencies {
     api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-build:$smithyVersion")
     api("software.amazon.smithy:smithy-utils:$smithyVersion")
+
+    // Makes the official smithy.ai trait definitions and validators available whenever the
+    // C# build plugin is loaded. In particular, models can use smithy.ai#prompts without copying
+    // the unstable trait definition into each contracts project.
+    runtimeOnly("software.amazon.smithy.java:smithy-ai-traits:$smithyAiTraitsVersion")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.4")

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
@@ -39,14 +39,11 @@ final class AiTraitsGeneratorTest {
     String operationSchema = renderOperationSchema(model, operation);
 
     assertTrue(
-        serviceSchema.contains("new Trait(ShapeId.Parse(\"smithy.ai#prompts\")"),
-        serviceSchema);
+        serviceSchema.contains("new Trait(ShapeId.Parse(\"smithy.ai#prompts\")"), serviceSchema);
     assertTrue(serviceSchema.contains("\"weather_brief\""), serviceSchema);
     assertTrue(serviceSchema.contains("\"Create a concise weather brief\""), serviceSchema);
-    assertTrue(
-        serviceSchema.contains("\"example.weather#WeatherBriefArguments\""), serviceSchema);
-    assertTrue(
-        serviceSchema.contains("\"The user wants a short weather summary\""), serviceSchema);
+    assertTrue(serviceSchema.contains("\"example.weather#WeatherBriefArguments\""), serviceSchema);
+    assertTrue(serviceSchema.contains("\"The user wants a short weather summary\""), serviceSchema);
 
     assertTrue(
         operationSchema.contains("new Trait(ShapeId.Parse(\"smithy.ai#prompts\")"),
@@ -82,7 +79,8 @@ final class AiTraitsGeneratorTest {
 
   private URL resource(String resourceName) {
     return Objects.requireNonNull(
-        getClass().getClassLoader().getResource(resourceName), "Missing test resource " + resourceName);
+        getClass().getClassLoader().getResource(resourceName),
+        "Missing test resource " + resourceName);
   }
 
   private static String renderServiceSchema(ServiceShape service) {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
@@ -1,0 +1,117 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
+import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpDelegator;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.ValidatedResult;
+
+final class AiTraitsGeneratorTest {
+
+  private static final String SERVICE_ID = "example.weather#WeatherService";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void preservesPromptsOnServiceAndOperationRuntimeSchemas() throws Exception {
+    Model model = assemble("ai/prompts.smithy").unwrap();
+    var service = model.expectShape(ShapeId.from(SERVICE_ID), ServiceShape.class);
+    var operation =
+        model.expectShape(ShapeId.from("example.weather#GetForecast"), OperationShape.class);
+
+    String serviceSchema = renderServiceSchema(service);
+    String operationSchema = renderOperationSchema(model, operation);
+
+    assertTrue(
+        serviceSchema.contains("new Trait(ShapeId.Parse(\"smithy.ai#prompts\")"),
+        serviceSchema);
+    assertTrue(serviceSchema.contains("\"weather_brief\""), serviceSchema);
+    assertTrue(serviceSchema.contains("\"Create a concise weather brief\""), serviceSchema);
+    assertTrue(
+        serviceSchema.contains("\"example.weather#WeatherBriefArguments\""), serviceSchema);
+    assertTrue(
+        serviceSchema.contains("\"The user wants a short weather summary\""), serviceSchema);
+
+    assertTrue(
+        operationSchema.contains("new Trait(ShapeId.Parse(\"smithy.ai#prompts\")"),
+        operationSchema);
+    assertTrue(operationSchema.contains("\"forecast_for_location\""), operationSchema);
+    assertTrue(operationSchema.contains("\"Get the forecast for one location\""), operationSchema);
+    assertTrue(operationSchema.contains("\"example.weather#GetForecastInput\""), operationSchema);
+  }
+
+  @Test
+  void rejectsPromptNamesThatOnlyDifferByCase() {
+    ValidatedResult<Model> result = assemble("ai/duplicate-prompts.smithy");
+
+    assertTrue(result.isBroken(), result.getValidationEvents().toString());
+    assertTrue(
+        result.getValidationEvents().stream()
+            .anyMatch(
+                event ->
+                    event
+                        .getMessage()
+                        .contains(
+                            "Duplicate prompt name detected: 'Weather_Report' conflicts with an"
+                                + " existing prompt")),
+        result.getValidationEvents().toString());
+  }
+
+  private ValidatedResult<Model> assemble(String resourceName) {
+    return Model.assembler()
+        .discoverModels(getClass().getClassLoader())
+        .addImport(resource(resourceName))
+        .assemble();
+  }
+
+  private URL resource(String resourceName) {
+    return Objects.requireNonNull(
+        getClass().getClassLoader().getResource(resourceName), "Missing test resource " + resourceName);
+  }
+
+  private static String renderServiceSchema(ServiceShape service) {
+    var writer = new CSharpWriter("Example.Weather");
+    new ServiceSchemaGenerator(writer, service).run();
+    return writer.toString();
+  }
+
+  private String renderOperationSchema(Model model, OperationShape operation) throws Exception {
+    CSharpSettings settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder()
+                .withMember("service", Node.from(SERVICE_ID))
+                .withMember("baseNamespace", Node.from("Example"))
+                .build());
+    var symbolProvider = new CSharpSymbolProvider(model, settings);
+    var manifest = FileManifest.create(Files.createDirectory(tempDir.resolve("manifest")));
+    var context =
+        GenerationContext.builder()
+            .model(model)
+            .settings(settings)
+            .symbolProvider(symbolProvider)
+            .fileManifest(manifest)
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .build();
+    var writer = new CSharpWriter("Example.Weather");
+
+    new OperationSchemaGenerator(context, writer, operation).run();
+
+    return writer.toString();
+  }
+}

--- a/codegen/smithy-csharp-codegen/src/test/resources/ai/duplicate-prompts.smithy
+++ b/codegen/smithy-csharp-codegen/src/test/resources/ai/duplicate-prompts.smithy
@@ -1,0 +1,24 @@
+$version: "2"
+
+namespace example.weather
+
+use smithy.ai#prompts
+
+@prompts({
+    weather_report: {
+        description: "Create a weather report"
+        template: "Create a weather report."
+    }
+})
+service WeatherService {
+    version: "2026-08-28"
+    operations: [GetForecast]
+}
+
+@prompts({
+    Weather_Report: {
+        description: "Get a weather report"
+        template: "Get a weather report."
+    }
+})
+operation GetForecast {}

--- a/codegen/smithy-csharp-codegen/src/test/resources/ai/prompts.smithy
+++ b/codegen/smithy-csharp-codegen/src/test/resources/ai/prompts.smithy
@@ -1,0 +1,46 @@
+$version: "2"
+
+namespace example.weather
+
+use smithy.ai#prompts
+
+@prompts({
+    weather_brief: {
+        description: "Create a concise weather brief"
+        template: "Summarize the forecast for {{location}}."
+        arguments: WeatherBriefArguments
+        preferWhen: "The user wants a short weather summary"
+    }
+})
+service WeatherService {
+    version: "2026-08-28"
+    operations: [GetForecast]
+}
+
+@readonly
+@prompts({
+    forecast_for_location: {
+        description: "Get the forecast for one location"
+        template: "Get the forecast for {{location}}."
+        arguments: GetForecastInput
+    }
+})
+operation GetForecast {
+    input: GetForecastInput
+    output: GetForecastOutput
+}
+
+structure WeatherBriefArguments {
+    /// City, coordinates, or another recognizable location.
+    @required
+    location: String
+}
+
+structure GetForecastInput {
+    @required
+    location: String
+}
+
+structure GetForecastOutput {
+    summary: String
+}


### PR DESCRIPTION
## Summary

- bundle the official Smithy AI traits artifact with the C# codegen plugin
- preserve service- and operation-level smithy.ai#prompts metadata in generated runtime schemas
- verify the official case-insensitive prompt-name validation behavior

## Verification

- just check-format
- cd codegen && gradle test
- just build
- dotnet test NSmithy.slnx --configuration Release --no-build --disable-build-servers

Part of #121.