### PR TITLE
feat: generate service operation catalogs

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -2,6 +2,7 @@
  * Server-side code generator. Emits:
  *   - one `I{Operation}Handler` per operation (streaming surface derived from the model)
  *   - aggregate `I{Service}ServiceHandler`
+ *   - a protocol-neutral executable operation catalog for the aggregate handler
  *   - `{Service}ServiceServerExtensions` with AddXxxHandler<THandler>(IServiceCollection)
  *   - `{Service}ServiceProtocols` flags and `Map{Service}Service(..., protocols)` that bind
  *     selected protocol routes to the shared handler
@@ -76,6 +77,7 @@ public final class ServerGenerator implements Runnable {
     boolean emitsAspNetCore = !serverKinds.isEmpty();
 
     writer.addImport(RuntimeTypes.NSMITHY_CORE);
+    writer.addImport(RuntimeTypes.NSMITHY_SERVER);
     writer.addImport(RuntimeTypes.MS_EXT_DI);
     if (emitsAspNetCore) {
       writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
@@ -158,6 +160,9 @@ public final class ServerGenerator implements Runnable {
                 writer.write("return services;");
               });
 
+          writer.write("");
+          writeOperationCatalog(ops, contract, aggInterface);
+
           if (serverKinds.isEmpty()) {
             return;
           }
@@ -173,6 +178,36 @@ public final class ServerGenerator implements Runnable {
             writer.write("");
             writeProtocolMapHelper(kind, ops, contract, protocolEnum);
           }
+        });
+  }
+
+  private void writeOperationCatalog(
+      List<OperationShape> ops, String contract, String aggregateInterface) {
+    writer.write(
+        "public static ServiceOperationCatalog Create$LOperationCatalog(this $L handler)",
+        contract,
+        aggregateInterface);
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("System.ArgumentNullException.ThrowIfNull(handler);");
+          writer.write("");
+          writer.write("return new ServiceOperationCatalog(");
+          writer.indent();
+          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(context, service));
+          writer.write("[");
+          writer.indent();
+          for (OperationShape op : ops) {
+            writer.write(
+                "ServiceOperation.Create($L, $L),",
+                SchemaGenerator.operationSchemaAccessor(context, op),
+                unaryAdapter(op));
+          }
+          writer.dedent();
+          writer.write("]");
+          writer.dedent();
+          writer.write(");");
         });
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -412,9 +412,9 @@ final class ServerGeneratorTest {
     assertTrue(generated.contains("CatalogServiceSchema.Schema,"), generated);
     assertTrue(
         generated.contains(
-            "ServiceOperation.Create(Example.Example.Catalog.NotifySchema.Schema, "
-                + "async (input, ct) => { await handler.NotifyAsync(input, ct).ConfigureAwait(false);"
-                + " return SmithyUnit.Value; }),"),
+            "ServiceOperation.Create(Example.Example.Catalog.NotifySchema.Schema, async (input, ct)"
+                + " => { await handler.NotifyAsync(input, ct).ConfigureAwait(false); return"
+                + " SmithyUnit.Value; }),"),
         generated);
     assertTrue(
         generated.contains(

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -249,6 +249,30 @@ final class ServerGeneratorTest {
       }
       """;
 
+  private static final String CATALOG_MODEL =
+      """
+      $version: "2"
+
+      namespace example.catalog
+
+      service CatalogService {
+          version: "1"
+          operations: [Ping, Notify]
+      }
+
+      operation Ping {
+          output := {
+              message: String
+          }
+      }
+
+      operation Notify {
+          input := {
+              message: String
+          }
+      }
+      """;
+
   @Test
   void streamingGrpcServerUsesAsyncEnumerableHandlersAndStreamingWriter() throws Exception {
     String generated = renderServer();
@@ -374,6 +398,31 @@ final class ServerGeneratorTest {
         generated);
   }
 
+  @Test
+  void serverGeneratesProtocolNeutralOperationCatalog() throws Exception {
+    String generated =
+        renderServer("", CATALOG_MODEL, "example.catalog#CatalogService", "Example.Catalog");
+
+    assertTrue(generated.contains("using NSmithy.Server;"), generated);
+    assertTrue(
+        generated.contains(
+            "public static ServiceOperationCatalog CreateCatalogServiceOperationCatalog("
+                + "this ICatalogServiceHandler handler)"),
+        generated);
+    assertTrue(generated.contains("CatalogServiceSchema.Schema,"), generated);
+    assertTrue(
+        generated.contains(
+            "ServiceOperation.Create(Example.Example.Catalog.NotifySchema.Schema, "
+                + "async (input, ct) => { await handler.NotifyAsync(input, ct).ConfigureAwait(false);"
+                + " return SmithyUnit.Value; }),"),
+        generated);
+    assertTrue(
+        generated.contains(
+            "ServiceOperation.Create(Example.Example.Catalog.PingSchema.Schema, "
+                + "(_, ct) => handler.PingAsync(ct)),"),
+        generated);
+  }
+
   private String renderServer() throws Exception {
     return renderServer(MODEL);
   }
@@ -387,9 +436,11 @@ final class ServerGeneratorTest {
       String protocolTraits, String modelText, String serviceId, String writerNamespace)
       throws Exception {
     var assembler = Model.assembler();
-    String[] protocolTraitModels = protocolTraits.split("(?m)^---$");
-    for (int i = 0; i < protocolTraitModels.length; i++) {
-      assembler.addUnparsedModel("protocol-traits-" + i + ".smithy", protocolTraitModels[i]);
+    if (!protocolTraits.isBlank()) {
+      String[] protocolTraitModels = protocolTraits.split("(?m)^---$");
+      for (int i = 0; i < protocolTraitModels.length; i++) {
+        assembler.addUnparsedModel("protocol-traits-" + i + ".smithy", protocolTraitModels[i]);
+      }
     }
     Model model = assembler.addUnparsedModel("model.smithy", modelText).assemble().unwrap();
     CSharpSettings settings =

--- a/designs/codegen-architecture.md
+++ b/designs/codegen-architecture.md
@@ -162,7 +162,8 @@ Generated code depends on .NET packages published to NuGet:
 - `NSmithy.Core` — `Schema`, `ShapeId`, `Trait`, codec interfaces
 - `NSmithy.Http` — `IHttpTransport`, `SmithyHttpRequest`, `SmithyHttpClientResponse`
 - `NSmithy.Client` — `SmithyClientRuntime`, `IClientInterceptor`
-- `NSmithy.Server` / `NSmithy.Server.AspNetCore` — server framework
+- `NSmithy.Server` / `NSmithy.Server.AspNetCore` — host-neutral operation
+  catalogs and server framework
 - `NSmithy.Codecs.Json/Xml/Cbor` — schema-bound body codec implementations
 - `NSmithy.Protocols.Rest` — shared REST HTTP binding projection
 - `NSmithy.Protocols.*` — protocol adapters such as restJson1, restXml,
@@ -184,7 +185,8 @@ Each generated shape file contains:
 Operation files contain:
 
 - `<Operation>Schema` — an `OperationSchema<TInput, TOutput>` that references
-  the input and output schemas plus operation traits.
+  the input and output schemas plus operation traits; it also implements the
+  non-generic `IOperationSchema` view used by protocol-neutral adapters.
 
 Service files contain:
 
@@ -192,14 +194,19 @@ Service files contain:
   service-level traits.
 - `<Service>.Client.g.cs` — typed async methods for each operation; binds
   protocol and transport at construction time.
-- `<Service>.Server.g.cs` — server-side handler interface and
-  ASP.NET Core adapter.
+- `<Service>.Server.g.cs` — server-side handler interface, a
+  `ServiceOperationCatalog` factory that binds operation schemas to the typed
+  handler, and the ASP.NET Core adapter.
 
 Generated client and server methods bind the service schema, operation schemas,
 typed input/output values, selected protocol adapter, and transport options into
 the runtime protocol pipeline. The protocol adapter projects each operation into
 transport fields and delegates body payloads to a schema-bound codec such as
 `JsonCodecFactory`.
+
+The generated operation catalog stops at typed handler invocation. It has no
+HTTP, ASP.NET Core, MCP, or stdio behavior; those hosts enumerate the catalog,
+construct input using its runtime schemas, and choose their own wire mapping.
 
 ## Tradeoffs
 

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -165,8 +165,10 @@ disagrees with the shape it belongs to.
 
 For each operation, the generator emits an `OperationSchema<TInput, TOutput>`
 that references the input and output schemas plus operation traits and modeled
-error descriptors. For each service, it emits a `ServiceSchema` with the service
-shape id and service-level traits.
+error descriptors. The generic schema implements `IOperationSchema`, retaining
+the same metadata through a non-generic input/output schema view for dynamic
+consumers. For each service, it emits a `ServiceSchema` with the service shape id
+and service-level traits.
 
 Traits stay on schemas and members. Core schemas carry any Smithy trait, but
 consumers decide which traits they interpret. REST protocols interpret

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -1580,7 +1580,26 @@ public sealed class UnionSchemaBuilder<T>
     }
 }
 
-public sealed class OperationSchema<TInput, TOutput>
+public interface IOperationSchema
+{
+    ShapeId Id { get; }
+
+    ShapeKind Kind { get; }
+
+    Schema Input { get; }
+
+    Schema Output { get; }
+
+    IReadOnlyList<IOperationErrorSchema> Errors { get; }
+
+    IReadOnlyDictionary<ShapeId, Trait> Traits { get; }
+
+    Trait? GetTrait(ShapeId id);
+
+    bool HasTrait(ShapeId id);
+}
+
+public sealed class OperationSchema<TInput, TOutput> : IOperationSchema
 {
     internal OperationSchema(
         ShapeId id,
@@ -1606,6 +1625,10 @@ public sealed class OperationSchema<TInput, TOutput>
     public Schema<TInput> Input { get; }
 
     public Schema<TOutput> Output { get; }
+
+    Schema IOperationSchema.Input => Input;
+
+    Schema IOperationSchema.Output => Output;
 
     public IReadOnlyList<IOperationErrorSchema> Errors { get; }
 

--- a/packages/NSmithy.Server/ServiceOperationCatalog.cs
+++ b/packages/NSmithy.Server/ServiceOperationCatalog.cs
@@ -1,0 +1,114 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Server;
+
+/// <summary>
+/// An operation schema bound to its server handler. The object-based invocation seam lets
+/// protocol-neutral adapters dispatch an operation after constructing input from its runtime
+/// schema; the generic implementation retains type safety at the handler boundary.
+/// </summary>
+public interface IServiceOperation
+{
+    IOperationSchema Schema { get; }
+
+    Task<object?> InvokeAsync(
+        object input,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>Creates typed service-operation bindings with inferred input and output types.</summary>
+public static class ServiceOperation
+{
+    public static ServiceOperation<TInput, TOutput> Create<TInput, TOutput>(
+        OperationSchema<TInput, TOutput> schema,
+        Func<TInput, CancellationToken, Task<TOutput>> handler
+    ) => new(schema, handler);
+}
+
+/// <summary>A type-safe operation binding exposed through <see cref="IServiceOperation"/>.</summary>
+public sealed class ServiceOperation<TInput, TOutput> : IServiceOperation
+{
+    private readonly Func<TInput, CancellationToken, Task<TOutput>> handler;
+
+    public ServiceOperation(
+        OperationSchema<TInput, TOutput> schema,
+        Func<TInput, CancellationToken, Task<TOutput>> handler
+    )
+    {
+        Schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public OperationSchema<TInput, TOutput> Schema { get; }
+
+    IOperationSchema IServiceOperation.Schema => Schema;
+
+    public async Task<object?> InvokeAsync(
+        object input,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (input is not TInput typedInput)
+        {
+            var actualType = input is null ? "<null>" : input.GetType().FullName;
+            throw new ArgumentException(
+                $"Operation '{Schema.Id}' expects input assignable to "
+                    + $"'{typeof(TInput).FullName}', but received '{actualType}'.",
+                nameof(input)
+            );
+        }
+
+        return await handler(typedInput, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// The protocol- and host-neutral executable surface of a generated Smithy service.
+/// </summary>
+public sealed class ServiceOperationCatalog
+{
+    private readonly ReadOnlyDictionary<ShapeId, IServiceOperation> operationsById;
+
+    public ServiceOperationCatalog(ServiceSchema schema, params IServiceOperation[] operations)
+    {
+        Schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        ArgumentNullException.ThrowIfNull(operations);
+
+        var copied = operations.ToArray();
+        var byId = new Dictionary<ShapeId, IServiceOperation>();
+        foreach (var operation in copied)
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            if (!byId.TryAdd(operation.Schema.Id, operation))
+            {
+                throw new ArgumentException(
+                    $"Operation '{operation.Schema.Id}' is registered more than once.",
+                    nameof(operations)
+                );
+            }
+        }
+
+        Operations = Array.AsReadOnly(copied);
+        operationsById = new ReadOnlyDictionary<ShapeId, IServiceOperation>(byId);
+    }
+
+    public ServiceSchema Schema { get; }
+
+    public IReadOnlyList<IServiceOperation> Operations { get; }
+
+    public IServiceOperation GetOperation(ShapeId id) =>
+        operationsById.TryGetValue(id, out var operation)
+            ? operation
+            : throw new KeyNotFoundException(
+                $"Service '{Schema.Id}' does not contain operation '{id}'."
+            );
+
+    public bool TryGetOperation(
+        ShapeId id,
+        [NotNullWhen(true)] out IServiceOperation? operation
+    ) => operationsById.TryGetValue(id, out operation);
+}

--- a/packages/NSmithy.Server/ServiceOperationCatalog.cs
+++ b/packages/NSmithy.Server/ServiceOperationCatalog.cs
@@ -14,10 +14,7 @@ public interface IServiceOperation
 {
     IOperationSchema Schema { get; }
 
-    Task<object?> InvokeAsync(
-        object input,
-        CancellationToken cancellationToken = default
-    );
+    Task<object?> InvokeAsync(object input, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Creates typed service-operation bindings with inferred input and output types.</summary>
@@ -107,8 +104,6 @@ public sealed class ServiceOperationCatalog
                 $"Service '{Schema.Id}' does not contain operation '{id}'."
             );
 
-    public bool TryGetOperation(
-        ShapeId id,
-        [NotNullWhen(true)] out IServiceOperation? operation
-    ) => operationsById.TryGetValue(id, out operation);
+    public bool TryGetOperation(ShapeId id, [NotNullWhen(true)] out IServiceOperation? operation) =>
+        operationsById.TryGetValue(id, out operation);
 }

--- a/tests/NSmithy.Tests/Server/ServiceOperationCatalogTests.cs
+++ b/tests/NSmithy.Tests/Server/ServiceOperationCatalogTests.cs
@@ -1,0 +1,85 @@
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Server;
+
+namespace NSmithy.Tests.Server;
+
+public sealed class ServiceOperationCatalogTests
+{
+    private static readonly ShapeId OperationId = new("example", "CountLetters");
+
+    [Fact]
+    public async Task CatalogEnumeratesLooksUpAndInvokesTypedOperations()
+    {
+        var serviceSchema = Schemas.Service(new ShapeId("example", "TextService"), "2026-08-30");
+        var operationSchema = Schemas.Operation(OperationId, Schemas.String, Schemas.Integer);
+        CancellationToken observedCancellationToken = default;
+        var operation = ServiceOperation.Create(
+            operationSchema,
+            (string input, CancellationToken cancellationToken) =>
+            {
+                observedCancellationToken = cancellationToken;
+                return Task.FromResult(input.Length);
+            }
+        );
+        var catalog = new ServiceOperationCatalog(serviceSchema, operation);
+        using var cancellation = new CancellationTokenSource();
+
+        var result = await catalog
+            .GetOperation(OperationId)
+            .InvokeAsync("Smithy", cancellation.Token);
+
+        var untypedSchema = Assert.IsAssignableFrom<IOperationSchema>(operationSchema);
+        Assert.Same(serviceSchema, catalog.Schema);
+        Assert.Same(operation, Assert.Single(catalog.Operations));
+        Assert.True(catalog.TryGetOperation(OperationId, out var found));
+        Assert.Same(operation, found);
+        Assert.Same(Schemas.String, untypedSchema.Input);
+        Assert.Same(Schemas.Integer, untypedSchema.Output);
+        Assert.Equal(6, result);
+        Assert.Equal(cancellation.Token, observedCancellationToken);
+    }
+
+    [Fact]
+    public async Task OperationRejectsInputOfTheWrongRuntimeType()
+    {
+        var operation = ServiceOperation.Create(
+            Schemas.Operation(OperationId, Schemas.String, Schemas.Integer),
+            static (string input, CancellationToken _) => Task.FromResult(input.Length)
+        );
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            operation.InvokeAsync(42)
+        );
+
+        Assert.Equal("input", exception.ParamName);
+        Assert.Contains(OperationId.ToString(), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(string).FullName!, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(int).FullName!, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CatalogRejectsDuplicateOperationIds()
+    {
+        var schema = Schemas.Operation(OperationId, Schemas.String, Schemas.Integer);
+        var first = ServiceOperation.Create(
+            schema,
+            static (string input, CancellationToken _) => Task.FromResult(input.Length)
+        );
+        var second = ServiceOperation.Create(
+            schema,
+            static (string input, CancellationToken _) => Task.FromResult(input.Length * 2)
+        );
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new ServiceOperationCatalog(
+                Schemas.Service(new ShapeId("example", "TextService")),
+                first,
+                second
+            )
+        );
+
+        Assert.Equal("operations", exception.ParamName);
+        Assert.Contains(OperationId.ToString(), exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- expose a non-generic operation schema surface for runtime discovery
- add a typed service operation catalog with lookup and dynamic invocation
- generate catalog factories that bind Smithy operations to server handlers
- document and test catalog generation, unit shapes, cancellation, and validation

## Context

This is the next transport-neutral slice of #121. It provides the operation metadata and invocation boundary that future MCP adapters can consume without coupling the generated service to stdio, HTTP, or another transport.

Refs #121