### PR TITLE
refactor: remove the untyped schema surface

### DIFF
--- a/NSmithy.slnx
+++ b/NSmithy.slnx
@@ -28,6 +28,7 @@
     <Project Path="tools/dotnet-nsmithy/dotnet-nsmithy.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/AotSmoke/NSmithy.AotSmoke.csproj" />
     <Project Path="tests/Fakes/Fakes.Tests.csproj" />
     <Project Path="tests/NSmithy.Tests/NSmithy.Tests.csproj" />
   </Folder>

--- a/benchmarks/Benchmarks.Micro/CodecBenchmarks.cs
+++ b/benchmarks/Benchmarks.Micro/CodecBenchmarks.cs
@@ -32,7 +32,7 @@ namespace Bench.Micro;
 [MemoryDiagnoser]
 public class SerializationBenchmarks
 {
-    private static readonly IJsonCodec<ListItemsOutput> ListCodec = JsonCodec.FromSchema(
+    private static readonly ICodec<ListItemsOutput> ListCodec = JsonCodecFactory.Default.FromSchema(
         ListItemsOutputSchema.Schema
     );
 
@@ -93,7 +93,7 @@ public class SerializationBenchmarks
 [MemoryDiagnoser]
 public class CborSerializationBenchmarks
 {
-    private static readonly ICborCodec<ListItemsOutput> Codec = CborCodec.FromSchema(
+    private static readonly ICodec<ListItemsOutput> Codec = CborCodecFactory.Default.FromSchema(
         ListItemsOutputSchema.Schema
     );
 
@@ -113,7 +113,7 @@ public class CborSerializationBenchmarks
 [MemoryDiagnoser]
 public class XmlSerializationBenchmarks
 {
-    private static readonly IXmlCodec<ListItemsOutput> Codec = XmlCodec.FromSchema(
+    private static readonly ICodec<ListItemsOutput> Codec = XmlCodecFactory.Default.FromSchema(
         ListItemsOutputSchema.Schema
     );
 
@@ -157,7 +157,9 @@ public class ProtoSerializationBenchmarks
             new ProtoValueSerializer()
         );
 
-    private static readonly IProtoCodec<ProtoValue> Codec = ProtoCodec.FromSchema(ValueSchema);
+    private static readonly ICodec<ProtoValue> Codec = ProtoCodecFactory.Default.FromSchema(
+        ValueSchema
+    );
     private readonly ProtoValue value = new("benchmark-value", 42);
 
     [Benchmark]
@@ -343,9 +345,8 @@ public class SerializationExecutionBenchmarks : IDisposable
 [MemoryDiagnoser]
 public class DeserializationBenchmarks
 {
-    private static readonly IJsonCodec<CreateOrderInput> OrderCodec = JsonCodec.FromSchema(
-        CreateOrderInputSchema.Schema
-    );
+    private static readonly ICodec<CreateOrderInput> OrderCodec =
+        JsonCodecFactory.Default.FromSchema(CreateOrderInputSchema.Schema);
 
     private byte[] payload = null!;
 

--- a/benchmarks/Benchmarks.Micro/ErrorBenchmarks.cs
+++ b/benchmarks/Benchmarks.Micro/ErrorBenchmarks.cs
@@ -24,10 +24,9 @@ namespace Bench.Micro;
 /// <em>smaller</em> payload. Any excess is overhead, not bytes.
 /// </para>
 /// <para>
-/// This exists because <c>RestProtocol.SerializeStructuredError</c> re-derives
+/// This exists because <c>RestProtocol.SerializeStructuredError</c> re-derived
 /// per response what the success path resolves once: a <c>(dynamic)</c> dispatch,
-/// <c>Schemas.GetMembers</c> (which walks the schema's members and allocates a
-/// list), and two dictionaries. The rpcv2Cbor equivalent is worse still — it
+/// a walk over the schema's members, and two dictionaries. The rpcv2Cbor equivalent is worse still — it
 /// constructs a fresh <c>CborWriterCompiler</c> and recompiles the error shape's
 /// whole writer tree per response — but rpcv2Cbor has no coverage in this suite,
 /// so it stays unmeasured.

--- a/benchmarks/Benchmarks.Micro/GrpcBenchmarks.cs
+++ b/benchmarks/Benchmarks.Micro/GrpcBenchmarks.cs
@@ -186,7 +186,7 @@ internal static class GrpcCodecCases
     {
         var googleValue = Bench.GrpcNet.GetItemOutput.Parser.ParseFrom(payload);
         var nsmithyValue = new Native.GetItemOutput(Item("item-0", 0));
-        var nsmithyCodec = ProtoCodec.FromSchema(Native.GetItemOutputSchema.Schema);
+        var nsmithyCodec = ProtoCodecFactory.Default.FromSchema(Native.GetItemOutputSchema.Schema);
         return new GrpcCodecCase(
             googleValue.ToByteArray,
             () => nsmithyCodec.Serialize(nsmithyValue),
@@ -203,7 +203,9 @@ internal static class GrpcCodecCases
                 Enumerable.Range(0, 100).Select(index => Item($"item-{index}", index))
             )
         );
-        var nsmithyCodec = ProtoCodec.FromSchema(Native.ListItemsOutputSchema.Schema);
+        var nsmithyCodec = ProtoCodecFactory.Default.FromSchema(
+            Native.ListItemsOutputSchema.Schema
+        );
         return new GrpcCodecCase(
             googleValue.ToByteArray,
             () => nsmithyCodec.Serialize(nsmithyValue),

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -333,6 +333,38 @@ was neutral at 1.90 µs for one item and about 105 µs for 100 items.
 
 ## Fixed
 
+### The untyped schema surface is gone, and it was not where the time went
+
+`MEASURED`, codec suite: neutral. The schema model no longer exposes an `object`
+tier (`GetObject`/`SetObject`, `*Object` collection accessors, `CreateObject` on
+enums, `GetCaseObject` on unions), and no codec or protocol reaches a typed
+overload through `(dynamic)` at request time. REST labels, headers, query
+parameters, prefix headers and status codes are compiled once per operation into
+typed per-member plans; the awsQuery form writer is compiled once per operation;
+XML scalars and proto scalars, timestamps and enums are compiled per kind, with
+proto enum ordinals in a frozen table rather than re-parsed from the synthetic
+trait per value; `@default` resolves once into a typed factory shared by JSON,
+CBOR, XML and the REST payload path.
+
+Measured before and after on the same machine, in process:
+
+| Benchmark | Before | After |
+| --- | --- | --- |
+| XML serialize, 1 item | 1.677 μs, 15.78 KB | 1.680 μs, 15.78 KB |
+| XML serialize, 100 items | 92.6 μs, 189.15 KB | 91.8 μs, 189.15 KB |
+| REST modeled error response | 276.9 ns, 1224 B | 274.7 ns, 1224 B |
+| Proto serialize | 39.31 ns, 48 B | 39.25 ns, 48 B |
+
+Every difference is inside the error bars. The per-value `ShapeKind` switch and
+the boxing it implied were real but invisible next to `XElement` construction
+(15 KB per single-item document) and the fixed cost of a response. What the
+change buys is the API and the AOT story, not time: `Schema.cs` lost the
+duplicate tier and two of its three collection-class families, and the runtime
+binder is no longer on any per-request path. `HYPOTHESIS`: header- and
+query-heavy REST operations, which no benchmark in this suite exercises, are
+where the removed boxing would show, and they should get a micro benchmark
+before any claim is made.
+
 ### Generated structures write typed values directly across codecs
 
 `MEASURED` for JSON, CBOR, XML and proto. Codegen now attaches an

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -517,7 +517,7 @@ member list, it was likely worse than 4×.
 `OBSERVED`, and **the suite cannot see it**. Recorded as a negative result.
 
 Every write-path member writer called
-`TryCreateDefaultValue(member.TargetSchema, member.MemberTraits, out _)` for each
+`TryCreateDefaultValue(member.TypedTarget, member.MemberTraits, out _)` for each
 optional member that was null, re-entering trait resolution — two dictionary
 lookups — per member per object. Whether a member has a default, and what it is,
 are constant per member, exactly like the wire name was, so both are now resolved

--- a/benchmarks/contract/proto/GrpcBenchmarkService.proto
+++ b/benchmarks/contract/proto/GrpcBenchmarkService.proto
@@ -34,3 +34,4 @@ message ListItemsInput {
 message ListItemsOutput {
   repeated Item items = 1;
 }
+

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -219,21 +219,28 @@ public interface ITargetedMemberSchema<TValue> : IMemberSchema
 ```
 
 A structure member additionally reads and writes its value on a container,
-which a collection member cannot do. Those accessors therefore live on the
-structure member, not on every member:
+which a collection member cannot do. Those accessors live on the structure
+member, typed over the container and its builder, so a plan compiled for a
+member moves the value without boxing it. A consumer that only knows the
+container reaches the value type through the member's visitor, never through
+`object`:
 
 ```csharp
-public interface IStructMemberSchema : IMemberSchema
+public interface IMemberSchema<TContainer, TValue>
+    : IMemberSchema<TContainer>, ITargetedMemberSchema<TValue>
 {
-    object? GetObject(object container);
-    void SetObject(object builder, object? value);
+    TValue GetValue(TContainer container);
 }
 
 public interface IMemberSchema<TContainer, TBuilder, TValue>
-    : IMemberSchema<TContainer, TValue>
+    : IMemberSchema<TContainer, TValue>, IStructMemberSchema<TContainer, TBuilder>
 {
-    TValue GetValue(TContainer container);
     void SetValue(TBuilder builder, TValue value);
+}
+
+public interface IMemberVisitor<TContainer, TBuilder>
+{
+    void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member);
 }
 ```
 
@@ -294,10 +301,12 @@ stand-in.
 ### Projections
 
 REST protocols use projections to keep the same container type while narrowing
-the visible member set:
+the visible member set. A projection is a predicate over the source's members;
+it holds no member list of its own, and a codec compiled for it visits the
+source and skips what the predicate excludes:
 
 ```csharp
-var bodyProjection = Schemas.Project(inputSchema, bodyMembers);
+var bodyProjection = Schemas.Project(inputSchema, bodyMemberNames);
 ```
 
 The projection itself is just schema metadata: it says which members of the
@@ -357,11 +366,24 @@ plan, cached per (consumer, schema).
 The hot path executes only precompiled, monomorphized delegates: no boxing, no
 per-value trait lookup, no runtime type tests. Because plans are delegate
 composition rather than emitted IL, the same machinery runs under Native AOT.
+This holds for protocols as much as for codecs: a REST operation's labels,
+headers, query parameters and status code are each a plan compiled from the
+member and its value codec, and a member's `@default` is resolved once into a
+typed factory (`DefaultValues.TryCompile`) rather than re-read per object.
 
 Generic dispatch through the visitor is the *only* dispatch. Adding a consumer
-means writing one fold; adding a shape kind means every fold fails to compile
-until it handles the new case. Exhaustiveness is enforced by the type system
-rather than by runtime `default:` branches.
+means writing one fold. A fold that must handle every kind implements
+`ISchemaVisitor<TResult>` directly, so a new shape kind fails to compile until
+the fold handles it; a fold that admits only a few kinds derives from
+`SchemaVisitor<TResult>`, overrides those, and answers the rest through
+`VisitDefault`. Exhaustiveness is enforced by the type system rather than by
+runtime `default:` branches.
+
+A generated structure also carries an `IStructValueSerializer<T>`, which hands
+a writer its members' values straight from the generated properties, in
+declaration order, through a `struct` member writer. A writer that finds one
+skips the member getter delegates; one that does not, or that writes a
+projection, uses them. Both paths produce the same bytes.
 
 ## Shape–Schema Binding
 
@@ -468,7 +490,7 @@ Projection codecs are used when a protocol wants to serialize only a subset of
 the members of a structure while keeping the same container type:
 
 ```csharp
-var bodyProjection = Schemas.Project(inputSchema, bodyMembers);
+var bodyProjection = Schemas.Project(inputSchema, bodyMemberNames);
 var bodyCodec = JsonCodecFactory.Default.FromProjection(bodyProjection);
 var body = bodyCodec.Serialize(input);
 ```

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -212,9 +212,9 @@ consumer needs to compile anything per member. That is one interface, shared by
 structure members and by list elements and map keys and values alike:
 
 ```csharp
-public interface ITargetedMemberSchema<TValue> : IMemberSchema
+public interface ITypedTargetMemberSchema<TValue> : IMemberSchema
 {
-    Schema<TValue> TargetSchema { get; }
+    Schema<TValue> TypedTarget { get; }
 }
 ```
 
@@ -227,13 +227,13 @@ container reaches the value type through the member's visitor, never through
 
 ```csharp
 public interface IMemberSchema<TContainer, TValue>
-    : IMemberSchema<TContainer>, ITargetedMemberSchema<TValue>
+    : IMemberSchema<TContainer>, ITypedTargetMemberSchema<TValue>
 {
     TValue GetValue(TContainer container);
 }
 
 public interface IMemberSchema<TContainer, TBuilder, TValue>
-    : IMemberSchema<TContainer, TValue>, IStructMemberSchema<TContainer, TBuilder>
+    : IMemberSchema<TContainer, TValue>, IBuilderMemberSchema<TContainer, TBuilder>
 {
     void SetValue(TBuilder builder, TValue value);
 }
@@ -301,9 +301,10 @@ stand-in.
 ### Projections
 
 REST protocols use projections to keep the same container type while narrowing
-the visible member set. A projection is a predicate over the source's members;
-it holds no member list of its own, and a codec compiled for it visits the
-source and skips what the predicate excludes:
+the visible member set. A projection evaluates its selection once at
+construction and snapshots the matching member schemas. A codec compiled for
+it therefore sees a stable view even when the caller constructed the selection
+from a mutable set:
 
 ```csharp
 var bodyProjection = Schemas.Project(inputSchema, bodyMemberNames);
@@ -375,7 +376,7 @@ Generic dispatch through the visitor is the *only* dispatch. Adding a consumer
 means writing one fold. A fold that must handle every kind implements
 `ISchemaVisitor<TResult>` directly, so a new shape kind fails to compile until
 the fold handles it; a fold that admits only a few kinds derives from
-`SchemaVisitor<TResult>`, overrides those, and answers the rest through
+`PartialSchemaVisitor<TResult>`, overrides those, and answers the rest through
 `VisitDefault`. Exhaustiveness is enforced by the type system rather than by
 runtime `default:` branches.
 
@@ -460,7 +461,7 @@ public interface ICodecFactory
 {
     ICodec<T> FromSchema<T>(Schema<T> schema, CodecFactoryOptions? options = null);
     ICodec<T> FromMember<T>(
-        ITargetedMemberSchema<T> member,
+        ITypedTargetMemberSchema<T> member,
         CodecFactoryOptions? options = null
     );
 }

--- a/justfile
+++ b/justfile
@@ -45,6 +45,13 @@ test:
     cd codegen && gradle test
     dotnet test NSmithy.slnx --configuration Release --no-build --disable-build-servers
 
+# Publish and execute a representative typed REST operation as a native binary. This guards the
+
+# reflection-free/runtime-binder-free path separately from ordinary JIT tests.
+aot-smoke:
+    dotnet publish tests/AotSmoke/NSmithy.AotSmoke.csproj --configuration Release -p:PublishAot=true --output artifacts/aot-smoke --disable-build-servers
+    artifacts/aot-smoke/NSmithy.AotSmoke
+
 pack:
     cd codegen && gradle bundleMavenRepo ${VERSION:+-Pversion=$VERSION}
     find packages/NSmithy.MSBuild/tools/maven-repo -mindepth 1 -not -name .gitignore -delete
@@ -72,7 +79,7 @@ smoke-templates:
     # codegen rename breaks `dotnet new` while everything else stays green.
     bash templates/smoke-test.sh
 
-ci: check-format build test pack refresh-examples smoke-templates
+ci: check-format build test aot-smoke pack refresh-examples smoke-templates
 
 # The examples pin the fixed `0.0.0-SNAPSHOT` dev version permanently, while a release build packs
 # release-versioned packages, so NuGet resolves a version other than the pinned one and NU1603
@@ -81,7 +88,7 @@ ci: check-format build test pack refresh-examples smoke-templates
 # match what `just pack` produced.
 
 # What a release build runs: everything in `ci` except the examples refresh.
-release-ci: check-format build test pack
+release-ci: check-format build test aot-smoke pack
 
 bench-build:
     dotnet build benchmarks/Benchmarks.slnx --configuration Release

--- a/packages/NSmithy.Codecs.Cbor/CborReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Cbor/CborReaderCompiler.cs
@@ -44,7 +44,7 @@ internal sealed class CborReaderCompiler : ISchemaVisitor<object>
     {
         ArgumentNullException.ThrowIfNull(schema);
 
-        return cache.GetOrCompile<ICborValueReader<T>, DeferredCborValueReader<T>>(
+        return cache.GetOrCompile(
             schema,
             static () => new DeferredCborValueReader<T>(),
             target => (ICborValueReader<T>)target.Accept(this)
@@ -79,7 +79,7 @@ internal sealed class CborReaderCompiler : ISchemaVisitor<object>
         throw new NotSupportedException("Smithy Document values are not supported by rpcv2Cbor.");
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableCborValueReader<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableCborValueReader<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("CBOR codec does not support streaming blob schemas.");
@@ -269,7 +269,7 @@ internal sealed class CborMemberReaderCompiler<TContainer, TBuilder>(CborReaderC
         readers.Add(
             new CborMemberReader<TContainer, TBuilder, TValue>(
                 member,
-                compiler.CompileValue(member.TargetSchema)
+                compiler.CompileValue(member.TypedTarget)
             )
         );
     }
@@ -286,7 +286,7 @@ internal sealed class CborMemberReader<TContainer, TBuilder, TValue>(
 
     // Constant per member, so resolved at compile time rather than per missing member.
     private readonly Func<TValue>? defaultValue = CompileDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits
     );
 

--- a/packages/NSmithy.Codecs.Cbor/CborReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Cbor/CborReaderCompiler.cs
@@ -284,17 +284,17 @@ internal sealed class CborMemberReader<TContainer, TBuilder, TValue>(
 
     public bool IsRequired => member.IsRequired;
 
+    // Constant per member, so resolved at compile time rather than per missing member.
+    private readonly Func<TValue>? defaultValue = CompileDefault(
+        member.TargetSchema,
+        member.MemberTraits
+    );
+
     public void ReadMissing(TBuilder builder)
     {
-        if (
-            TryCreateDefaultValue(
-                member.TargetSchema,
-                member.MemberTraits,
-                out TValue? defaultValue
-            )
-        )
+        if (defaultValue is { } create)
         {
-            member.SetValue(builder, defaultValue!);
+            member.SetValue(builder, create());
         }
     }
 

--- a/packages/NSmithy.Codecs.Cbor/CborWire.cs
+++ b/packages/NSmithy.Codecs.Cbor/CborWire.cs
@@ -296,80 +296,24 @@ internal static class CborWire
         out T? value
     )
     {
-        if (
-            traits.ContainsKey(ClientOptionalTrait)
-            || !traits.TryGetValue(DefaultTrait, out var trait)
-            || trait.Value.Kind == DocumentKind.Null
-        )
+        if (CompileDefault(schema, traits) is { } create)
         {
-            value = default;
-            return false;
+            value = create();
+            return true;
         }
 
-        value = CreateDefaultValue(schema, trait.Value);
-        return value is not null;
+        value = default;
+        return false;
     }
 
-    internal static T? CreateDefaultValue<T>(Schema<T> schema, Document value)
-    {
-        var resolved = schema.Resolved;
-        if (resolved is INullableSchema nullable)
-        {
-            return (T?)CreateDefaultValue((dynamic)nullable.Target, value);
-        }
-
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (T)(object)value.AsBoolean(),
-            ShapeKind.Byte => (T)(object)(sbyte)value.AsNumber(),
-            ShapeKind.Short => (T)(object)(short)value.AsNumber(),
-            ShapeKind.Integer => (T)(object)(int)value.AsNumber(),
-            ShapeKind.Long => (T)(object)(long)value.AsNumber(),
-            ShapeKind.Float => (T)(object)(float)value.AsNumber(),
-            ShapeKind.Double => (T)(object)(double)value.AsNumber(),
-            ShapeKind.BigInteger => (T)(object)new BigInteger(value.AsNumber()),
-            ShapeKind.BigDecimal => (T)(object)value.AsNumber(),
-            ShapeKind.String => (T)(object)value.AsString(),
-            ShapeKind.Enum => (T)((IStringEnumSchema)resolved).CreateObject(value.AsString()),
-            ShapeKind.IntEnum => (T)((IIntEnumSchema)resolved).CreateObject((int)value.AsNumber()),
-            ShapeKind.Blob => (T)(object)Convert.FromBase64String(value.AsString()),
-            ShapeKind.Timestamp => (T)
-                (object)DateTimeOffset.FromUnixTimeSeconds((long)value.AsNumber()),
-            ShapeKind.Document => (T)(object)value,
-            ShapeKind.List or ShapeKind.Set when resolved is IListSchema list => CreateDefaultList(
-                (dynamic)list,
-                value
-            ),
-            ShapeKind.Map when resolved is IMapSchema map => CreateDefaultMap((dynamic)map, value),
-            _ => null,
-        };
-    }
-
-    internal static TCollection CreateDefaultList<TCollection, TElement, TBuilder>(
-        IListSchema<TCollection, TElement, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var item in value.AsArray())
-            schema.Add(builder, CreateDefaultValue(schema.TypedElementMember.TargetSchema, item)!);
-        return schema.Build(builder);
-    }
-
-    internal static TDictionary CreateDefaultMap<TDictionary, TValue, TBuilder>(
-        IMapSchema<TDictionary, TValue, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var entry in value.AsObject())
-            schema.Add(
-                builder,
-                entry.Key,
-                CreateDefaultValue(schema.TypedValueMember.TargetSchema, entry.Value)!
-            );
-        return schema.Build(builder);
-    }
+    /// <summary>The member's <c>@default</c> as a factory, or null when it has none.</summary>
+    internal static Func<T>? CompileDefault<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    ) =>
+        DefaultValues.TryCompile(schema, traits, honorClientOptional: true, out var create)
+            ? create
+            : null;
 
     internal static Schema UnwrapNullable(Schema schema)
     {

--- a/packages/NSmithy.Codecs.Cbor/CborWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Cbor/CborWriterCompiler.cs
@@ -49,7 +49,7 @@ internal sealed class CborWriterCompiler : ISchemaVisitor<object>
     {
         ArgumentNullException.ThrowIfNull(schema);
 
-        return cache.GetOrCompile<ICborValueWriter<T>, DeferredCborValueWriter<T>>(
+        return cache.GetOrCompile(
             schema,
             static () => new DeferredCborValueWriter<T>(),
             target => (ICborValueWriter<T>)target.Accept(this)
@@ -112,7 +112,7 @@ internal sealed class CborWriterCompiler : ISchemaVisitor<object>
         throw new NotSupportedException("Smithy Document values are not supported by rpcv2Cbor.");
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableCborValueWriter<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableCborValueWriter<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("CBOR codec does not support streaming blob schemas.");
@@ -238,7 +238,7 @@ internal sealed class CborMemberWriterCompiler<TContainer>(
 
         var plan = new CborMemberPlan<TValue>(
             member,
-            compiler.CompileValue(member.TargetSchema),
+            compiler.CompileValue(member.TypedTarget),
             materializeDefaults
         );
         plans.Add(plan);
@@ -264,7 +264,7 @@ internal sealed class CborMemberWriter<TContainer, TValue>(
 }
 
 internal sealed class CborMemberPlan<TValue>(
-    ITargetedMemberSchema<TValue> member,
+    ITypedTargetMemberSchema<TValue> member,
     ICborValueWriter<TValue> valueWriter,
     bool materializeDefault
 )
@@ -274,7 +274,7 @@ internal sealed class CborMemberPlan<TValue>(
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TValue? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );

--- a/packages/NSmithy.Codecs.Cbor/CompiledCborProjectionCodec.cs
+++ b/packages/NSmithy.Codecs.Cbor/CompiledCborProjectionCodec.cs
@@ -120,17 +120,17 @@ internal sealed class CborProjectionMemberReader<TContainer, TBuilder, TValue>(
 
     public bool IsRequired => member.IsRequired;
 
+    // Constant per member, so resolved at compile time rather than per missing member.
+    private readonly Func<TValue>? defaultValue = CompileDefault(
+        member.TargetSchema,
+        member.MemberTraits
+    );
+
     public void ReadMissing(TBuilder builder)
     {
-        if (
-            TryCreateDefaultValue(
-                member.TargetSchema,
-                member.MemberTraits,
-                out TValue? defaultValue
-            )
-        )
+        if (defaultValue is { } create)
         {
-            member.SetValue(builder, defaultValue!);
+            member.SetValue(builder, create());
         }
     }
 

--- a/packages/NSmithy.Codecs.Cbor/CompiledCborProjectionCodec.cs
+++ b/packages/NSmithy.Codecs.Cbor/CompiledCborProjectionCodec.cs
@@ -105,7 +105,7 @@ internal sealed class CborProjectionMemberReaderCompiler<TContainer, TBuilder>(
         readers.Add(
             new CborProjectionMemberReader<TContainer, TBuilder, TValue>(
                 member,
-                compiler.CompileValue(member.TargetSchema)
+                compiler.CompileValue(member.TypedTarget)
             )
         );
     }
@@ -122,7 +122,7 @@ internal sealed class CborProjectionMemberReader<TContainer, TBuilder, TValue>(
 
     // Constant per member, so resolved at compile time rather than per missing member.
     private readonly Func<TValue>? defaultValue = CompileDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits
     );
 

--- a/packages/NSmithy.Codecs.Json/JsonCodecFactory.cs
+++ b/packages/NSmithy.Codecs.Json/JsonCodecFactory.cs
@@ -25,14 +25,14 @@ public sealed class JsonCodecFactory(
     }
 
     public ICodec<T> FromMember<T>(
-        ITargetedMemberSchema<T> member,
+        ITypedTargetMemberSchema<T> member,
         CodecFactoryOptions? options = null
     )
     {
         ArgumentNullException.ThrowIfNull(member);
         var resolved = options ?? CodecFactoryOptions.Default;
         return new CompiledJsonCodec<T>(
-            member.TargetSchema,
+            member.TypedTarget,
             resolved.MaterializeTopLevelDefaults,
             readMode,
             honorJsonNameTrait,

--- a/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
@@ -66,7 +66,7 @@ internal sealed class JsonReaderCompiler(WireReadMode readMode, bool honorJsonNa
 
     public IJsonValueReader<T> CompileValue<T>(Schema<T> schema)
     {
-        return cache.GetOrCompile<IJsonValueReader<T>, DeferredJsonValueReader<T>>(
+        return cache.GetOrCompile(
             schema,
             static () => new DeferredJsonValueReader<T>(),
             target => CompileValueCore<T>(target)
@@ -148,7 +148,7 @@ internal sealed class JsonReaderCompiler(WireReadMode readMode, bool honorJsonNa
         where T : struct, Enum => CompileIntEnum(schema);
 
     private NullableJsonValueReader<T> CompileNullable<T>(NullableSchema<T> schema)
-        where T : struct => new(CompileValue(schema.TargetSchema));
+        where T : struct => new(CompileValue(schema.TypedTarget));
 
     private static StringEnumJsonValueReader<T> CompileStringEnum<T>(StringEnumSchema<T> schema)
         where T : IStringEnumValue<T> => new(schema);
@@ -177,7 +177,7 @@ internal sealed class JsonReaderCompiler(WireReadMode readMode, bool honorJsonNa
         new(
             schema,
             CompileValue(
-                schema.TypedElementMember.TargetSchema,
+                schema.TypedElementMember.TypedTarget,
                 schema.TypedElementMember.MemberTraits
             )
         );
@@ -189,7 +189,7 @@ internal sealed class JsonReaderCompiler(WireReadMode readMode, bool honorJsonNa
     >(IMapSchema<TDictionary, TValue, TBuilder> schema) =>
         new(
             schema,
-            CompileValue(schema.TypedValueMember.TargetSchema, schema.TypedValueMember.MemberTraits)
+            CompileValue(schema.TypedValueMember.TypedTarget, schema.TypedValueMember.MemberTraits)
         );
 
     private IJsonValueReader<T> CompileUnion<T>(IUnionSchema<T> schema)
@@ -257,7 +257,7 @@ internal sealed class MemberTraitJsonReaderCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableJsonValueReader<T>(inner.CompileValue(schema.TargetSchema, memberTraits));
+        new NullableJsonValueReader<T>(inner.CompileValue(schema.TypedTarget, memberTraits));
 
     public object VisitBoolean(Schema<bool> schema) => inner.CompileValue(schema);
 
@@ -320,7 +320,7 @@ internal sealed class JsonMemberReaderCompiler<TContainer, TBuilder>(JsonReaderC
         readers.Add(
             new JsonMemberReader<TContainer, TBuilder, TValue>(
                 member,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits),
+                compiler.CompileValue(member.TypedTarget, member.MemberTraits),
                 compiler.ResolveWireName(member.MemberTraits, member.Name)
             )
         );
@@ -339,7 +339,7 @@ internal sealed class JsonMemberReader<TContainer, TBuilder, TValue>(
 
     // Constant per member, so resolved at compile time rather than per missing member.
     private readonly Func<TValue>? defaultValue = CompileDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits
     );
 

--- a/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonReaderCompiler.cs
@@ -337,17 +337,17 @@ internal sealed class JsonMemberReader<TContainer, TBuilder, TValue>(
 
     public bool IsRequired => member.IsRequired;
 
+    // Constant per member, so resolved at compile time rather than per missing member.
+    private readonly Func<TValue>? defaultValue = CompileDefault(
+        member.TargetSchema,
+        member.MemberTraits
+    );
+
     public void ReadMissing(TBuilder builder)
     {
-        if (
-            TryCreateDefaultValue(
-                member.TargetSchema,
-                member.MemberTraits,
-                out TValue? defaultValue
-            )
-        )
+        if (defaultValue is { } create)
         {
-            member.SetValue(builder, defaultValue!);
+            member.SetValue(builder, create());
         }
     }
 

--- a/packages/NSmithy.Codecs.Json/JsonWire.cs
+++ b/packages/NSmithy.Codecs.Json/JsonWire.cs
@@ -8,7 +8,6 @@ namespace NSmithy.Codecs.Json;
 
 internal static class JsonWire
 {
-    private static readonly ShapeId ClientOptionalTrait = new("smithy.api", "clientOptional");
     private static readonly ShapeId DefaultTrait = new("smithy.api", "default");
     private static readonly ShapeId JsonNameTrait = new("smithy.api", "jsonName");
     private static readonly ShapeId SparseTrait = new("smithy.api", "sparse");
@@ -57,86 +56,24 @@ internal static class JsonWire
         out T? value
     )
     {
-        if (
-            traits.ContainsKey(ClientOptionalTrait)
-            || !traits.TryGetValue(DefaultTrait, out var trait)
-            || trait.Value.Kind == DocumentKind.Null
-        )
+        if (CompileDefault(schema, traits) is { } create)
         {
-            value = default;
-            return false;
+            value = create();
+            return true;
         }
 
-        value = CreateDefaultValue(schema, trait.Value);
-        return value is not null;
+        value = default;
+        return false;
     }
 
-    private static T? CreateDefaultValue<T>(Schema<T> schema, Document value)
-    {
-        var resolved = schema.Resolved;
-        if (resolved is INullableSchema nullable)
-        {
-            return (T?)CreateDefaultValue((dynamic)nullable.Target, value);
-        }
-
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (T)(object)value.AsBoolean(),
-            ShapeKind.Byte => (T)(object)(sbyte)value.AsNumber(),
-            ShapeKind.Short => (T)(object)(short)value.AsNumber(),
-            ShapeKind.Integer => (T)(object)(int)value.AsNumber(),
-            ShapeKind.Long => (T)(object)(long)value.AsNumber(),
-            ShapeKind.Float => (T)(object)(float)value.AsNumber(),
-            ShapeKind.Double => (T)(object)(double)value.AsNumber(),
-            ShapeKind.BigInteger => (T)(object)new BigInteger(value.AsNumber()),
-            ShapeKind.BigDecimal => (T)(object)value.AsNumber(),
-            ShapeKind.String => (T)(object)value.AsString(),
-            ShapeKind.Enum => (T)((IStringEnumSchema)resolved).CreateObject(value.AsString()),
-            ShapeKind.IntEnum => (T)((IIntEnumSchema)resolved).CreateObject((int)value.AsNumber()),
-            ShapeKind.Blob => (T)(object)Convert.FromBase64String(value.AsString()),
-            ShapeKind.Timestamp => (T)
-                (object)DateTimeOffset.FromUnixTimeSeconds((long)value.AsNumber()),
-            ShapeKind.Document => (T)(object)value,
-            ShapeKind.List or ShapeKind.Set when resolved is IListSchema list => CreateDefaultList(
-                (dynamic)list,
-                value
-            ),
-            ShapeKind.Map when resolved is IMapSchema map => CreateDefaultMap((dynamic)map, value),
-            _ => null,
-        };
-    }
-
-    private static TCollection CreateDefaultList<TCollection, TElement, TBuilder>(
-        IListSchema<TCollection, TElement, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var item in value.AsArray())
-        {
-            schema.Add(builder, CreateDefaultValue(schema.TypedElementMember.TargetSchema, item)!);
-        }
-
-        return schema.Build(builder);
-    }
-
-    private static TDictionary CreateDefaultMap<TDictionary, TValue, TBuilder>(
-        IMapSchema<TDictionary, TValue, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var entry in value.AsObject())
-        {
-            schema.Add(
-                builder,
-                entry.Key,
-                CreateDefaultValue(schema.TypedValueMember.TargetSchema, entry.Value)!
-            );
-        }
-
-        return schema.Build(builder);
-    }
+    /// <summary>The member's <c>@default</c> as a factory, or null when it has none.</summary>
+    internal static Func<T>? CompileDefault<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    ) =>
+        DefaultValues.TryCompile(schema, traits, honorClientOptional: true, out var create)
+            ? create
+            : null;
 
     internal static bool TryGetDiscriminatorName(IUnionSchema schema, out string discriminatorName)
     {

--- a/packages/NSmithy.Codecs.Json/JsonWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Json/JsonWriterCompiler.cs
@@ -68,7 +68,7 @@ internal sealed class JsonWriterCompiler(bool honorJsonNameTrait) : ISchemaVisit
 
     public IJsonValueWriter<T> CompileValue<T>(Schema<T> schema)
     {
-        return cache.GetOrCompile<IJsonValueWriter<T>, DeferredJsonValueWriter<T>>(
+        return cache.GetOrCompile(
             schema,
             static () => new DeferredJsonValueWriter<T>(),
             target => CompileValueCore<T>(target)
@@ -150,7 +150,7 @@ internal sealed class JsonWriterCompiler(bool honorJsonNameTrait) : ISchemaVisit
         where T : struct, Enum => CompileIntEnum(schema);
 
     internal NullableJsonValueWriter<T> CompileNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableJsonValueWriter<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableJsonValueWriter<T>(CompileValue(schema.TypedTarget));
 
     internal static StringEnumJsonValueWriter<T> CompileStringEnum<T>(StringEnumSchema<T> schema)
         where T : IStringEnumValue<T> => new StringEnumJsonValueWriter<T>();
@@ -202,7 +202,7 @@ internal sealed class JsonWriterCompiler(bool honorJsonNameTrait) : ISchemaVisit
         new ListJsonValueWriter<TCollection, TElement>(
             schema,
             CompileValue(
-                schema.TypedElementMember.TargetSchema,
+                schema.TypedElementMember.TypedTarget,
                 schema.TypedElementMember.MemberTraits
             )
         );
@@ -212,7 +212,7 @@ internal sealed class JsonWriterCompiler(bool honorJsonNameTrait) : ISchemaVisit
     ) =>
         new MapJsonValueWriter<TDictionary, TValue>(
             schema,
-            CompileValue(schema.TypedValueMember.TargetSchema, schema.TypedValueMember.MemberTraits)
+            CompileValue(schema.TypedValueMember.TypedTarget, schema.TypedValueMember.MemberTraits)
         );
 
     internal IJsonValueWriter<T> CompileUnion<T>(IUnionSchema<T> schema)
@@ -277,7 +277,7 @@ internal sealed class MemberTraitJsonWriterCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableJsonValueWriter<T>(inner.CompileValue(schema.TargetSchema, memberTraits));
+        new NullableJsonValueWriter<T>(inner.CompileValue(schema.TypedTarget, memberTraits));
 
     public object VisitBoolean(Schema<bool> schema) => inner.CompileValue(schema);
 
@@ -354,7 +354,7 @@ internal sealed class JsonMemberWriterCompiler<TContainer>(
 
         var plan = new JsonMemberPlan<TValue>(
             member,
-            compiler.CompileValue(member.TargetSchema, member.MemberTraits),
+            compiler.CompileValue(member.TypedTarget, member.MemberTraits),
             materializeDefaults,
             compiler.ResolveWireName(member.MemberTraits, member.Name)
         );
@@ -381,7 +381,7 @@ internal sealed class JsonMemberWriter<TContainer, TValue>(
 }
 
 internal sealed class JsonMemberPlan<TValue>(
-    ITargetedMemberSchema<TValue> member,
+    ITypedTargetMemberSchema<TValue> member,
     IJsonValueWriter<TValue> valueWriter,
     bool materializeDefault,
     string wireName
@@ -400,7 +400,7 @@ internal sealed class JsonMemberPlan<TValue>(
     // and what that default is, are constant per member. Previously every optional
     // member that happened to be null cost two more trait lookups per object.
     private readonly (bool Present, TValue? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );

--- a/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
@@ -149,15 +149,15 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
 
     public object VisitDouble(Schema<double> schema) => new DoubleProtoValueReader();
 
-    public object VisitBigInteger(Schema<BigInteger> schema) => Scalar(schema, EmptyTraits);
+    public object VisitBigInteger(Schema<BigInteger> schema) => new BigIntegerProtoValueReader();
 
-    public object VisitBigDecimal(Schema<decimal> schema) => Scalar(schema, EmptyTraits);
+    public object VisitBigDecimal(Schema<decimal> schema) => new BigDecimalProtoValueReader();
 
     public object VisitString(Schema<string> schema) => new StringProtoValueReader();
 
     public object VisitBlob(Schema<byte[]> schema) => new BlobProtoValueReader();
 
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) => Scalar(schema, EmptyTraits);
+    public object VisitTimestamp(Schema<DateTimeOffset> schema) => new TimestampProtoValueReader();
 
     public object VisitDocument(Schema<Document> schema) => new DocumentProtoValueReader();
 
@@ -200,15 +200,10 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
     }
 
     public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => Scalar(schema, EmptyTraits);
+        where T : IStringEnumValue<T> => new StringEnumProtoValueReader<T>(schema);
 
     public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => Scalar(schema, EmptyTraits);
-
-    private static ScalarProtoValueReader<T> Scalar<T>(
-        Schema<T> schema,
-        IReadOnlyDictionary<ShapeId, Trait> traits
-    ) => new(schema, traits);
+        where T : struct, Enum => new IntEnumProtoValueReader<T>(schema);
 
     private static object UnsupportedAggregateValue() =>
         throw new NotSupportedException(
@@ -314,18 +309,15 @@ internal sealed class MemberTraitProtoReaderCompiler(
 
     public object VisitDouble(Schema<double> schema) => new DoubleProtoValueReader();
 
-    public object VisitBigInteger(Schema<BigInteger> schema) =>
-        new ScalarProtoValueReader<BigInteger>(schema, traits);
+    public object VisitBigInteger(Schema<BigInteger> schema) => new BigIntegerProtoValueReader();
 
-    public object VisitBigDecimal(Schema<decimal> schema) =>
-        new ScalarProtoValueReader<decimal>(schema, traits);
+    public object VisitBigDecimal(Schema<decimal> schema) => new BigDecimalProtoValueReader();
 
     public object VisitString(Schema<string> schema) => new StringProtoValueReader();
 
     public object VisitBlob(Schema<byte[]> schema) => new BlobProtoValueReader();
 
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) =>
-        new ScalarProtoValueReader<DateTimeOffset>(schema, traits);
+    public object VisitTimestamp(Schema<DateTimeOffset> schema) => new TimestampProtoValueReader();
 
     public object VisitDocument(Schema<Document> schema) => inner.CompileValue(schema);
 
@@ -352,10 +344,10 @@ internal sealed class MemberTraitProtoReaderCompiler(
     public object VisitUnion<T>(IUnionSchema<T> schema) => inner.CompileValue((Schema<T>)schema);
 
     public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => new ScalarProtoValueReader<T>(schema, traits);
+        where T : IStringEnumValue<T> => new StringEnumProtoValueReader<T>(schema);
 
     public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => new ScalarProtoValueReader<T>(schema, traits);
+        where T : struct, Enum => new IntEnumProtoValueReader<T>(schema);
 }
 
 internal sealed class DeferredProtoValueReader<T>
@@ -456,56 +448,51 @@ internal sealed class BlobProtoValueReader : IProtoValueReader<byte[]>
         reader.ReadLengthDelimited().ToArray();
 }
 
-internal sealed class ScalarProtoValueReader<T>(
-    Schema<T> schema,
-    IReadOnlyDictionary<ShapeId, Trait> traits
-) : IProtoValueReader<T>
+internal sealed class BigIntegerProtoValueReader : IProtoValueReader<BigInteger>
 {
+    public BigInteger ReadBody(ref ProtoReader reader, WireType wireType) =>
+        BigInteger.Parse(
+            Encoding.UTF8.GetString(reader.ReadLengthDelimited()),
+            CultureInfo.InvariantCulture
+        );
+}
+
+internal sealed class BigDecimalProtoValueReader : IProtoValueReader<decimal>
+{
+    public decimal ReadBody(ref ProtoReader reader, WireType wireType) =>
+        decimal.Parse(
+            Encoding.UTF8.GetString(reader.ReadLengthDelimited()),
+            CultureInfo.InvariantCulture
+        );
+}
+
+internal sealed class TimestampProtoValueReader : IProtoValueReader<DateTimeOffset>
+{
+    public DateTimeOffset ReadBody(ref ProtoReader reader, WireType wireType) =>
+        ProtoWire.DecodeTimestamp(reader.ReadLengthDelimited());
+}
+
+internal sealed class StringEnumProtoValueReader<T>(StringEnumSchema<T> schema)
+    : IProtoValueReader<T>
+    where T : IStringEnumValue<T>
+{
+    private readonly string[] values = ProtoWire.EnumValues(schema);
+
+    // 0 is the synthetic proto UNSPECIFIED, which has no Smithy enum member.
     public T ReadBody(ref ProtoReader reader, WireType wireType)
     {
-        var resolved = ProtoWire.Unwrap(schema);
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (T)(object)(reader.ReadVarint() != 0),
-            ShapeKind.Byte => (T)
-                (object)(sbyte)ProtoWire.ReadInteger(ref reader, resolved.Kind, traits),
-            ShapeKind.Short => (T)
-                (object)(short)ProtoWire.ReadInteger(ref reader, resolved.Kind, traits),
-            ShapeKind.Integer => (T)
-                (object)(int)ProtoWire.ReadInteger(ref reader, resolved.Kind, traits),
-            ShapeKind.Long => (T)(object)ProtoWire.ReadInteger(ref reader, resolved.Kind, traits),
-            ShapeKind.Float => (T)(object)BitConverter.UInt32BitsToSingle(reader.ReadFixed32()),
-            ShapeKind.Double => (T)(object)BitConverter.UInt64BitsToDouble(reader.ReadFixed64()),
-            ShapeKind.String => (T)(object)Encoding.UTF8.GetString(reader.ReadLengthDelimited()),
-            ShapeKind.Blob => (T)(object)reader.ReadLengthDelimited().ToArray(),
-            ShapeKind.BigInteger => (T)
-                (object)
-                    BigInteger.Parse(
-                        Encoding.UTF8.GetString(reader.ReadLengthDelimited()),
-                        CultureInfo.InvariantCulture
-                    ),
-            ShapeKind.BigDecimal => (T)
-                (object)
-                    decimal.Parse(
-                        Encoding.UTF8.GetString(reader.ReadLengthDelimited()),
-                        CultureInfo.InvariantCulture
-                    ),
-            ShapeKind.IntEnum => (T)
-                ((IIntEnumSchema)resolved).CreateObject((int)reader.ReadVarint()),
-            ShapeKind.Timestamp => (T)
-                (object)ProtoWire.DecodeTimestamp(reader.ReadLengthDelimited()),
-            ShapeKind.Enum => ReadStringEnum(resolved, ref reader),
-            _ => throw new NotSupportedException(
-                $"Proto codec cannot decode schema kind '{resolved.Kind}' (wire type {wireType})."
-            ),
-        };
+        var ordinal = (int)reader.ReadVarint();
+        return ordinal > 0 && ordinal <= values.Length
+            ? schema.Create(values[ordinal - 1])
+            : default!;
     }
+}
 
-    private static T ReadStringEnum(Schema schema, ref ProtoReader reader)
-    {
-        var name = ProtoWire.EnumValueForOrdinal(schema, (int)reader.ReadVarint());
-        return name is null ? default! : (T)((IStringEnumSchema)schema).CreateObject(name);
-    }
+internal sealed class IntEnumProtoValueReader<T>(IntEnumSchema<T> schema) : IProtoValueReader<T>
+    where T : struct, Enum
+{
+    public T ReadBody(ref ProtoReader reader, WireType wireType) =>
+        schema.Create((int)reader.ReadVarint());
 }
 
 internal sealed class NullableProtoValueReader<T>(IProtoValueReader<T> inner)
@@ -543,36 +530,68 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
     public void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member)
     {
         var target = ProtoWire.Unwrap(member.TargetSchema);
-        if (target is IUnionSchema union && ProtoWire.IsInlinedUnion(target))
+        if (ProtoWire.IsInlinedUnion(target))
         {
-            AddInlinedOneOfReaders(member, (dynamic)union);
+            target.Accept(new InlinedOneOfCompiler<TValue>(this, member));
             return;
         }
 
         var fieldNumber = ProtoWire.FieldNumber(member.Id, member.MemberTraits, readers.Count);
-        readers.Add(
-            target switch
-            {
-                IListSchema list => CreateListReader(
-                    member,
-                    (dynamic)list,
-                    fieldNumber,
-                    stateSlotCount++
-                ),
-                IMapSchema map => CreateMapReader(
-                    member,
-                    (dynamic)map,
-                    fieldNumber,
-                    stateSlotCount++
-                ),
-                _ => new ValueProtoFieldReader<TContainer, TBuilder, TValue>(
-                    member,
-                    fieldNumber,
-                    compiler.CompileValue(member.TargetSchema, member.MemberTraits)
-                ),
-            }
-        );
+        readers.Add(target.Accept(new ReaderCompiler<TValue>(this, member, fieldNumber)));
     }
+
+    // A repeated or map field's element type only comes into scope by visiting the target.
+    private sealed class ReaderCompiler<TValue>(
+        ProtoFieldReaderCompiler<TContainer, TBuilder> owner,
+        IMemberSchema<TContainer, TBuilder, TValue> member,
+        int fieldNumber
+    ) : SchemaVisitor<IProtoFieldReader<TBuilder>>
+    {
+        public override IProtoFieldReader<TBuilder> VisitList<
+            TCollection,
+            TElement,
+            TCollectionBuilder
+        >(IListSchema<TCollection, TElement, TCollectionBuilder> schema) =>
+            owner.CreateListReader(
+                member,
+                (IListSchema<TValue, TElement, TCollectionBuilder>)(object)schema,
+                fieldNumber,
+                owner.stateSlotCount++
+            );
+
+        public override IProtoFieldReader<TBuilder> VisitMap<TDictionary, TMapValue, TMapBuilder>(
+            IMapSchema<TDictionary, TMapValue, TMapBuilder> schema
+        ) =>
+            owner.CreateMapReader(
+                member,
+                (IMapSchema<TValue, TMapValue, TMapBuilder>)(object)schema,
+                fieldNumber,
+                owner.stateSlotCount++
+            );
+
+        protected override IProtoFieldReader<TBuilder> VisitDefault(Schema schema) =>
+            owner.CreateValueReader(member, fieldNumber);
+    }
+
+    private sealed class InlinedOneOfCompiler<TValue>(
+        ProtoFieldReaderCompiler<TContainer, TBuilder> owner,
+        IMemberSchema<TContainer, TBuilder, TValue> member
+    ) : SchemaVisitor<object?>
+    {
+        public override object? VisitUnion<TUnion>(IUnionSchema<TUnion> schema)
+        {
+            owner.AddInlinedOneOfReaders(
+                (IMemberSchema<TContainer, TBuilder, TUnion>)(object)member,
+                schema
+            );
+            return null;
+        }
+    }
+
+    private ValueProtoFieldReader<TContainer, TBuilder, TValue> CreateValueReader<TValue>(
+        IMemberSchema<TContainer, TBuilder, TValue> member,
+        int fieldNumber
+    ) => new(member, fieldNumber, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
 
     private void AddInlinedOneOfReaders<TUnion>(
         IMemberSchema<TContainer, TBuilder, TUnion> member,

--- a/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoReaderCompiler.cs
@@ -124,7 +124,7 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
                 resolved.Accept(new MemberTraitProtoReaderCompiler(this, traits));
         }
 
-        return cache.GetOrCompile<IProtoValueReader<T>, DeferredProtoValueReader<T>>(
+        return cache.GetOrCompile(
             resolved,
             static () => new DeferredProtoValueReader<T>(),
             target => (IProtoValueReader<T>)target.Accept(this)
@@ -162,7 +162,7 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
     public object VisitDocument(Schema<Document> schema) => new DocumentProtoValueReader();
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableProtoValueReader<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableProtoValueReader<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("Proto codec does not support streaming blob schemas.");
@@ -212,50 +212,9 @@ internal sealed class ProtoValueReaderCompiler : ISchemaVisitor<object>
 }
 
 internal sealed class MessageReaderVisitor(ProtoValueReaderCompiler compiler)
-    : ISchemaVisitor<object>
+    : PartialSchemaVisitor<object>
 {
-    public object VisitBoolean(Schema<bool> schema) => Unsupported();
-
-    public object VisitByte(Schema<sbyte> schema) => Unsupported();
-
-    public object VisitShort(Schema<short> schema) => Unsupported();
-
-    public object VisitInteger(Schema<int> schema) => Unsupported();
-
-    public object VisitLong(Schema<long> schema) => Unsupported();
-
-    public object VisitFloat(Schema<float> schema) => Unsupported();
-
-    public object VisitDouble(Schema<double> schema) => Unsupported();
-
-    public object VisitBigInteger(Schema<BigInteger> schema) => Unsupported();
-
-    public object VisitBigDecimal(Schema<decimal> schema) => Unsupported();
-
-    public object VisitString(Schema<string> schema) => Unsupported();
-
-    public object VisitBlob(Schema<byte[]> schema) => Unsupported();
-
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) => Unsupported();
-
-    public object VisitDocument(Schema<Document> schema) => Unsupported();
-
-    public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => Unsupported();
-
-    public object VisitStreamingBlob(Schema<Stream> schema) => Unsupported();
-
-    public object VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) => Unsupported();
-
-    public object VisitList<TCollection, TElement, TBuilder>(
-        IListSchema<TCollection, TElement, TBuilder> schema
-    ) => Unsupported();
-
-    public object VisitMap<TDictionary, TValue, TBuilder>(
-        IMapSchema<TDictionary, TValue, TBuilder> schema
-    ) => Unsupported();
-
-    public object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
+    public override object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
     {
         var visitor = new ProtoFieldReaderCompiler<T, TBuilder>(compiler);
         schema.VisitMembers(visitor);
@@ -267,20 +226,14 @@ internal sealed class MessageReaderVisitor(ProtoValueReaderCompiler compiler)
         );
     }
 
-    public object VisitUnion<T>(IUnionSchema<T> schema)
+    public override object VisitUnion<T>(IUnionSchema<T> schema)
     {
         var visitor = new ProtoUnionCaseReaderCompiler<T>(compiler);
         schema.VisitCases(visitor);
         return new UnionProtoMessageReader<T>(visitor.Readers);
     }
 
-    public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => Unsupported();
-
-    public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => Unsupported();
-
-    private static object Unsupported() =>
+    protected override object VisitDefault(Schema schema) =>
         throw new InvalidOperationException(
             "Protobuf messages must be backed by a structure or union schema."
         );
@@ -323,7 +276,7 @@ internal sealed class MemberTraitProtoReaderCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableProtoValueReader<T>(inner.CompileValue(schema.TargetSchema, traits));
+        new NullableProtoValueReader<T>(inner.CompileValue(schema.TypedTarget, traits));
 
     public object VisitStreamingBlob(Schema<Stream> schema) => inner.CompileValue(schema);
 
@@ -529,7 +482,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
 
     public void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member)
     {
-        var target = ProtoWire.Unwrap(member.TargetSchema);
+        var target = ProtoWire.Unwrap(member.TypedTarget);
         if (ProtoWire.IsInlinedUnion(target))
         {
             target.Accept(new InlinedOneOfCompiler<TValue>(this, member));
@@ -545,7 +498,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
         ProtoFieldReaderCompiler<TContainer, TBuilder> owner,
         IMemberSchema<TContainer, TBuilder, TValue> member,
         int fieldNumber
-    ) : SchemaVisitor<IProtoFieldReader<TBuilder>>
+    ) : PartialSchemaVisitor<IProtoFieldReader<TBuilder>>
     {
         public override IProtoFieldReader<TBuilder> VisitList<
             TCollection,
@@ -576,7 +529,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
     private sealed class InlinedOneOfCompiler<TValue>(
         ProtoFieldReaderCompiler<TContainer, TBuilder> owner,
         IMemberSchema<TContainer, TBuilder, TValue> member
-    ) : SchemaVisitor<object?>
+    ) : PartialSchemaVisitor<object?>
     {
         public override object? VisitUnion<TUnion>(IUnionSchema<TUnion> schema)
         {
@@ -591,7 +544,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
     private ValueProtoFieldReader<TContainer, TBuilder, TValue> CreateValueReader<TValue>(
         IMemberSchema<TContainer, TBuilder, TValue> member,
         int fieldNumber
-    ) => new(member, fieldNumber, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
+    ) => new(member, fieldNumber, compiler.CompileValue(member.TypedTarget, member.MemberTraits));
 
     private void AddInlinedOneOfReaders<TUnion>(
         IMemberSchema<TContainer, TBuilder, TUnion> member,
@@ -624,7 +577,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
             fieldNumber,
             stateSlot,
             compiler.CompileValue(
-                list.TypedElementMember.TargetSchema,
+                list.TypedElementMember.TypedTarget,
                 list.TypedElementMember.MemberTraits
             )
         );
@@ -648,7 +601,7 @@ internal sealed class ProtoFieldReaderCompiler<TContainer, TBuilder>(
             stateSlot,
             ProtoWire.IsSparse((Schema)map),
             compiler.CompileValue(
-                map.TypedValueMember.TargetSchema,
+                map.TypedValueMember.TypedTarget,
                 map.TypedValueMember.MemberTraits
             )
         );
@@ -753,7 +706,7 @@ internal sealed class MapProtoFieldReader<TContainer, TBuilder, TDictionary, TVa
     public int FieldNumber { get; } = fieldNumber;
 
     private readonly SparseScalarValueReader<TValue> sparseReader = new(
-        map.TypedValueMember.TargetSchema
+        map.TypedValueMember.TypedTarget
     );
 
     public void ReadInto(

--- a/packages/NSmithy.Codecs.Proto/ProtoWire.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWire.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
@@ -551,25 +552,21 @@ internal static class ProtoWire
 
     // ---- string enum ordinals ----------------------------------------------
 
-    internal static int EnumOrdinal(Schema enumSchema, string value)
+    /// <summary>Each declared value's proto ordinal: declaration order, 1-based, 0 being UNSPECIFIED.</summary>
+    internal static FrozenDictionary<string, int> EnumOrdinals(Schema enumSchema)
     {
         var members = EnumMembers(enumSchema);
-        var index = members.IndexOf(value);
-        // Unknown / unmatched maps to the proto UNSPECIFIED = 0 default.
-        return index < 0 ? 0 : index + 1;
-    }
-
-    internal static string? EnumValueForOrdinal(Schema enumSchema, int ordinal)
-    {
-        if (ordinal <= 0)
+        var ordinals = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < members.Count; i++)
         {
-            // 0 is the synthetic proto UNSPECIFIED, which has no Smithy enum member.
-            return null;
+            ordinals.TryAdd(members[i], i + 1);
         }
 
-        var members = EnumMembers(enumSchema);
-        return ordinal - 1 < members.Count ? members[ordinal - 1] : null;
+        return ordinals.ToFrozenDictionary(StringComparer.Ordinal);
     }
+
+    /// <summary>The declared values by ordinal minus one.</summary>
+    internal static string[] EnumValues(Schema enumSchema) => [.. EnumMembers(enumSchema)];
 
     private static List<string> EnumMembers(Schema enumSchema)
     {

--- a/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
@@ -98,15 +99,15 @@ internal sealed class ProtoValueWriterCompiler : ISchemaVisitor<object>
 
     public object VisitDouble(Schema<double> schema) => new DoubleProtoValueWriter();
 
-    public object VisitBigInteger(Schema<BigInteger> schema) => Scalar(schema, EmptyTraits);
+    public object VisitBigInteger(Schema<BigInteger> schema) => new BigIntegerProtoValueWriter();
 
-    public object VisitBigDecimal(Schema<decimal> schema) => Scalar(schema, EmptyTraits);
+    public object VisitBigDecimal(Schema<decimal> schema) => new BigDecimalProtoValueWriter();
 
     public object VisitString(Schema<string> schema) => new StringProtoValueWriter();
 
     public object VisitBlob(Schema<byte[]> schema) => new BlobProtoValueWriter();
 
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) => Scalar(schema, EmptyTraits);
+    public object VisitTimestamp(Schema<DateTimeOffset> schema) => new TimestampProtoValueWriter();
 
     public object VisitDocument(Schema<Document> schema) => new DocumentProtoValueWriter();
 
@@ -142,15 +143,10 @@ internal sealed class ProtoValueWriterCompiler : ISchemaVisitor<object>
     }
 
     public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => Scalar(schema, EmptyTraits);
+        where T : IStringEnumValue<T> => new StringEnumProtoValueWriter<T>(schema);
 
     public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => Scalar(schema, EmptyTraits);
-
-    private static ScalarProtoValueWriter<T> Scalar<T>(
-        Schema<T> schema,
-        IReadOnlyDictionary<ShapeId, Trait> traits
-    ) => new(schema, traits);
+        where T : struct, Enum => new IntEnumProtoValueWriter<T>(schema);
 
     private static object UnsupportedAggregateValue() =>
         throw new NotSupportedException(
@@ -259,18 +255,15 @@ internal sealed class MemberTraitProtoWriterCompiler(
 
     public object VisitDouble(Schema<double> schema) => new DoubleProtoValueWriter();
 
-    public object VisitBigInteger(Schema<BigInteger> schema) =>
-        new ScalarProtoValueWriter<BigInteger>(schema, traits);
+    public object VisitBigInteger(Schema<BigInteger> schema) => new BigIntegerProtoValueWriter();
 
-    public object VisitBigDecimal(Schema<decimal> schema) =>
-        new ScalarProtoValueWriter<decimal>(schema, traits);
+    public object VisitBigDecimal(Schema<decimal> schema) => new BigDecimalProtoValueWriter();
 
     public object VisitString(Schema<string> schema) => new StringProtoValueWriter();
 
     public object VisitBlob(Schema<byte[]> schema) => new BlobProtoValueWriter();
 
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) =>
-        new ScalarProtoValueWriter<DateTimeOffset>(schema, traits);
+    public object VisitTimestamp(Schema<DateTimeOffset> schema) => new TimestampProtoValueWriter();
 
     public object VisitDocument(Schema<Document> schema) => inner.CompileValue(schema);
 
@@ -297,10 +290,10 @@ internal sealed class MemberTraitProtoWriterCompiler(
     public object VisitUnion<T>(IUnionSchema<T> schema) => inner.CompileValue((Schema<T>)schema);
 
     public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => new ScalarProtoValueWriter<T>(schema, traits);
+        where T : IStringEnumValue<T> => new StringEnumProtoValueWriter<T>(schema);
 
     public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => new ScalarProtoValueWriter<T>(schema, traits);
+        where T : struct, Enum => new IntEnumProtoValueWriter<T>(schema);
 }
 
 internal sealed class DeferredProtoValueWriter<T>
@@ -422,81 +415,57 @@ internal sealed class BlobProtoValueWriter : IProtoValueWriter<byte[]>
     public void WriteBody(ProtoWriter writer, byte[] value) => writer.WriteLengthDelimited(value);
 }
 
-internal sealed class ScalarProtoValueWriter<T>(
-    Schema<T> schema,
-    IReadOnlyDictionary<ShapeId, Trait> traits
-) : IProtoValueWriter<T>
+internal sealed class BigIntegerProtoValueWriter : IProtoValueWriter<BigInteger>
 {
-    public WireType WireType { get; } = ProtoWire.WireTypeOf(ProtoWire.Unwrap(schema).Kind, traits);
+    public WireType WireType => WireType.Len;
 
-    public void WriteBody(ProtoWriter writer, T value)
+    public void WriteBody(ProtoWriter writer, BigInteger value) =>
+        writer.WriteLengthDelimitedUtf8(value.ToString(CultureInfo.InvariantCulture));
+}
+
+internal sealed class BigDecimalProtoValueWriter : IProtoValueWriter<decimal>
+{
+    public WireType WireType => WireType.Len;
+
+    public void WriteBody(ProtoWriter writer, decimal value) =>
+        writer.WriteLengthDelimitedUtf8(value.ToString(CultureInfo.InvariantCulture));
+}
+
+internal sealed class TimestampProtoValueWriter : IProtoValueWriter<DateTimeOffset>
+{
+    public WireType WireType => WireType.Len;
+
+    public void WriteBody(ProtoWriter writer, DateTimeOffset value)
     {
-        var resolved = ProtoWire.Unwrap(schema);
-        switch (resolved.Kind)
-        {
-            case ShapeKind.Boolean:
-                writer.WriteVarint((bool)(object)value! ? 1UL : 0UL);
-                break;
-            case ShapeKind.Byte:
-                ProtoWire.WriteInteger(writer, resolved.Kind, traits, (sbyte)(object)value!);
-                break;
-            case ShapeKind.Short:
-                ProtoWire.WriteInteger(writer, resolved.Kind, traits, (short)(object)value!);
-                break;
-            case ShapeKind.Integer:
-                ProtoWire.WriteInteger(writer, resolved.Kind, traits, (int)(object)value!);
-                break;
-            case ShapeKind.Long:
-                ProtoWire.WriteInteger(writer, resolved.Kind, traits, (long)(object)value!);
-                break;
-            case ShapeKind.Float:
-                writer.WriteFixed32(BitConverter.SingleToUInt32Bits((float)(object)value!));
-                break;
-            case ShapeKind.Double:
-                writer.WriteFixed64(BitConverter.DoubleToUInt64Bits((double)(object)value!));
-                break;
-            case ShapeKind.String:
-                writer.WriteLengthDelimitedUtf8((string)(object)value!);
-                break;
-            case ShapeKind.Blob:
-                writer.WriteLengthDelimited((byte[])(object)value!);
-                break;
-            case ShapeKind.BigInteger:
-                writer.WriteLengthDelimitedUtf8(
-                    ((BigInteger)(object)value!).ToString(CultureInfo.InvariantCulture)
-                );
-                break;
-            case ShapeKind.BigDecimal:
-                writer.WriteLengthDelimitedUtf8(
-                    ((decimal)(object)value!).ToString(CultureInfo.InvariantCulture)
-                );
-                break;
-            case ShapeKind.IntEnum:
-                writer.WriteVarint(
-                    (ulong)(long)((IIntEnumSchema)resolved).GetIntegerValueObject(value!)
-                );
-                break;
-            case ShapeKind.Timestamp:
-                var timestamp = writer.BeginLengthDelimited();
-                ProtoWire.EncodeTimestamp(writer, (DateTimeOffset)(object)value!);
-                writer.EndLengthDelimited(timestamp);
-                break;
-            case ShapeKind.Enum:
-                writer.WriteVarint(
-                    (ulong)
-                        (long)
-                            ProtoWire.EnumOrdinal(
-                                resolved,
-                                ((IStringEnumValue)(object)value!).Value
-                            )
-                );
-                break;
-            default:
-                throw new NotSupportedException(
-                    $"Proto codec cannot encode schema kind '{resolved.Kind}'."
-                );
-        }
+        var prefix = writer.BeginLengthDelimited();
+        ProtoWire.EncodeTimestamp(writer, value);
+        writer.EndLengthDelimited(prefix);
     }
+}
+
+/// <summary>A string enum is a proto enum whose ordinals follow the model's declaration order.</summary>
+internal sealed class StringEnumProtoValueWriter<T>(StringEnumSchema<T> schema)
+    : IProtoValueWriter<T>
+    where T : IStringEnumValue<T>
+{
+    private readonly FrozenDictionary<string, int> ordinals = ProtoWire.EnumOrdinals(schema);
+
+    public WireType WireType => WireType.Varint;
+
+    // Unknown / unmatched maps to the proto UNSPECIFIED = 0 default.
+    public void WriteBody(ProtoWriter writer, T value) =>
+        writer.WriteVarint(
+            (ulong)(long)(ordinals.TryGetValue(value.Value, out var ordinal) ? ordinal : 0)
+        );
+}
+
+internal sealed class IntEnumProtoValueWriter<T>(IntEnumSchema<T> schema) : IProtoValueWriter<T>
+    where T : struct, Enum
+{
+    public WireType WireType => WireType.Varint;
+
+    public void WriteBody(ProtoWriter writer, T value) =>
+        writer.WriteVarint((ulong)(long)schema.GetIntegerValue(value));
 }
 
 internal sealed class NullableProtoValueWriter<T>(IProtoValueWriter<T> inner)
@@ -552,25 +521,53 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
     public void Visit<TValue>(IMemberSchema<TContainer, TValue> member)
     {
         var target = ProtoWire.Unwrap(member.TargetSchema);
-        if (target is IUnionSchema union && ProtoWire.IsInlinedUnion(target))
+        if (ProtoWire.IsInlinedUnion(target))
         {
-            AddInlinedOneOfPlan(member, (dynamic)union);
+            target.Accept(new InlinedOneOfCompiler<TValue>(this, member));
             return;
         }
 
         var fieldNumber = ProtoWire.FieldNumber(member.Id, member.MemberTraits, writers.Count);
-        IProtoMemberPlan<TValue> plan = target switch
-        {
-            IListSchema list => CreateListPlan((dynamic)list, fieldNumber),
-            IMapSchema map => CreateMapPlan((dynamic)map, fieldNumber),
-            _ => new ValueProtoMemberPlan<TValue>(
-                fieldNumber,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits)
-            ),
-        };
+        var plan = target.Accept(new PlanCompiler<TValue>(this, member, fieldNumber));
         plans.Add(plan);
         writers.Add(new ProtoMemberWriter<TContainer, TValue>(member, plan));
     }
+
+    // A repeated or map field's element type only comes into scope by visiting the target.
+    private sealed class PlanCompiler<TValue>(
+        ProtoMemberWriterCompiler<TContainer> owner,
+        IMemberSchema<TContainer, TValue> member,
+        int fieldNumber
+    ) : SchemaVisitor<IProtoMemberPlan<TValue>>
+    {
+        public override IProtoMemberPlan<TValue> VisitList<TCollection, TElement, TBuilder>(
+            IListSchema<TCollection, TElement, TBuilder> schema
+        ) => owner.CreateListPlan((IListSchema<TValue, TElement>)(object)schema, fieldNumber);
+
+        public override IProtoMemberPlan<TValue> VisitMap<TDictionary, TMapValue, TBuilder>(
+            IMapSchema<TDictionary, TMapValue, TBuilder> schema
+        ) => owner.CreateMapPlan((IMapSchema<TValue, TMapValue>)(object)schema, fieldNumber);
+
+        protected override IProtoMemberPlan<TValue> VisitDefault(Schema schema) =>
+            owner.CreateValuePlan(member, fieldNumber);
+    }
+
+    private sealed class InlinedOneOfCompiler<TValue>(
+        ProtoMemberWriterCompiler<TContainer> owner,
+        IMemberSchema<TContainer, TValue> member
+    ) : SchemaVisitor<object?>
+    {
+        public override object? VisitUnion<TUnion>(IUnionSchema<TUnion> schema)
+        {
+            owner.AddInlinedOneOfPlan((IMemberSchema<TContainer, TUnion>)(object)member, schema);
+            return null;
+        }
+    }
+
+    private ValueProtoMemberPlan<TValue> CreateValuePlan<TValue>(
+        IMemberSchema<TContainer, TValue> member,
+        int fieldNumber
+    ) => new(fieldNumber, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
 
     private void AddInlinedOneOfPlan<TUnion>(
         IMemberSchema<TContainer, TUnion> member,

--- a/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Proto/ProtoWriterCompiler.cs
@@ -74,7 +74,7 @@ internal sealed class ProtoValueWriterCompiler : ISchemaVisitor<object>
                 resolved.Accept(new MemberTraitProtoWriterCompiler(this, traits));
         }
 
-        return cache.GetOrCompile<IProtoValueWriter<T>, DeferredProtoValueWriter<T>>(
+        return cache.GetOrCompile(
             resolved,
             static () => new DeferredProtoValueWriter<T>(),
             target => (IProtoValueWriter<T>)target.Accept(this)
@@ -112,7 +112,7 @@ internal sealed class ProtoValueWriterCompiler : ISchemaVisitor<object>
     public object VisitDocument(Schema<Document> schema) => new DocumentProtoValueWriter();
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableProtoValueWriter<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableProtoValueWriter<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("Proto codec does not support streaming blob schemas.");
@@ -163,70 +163,23 @@ internal sealed class ProtoValueWriterCompiler : ISchemaVisitor<object>
 }
 
 internal sealed class MessageWriterVisitor(ProtoValueWriterCompiler compiler)
-    : ISchemaVisitor<object>
+    : PartialSchemaVisitor<object>
 {
-    public object VisitBoolean(Schema<bool> schema) => Unsupported();
-
-    public object VisitByte(Schema<sbyte> schema) => Unsupported();
-
-    public object VisitShort(Schema<short> schema) => Unsupported();
-
-    public object VisitInteger(Schema<int> schema) => Unsupported();
-
-    public object VisitLong(Schema<long> schema) => Unsupported();
-
-    public object VisitFloat(Schema<float> schema) => Unsupported();
-
-    public object VisitDouble(Schema<double> schema) => Unsupported();
-
-    public object VisitBigInteger(Schema<BigInteger> schema) => Unsupported();
-
-    public object VisitBigDecimal(Schema<decimal> schema) => Unsupported();
-
-    public object VisitString(Schema<string> schema) => Unsupported();
-
-    public object VisitBlob(Schema<byte[]> schema) => Unsupported();
-
-    public object VisitTimestamp(Schema<DateTimeOffset> schema) => Unsupported();
-
-    public object VisitDocument(Schema<Document> schema) => Unsupported();
-
-    public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => Unsupported();
-
-    public object VisitStreamingBlob(Schema<Stream> schema) => Unsupported();
-
-    public object VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) => Unsupported();
-
-    public object VisitList<TCollection, TElement, TBuilder>(
-        IListSchema<TCollection, TElement, TBuilder> schema
-    ) => Unsupported();
-
-    public object VisitMap<TDictionary, TValue, TBuilder>(
-        IMapSchema<TDictionary, TValue, TBuilder> schema
-    ) => Unsupported();
-
-    public object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
+    public override object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
     {
         var visitor = new ProtoMemberWriterCompiler<T>(compiler);
         schema.VisitMembers(visitor);
         return ProtoValueWriterCompiler.CreateStructureWriter(schema, visitor);
     }
 
-    public object VisitUnion<T>(IUnionSchema<T> schema)
+    public override object VisitUnion<T>(IUnionSchema<T> schema)
     {
         var visitor = new ProtoUnionCaseWriterCompiler<T>(compiler);
         schema.VisitCases(visitor);
         return new UnionProtoMessageWriter<T>(visitor.Writers);
     }
 
-    public object VisitStringEnum<T>(StringEnumSchema<T> schema)
-        where T : IStringEnumValue<T> => Unsupported();
-
-    public object VisitIntEnum<T>(IntEnumSchema<T> schema)
-        where T : struct, Enum => Unsupported();
-
-    private static object Unsupported() =>
+    protected override object VisitDefault(Schema schema) =>
         throw new InvalidOperationException(
             "Protobuf messages must be backed by a structure or union schema."
         );
@@ -269,7 +222,7 @@ internal sealed class MemberTraitProtoWriterCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableProtoValueWriter<T>(inner.CompileValue(schema.TargetSchema, traits));
+        new NullableProtoValueWriter<T>(inner.CompileValue(schema.TypedTarget, traits));
 
     public object VisitStreamingBlob(Schema<Stream> schema) => inner.CompileValue(schema);
 
@@ -520,7 +473,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
 
     public void Visit<TValue>(IMemberSchema<TContainer, TValue> member)
     {
-        var target = ProtoWire.Unwrap(member.TargetSchema);
+        var target = ProtoWire.Unwrap(member.TypedTarget);
         if (ProtoWire.IsInlinedUnion(target))
         {
             target.Accept(new InlinedOneOfCompiler<TValue>(this, member));
@@ -538,7 +491,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
         ProtoMemberWriterCompiler<TContainer> owner,
         IMemberSchema<TContainer, TValue> member,
         int fieldNumber
-    ) : SchemaVisitor<IProtoMemberPlan<TValue>>
+    ) : PartialSchemaVisitor<IProtoMemberPlan<TValue>>
     {
         public override IProtoMemberPlan<TValue> VisitList<TCollection, TElement, TBuilder>(
             IListSchema<TCollection, TElement, TBuilder> schema
@@ -555,7 +508,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
     private sealed class InlinedOneOfCompiler<TValue>(
         ProtoMemberWriterCompiler<TContainer> owner,
         IMemberSchema<TContainer, TValue> member
-    ) : SchemaVisitor<object?>
+    ) : PartialSchemaVisitor<object?>
     {
         public override object? VisitUnion<TUnion>(IUnionSchema<TUnion> schema)
         {
@@ -567,7 +520,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
     private ValueProtoMemberPlan<TValue> CreateValuePlan<TValue>(
         IMemberSchema<TContainer, TValue> member,
         int fieldNumber
-    ) => new(fieldNumber, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
+    ) => new(fieldNumber, compiler.CompileValue(member.TypedTarget, member.MemberTraits));
 
     private void AddInlinedOneOfPlan<TUnion>(
         IMemberSchema<TContainer, TUnion> member,
@@ -589,7 +542,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
             list,
             fieldNumber,
             compiler.CompileValue(
-                list.TypedElementMember.TargetSchema,
+                list.TypedElementMember.TypedTarget,
                 list.TypedElementMember.MemberTraits
             )
         );
@@ -603,7 +556,7 @@ internal sealed class ProtoMemberWriterCompiler<TContainer>(ProtoValueWriterComp
             fieldNumber,
             ProtoWire.IsSparse((Schema)map),
             compiler.CompileValue(
-                map.TypedValueMember.TargetSchema,
+                map.TypedValueMember.TypedTarget,
                 map.TypedValueMember.MemberTraits
             )
         );
@@ -693,7 +646,7 @@ internal sealed class MapProtoMemberPlan<TDictionary, TValue>(
 ) : IProtoMemberPlan<TDictionary>
 {
     private readonly SparseScalarValueWriter<TValue> sparseWriter = new(
-        map.TypedValueMember.TargetSchema
+        map.TypedValueMember.TypedTarget
     );
     private readonly WireType valueWireType = valueWriter.WireType;
 

--- a/packages/NSmithy.Codecs.Xml/XmlCodecFactory.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlCodecFactory.cs
@@ -26,14 +26,14 @@ public sealed class XmlCodecFactory(
     }
 
     public ICodec<T> FromMember<T>(
-        ITargetedMemberSchema<T> member,
+        ITypedTargetMemberSchema<T> member,
         CodecFactoryOptions? options = null
     )
     {
         ArgumentNullException.ThrowIfNull(member);
         var resolved = options ?? CodecFactoryOptions.Default;
         return new CompiledXmlCodec<T>(
-            member.TargetSchema,
+            member.TypedTarget,
             resolved.MaterializeTopLevelDefaults,
             member.MemberTraits,
             defaultNamespaceUri,

--- a/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
@@ -75,7 +75,7 @@ internal sealed class XmlReaderCompiler : ISchemaVisitor<object>
                 resolved.Accept(new MemberTraitXmlReaderCompiler(this, memberTraits));
         }
 
-        return cache.GetOrCompile<IXmlValueReader<T>, DeferredXmlValueReader<T>>(
+        return cache.GetOrCompile(
             resolved,
             static () => new DeferredXmlValueReader<T>(),
             target => (IXmlValueReader<T>)target.Accept(this)
@@ -110,7 +110,7 @@ internal sealed class XmlReaderCompiler : ISchemaVisitor<object>
         throw new NotSupportedException("Smithy Document values are not supported in XML.");
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableXmlValueReader<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableXmlValueReader<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("XML codec does not support streaming blob schemas.");
@@ -124,7 +124,7 @@ internal sealed class XmlReaderCompiler : ISchemaVisitor<object>
         new ListXmlValueReader<TCollection, TElement, TBuilder>(
             schema,
             CompileValue(
-                schema.TypedElementMember.TargetSchema,
+                schema.TypedElementMember.TypedTarget,
                 schema.TypedElementMember.MemberTraits
             )
         );
@@ -134,7 +134,7 @@ internal sealed class XmlReaderCompiler : ISchemaVisitor<object>
     ) =>
         new MapXmlValueReader<TDictionary, TValue, TBuilder>(
             schema,
-            CompileValue(schema.TypedValueMember.TargetSchema, schema.TypedValueMember.MemberTraits)
+            CompileValue(schema.TypedValueMember.TypedTarget, schema.TypedValueMember.MemberTraits)
         );
 
     public object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
@@ -237,7 +237,7 @@ internal sealed class MemberTraitXmlReaderCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableXmlValueReader<T>(inner.CompileValue(schema.TargetSchema, memberTraits));
+        new NullableXmlValueReader<T>(inner.CompileValue(schema.TypedTarget, memberTraits));
 
     public object VisitStreamingBlob(Schema<Stream> schema) => inner.CompileValue(schema);
 
@@ -298,21 +298,21 @@ internal sealed class XmlMemberReaderCompiler<TContainer, TBuilder>(XmlReaderCom
         readers.Add(
             new XmlMemberReader<TContainer, TBuilder, TValue>(
                 member,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits)
+                compiler.CompileValue(member.TypedTarget, member.MemberTraits)
             )
         );
     }
 
     private IXmlMemberReader<TBuilder> CreateFlattenedReader<TValue>(
         IMemberSchema<TContainer, TBuilder, TValue> member
-    ) => member.TargetSchema.Resolved.Accept(new FlattenedReaderCompiler<TValue>(this, member));
+    ) => member.TypedTarget.Resolved.Accept(new FlattenedReaderCompiler<TValue>(this, member));
 
     // A flattened member targets a list or map whose element type only comes into scope by
     // visiting it; anything else flattens to a plain member.
     private sealed class FlattenedReaderCompiler<TValue>(
         XmlMemberReaderCompiler<TContainer, TBuilder> owner,
         IMemberSchema<TContainer, TBuilder, TValue> member
-    ) : SchemaVisitor<IXmlMemberReader<TBuilder>>
+    ) : PartialSchemaVisitor<IXmlMemberReader<TBuilder>>
     {
         public override IXmlMemberReader<TBuilder> VisitList<
             TCollection,
@@ -341,7 +341,7 @@ internal sealed class XmlMemberReaderCompiler<TContainer, TBuilder>(XmlReaderCom
         TBuilder,
         TValue
     > CreateFlattenedValueReader<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member) =>
-        new(member, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
+        new(member, compiler.CompileValue(member.TypedTarget, member.MemberTraits));
 
     private FlattenedListXmlMemberReader<
         TContainer,
@@ -357,7 +357,7 @@ internal sealed class XmlMemberReaderCompiler<TContainer, TBuilder>(XmlReaderCom
             member,
             list,
             compiler.CompileValue(
-                list.TypedElementMember.TargetSchema,
+                list.TypedElementMember.TypedTarget,
                 list.TypedElementMember.MemberTraits
             )
         );
@@ -376,7 +376,7 @@ internal sealed class XmlMemberReaderCompiler<TContainer, TBuilder>(XmlReaderCom
             member,
             map,
             compiler.CompileValue(
-                map.TypedValueMember.TargetSchema,
+                map.TypedValueMember.TypedTarget,
                 map.TypedValueMember.MemberTraits
             )
         );
@@ -388,7 +388,7 @@ internal sealed class XmlMemberReader<TContainer, TBuilder, TValue>(
 ) : IXmlMemberReader<TBuilder>
 {
     private readonly IXmlScalar<TValue>? attribute = XmlTraits.IsXmlAttribute(member)
-        ? XmlScalars.Compile(member.TargetSchema, member.MemberTraits)
+        ? XmlScalars.Compile(member.TypedTarget, member.MemberTraits)
         : null;
 
     public string Name => ElementName(member);

--- a/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlReaderCompiler.cs
@@ -269,7 +269,9 @@ internal sealed class ScalarXmlValueReader<T>(
     IReadOnlyDictionary<ShapeId, Trait> traits
 ) : IXmlValueReader<T>
 {
-    public T Read(XElement? element) => ReadScalar(schema, traits, element?.Value ?? string.Empty);
+    private readonly IXmlScalar<T> scalar = XmlScalars.Compile(schema, traits);
+
+    public T Read(XElement? element) => scalar.Parse(element?.Value ?? string.Empty);
 }
 
 internal sealed class NullableXmlValueReader<T>(IXmlValueReader<T> inner) : IXmlValueReader<T?>
@@ -303,19 +305,43 @@ internal sealed class XmlMemberReaderCompiler<TContainer, TBuilder>(XmlReaderCom
 
     private IXmlMemberReader<TBuilder> CreateFlattenedReader<TValue>(
         IMemberSchema<TContainer, TBuilder, TValue> member
-    )
+    ) => member.TargetSchema.Resolved.Accept(new FlattenedReaderCompiler<TValue>(this, member));
+
+    // A flattened member targets a list or map whose element type only comes into scope by
+    // visiting it; anything else flattens to a plain member.
+    private sealed class FlattenedReaderCompiler<TValue>(
+        XmlMemberReaderCompiler<TContainer, TBuilder> owner,
+        IMemberSchema<TContainer, TBuilder, TValue> member
+    ) : SchemaVisitor<IXmlMemberReader<TBuilder>>
     {
-        var target = member.TargetSchema.Resolved;
-        return target switch
-        {
-            IListSchema list => CreateFlattenedListReader(member, (dynamic)list),
-            IMapSchema map => CreateFlattenedMapReader(member, (dynamic)map),
-            _ => new FlattenedXmlMemberReader<TContainer, TBuilder, TValue>(
+        public override IXmlMemberReader<TBuilder> VisitList<
+            TCollection,
+            TElement,
+            TCollectionBuilder
+        >(IListSchema<TCollection, TElement, TCollectionBuilder> schema) =>
+            owner.CreateFlattenedListReader(
                 member,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits)
-            ),
-        };
+                (IListSchema<TValue, TElement, TCollectionBuilder>)(object)schema
+            );
+
+        public override IXmlMemberReader<TBuilder> VisitMap<TDictionary, TMapValue, TMapBuilder>(
+            IMapSchema<TDictionary, TMapValue, TMapBuilder> schema
+        ) =>
+            owner.CreateFlattenedMapReader(
+                member,
+                (IMapSchema<TValue, TMapValue, TMapBuilder>)(object)schema
+            );
+
+        protected override IXmlMemberReader<TBuilder> VisitDefault(Schema schema) =>
+            owner.CreateFlattenedValueReader(member);
     }
+
+    private FlattenedXmlMemberReader<
+        TContainer,
+        TBuilder,
+        TValue
+    > CreateFlattenedValueReader<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member) =>
+        new(member, compiler.CompileValue(member.TargetSchema, member.MemberTraits));
 
     private FlattenedListXmlMemberReader<
         TContainer,
@@ -361,6 +387,10 @@ internal sealed class XmlMemberReader<TContainer, TBuilder, TValue>(
     IXmlValueReader<TValue> valueReader
 ) : IXmlMemberReader<TBuilder>
 {
+    private readonly IXmlScalar<TValue>? attribute = XmlTraits.IsXmlAttribute(member)
+        ? XmlScalars.Compile(member.TargetSchema, member.MemberTraits)
+        : null;
+
     public string Name => ElementName(member);
 
     public bool IsRequired => member.IsRequired;
@@ -372,10 +402,7 @@ internal sealed class XmlMemberReader<TContainer, TBuilder, TValue>(
             var attr = element.Attribute(AttributeName(element, Name));
             if (attr is not null)
             {
-                member.SetValue(
-                    builder,
-                    ReadScalar(member.TargetSchema, member.MemberTraits, attr.Value)
-                );
+                member.SetValue(builder, attribute!.Parse(attr.Value));
             }
             else if (member.IsRequired)
             {

--- a/packages/NSmithy.Codecs.Xml/XmlScalars.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlScalars.cs
@@ -22,7 +22,7 @@ internal static class XmlScalars
     ) => (IXmlScalar<T>)schema.Resolved.Accept(new Compiler(traits));
 
     private sealed class Compiler(IReadOnlyDictionary<ShapeId, Trait>? traits)
-        : SchemaVisitor<object>
+        : PartialSchemaVisitor<object>
     {
         public override object VisitBoolean(Schema<bool> schema) =>
             new Scalar<bool>(
@@ -93,7 +93,7 @@ internal static class XmlScalars
             };
 
         public override object VisitNullable<T>(NullableSchema<T> schema) =>
-            new NullableScalar<T>((IXmlScalar<T>)schema.TargetSchema.Resolved.Accept(this));
+            new NullableScalar<T>((IXmlScalar<T>)schema.TypedTarget.Resolved.Accept(this));
 
         public override object VisitStringEnum<T>(StringEnumSchema<T> schema) =>
             new Scalar<T>(static value => value.Value, schema.Create);

--- a/packages/NSmithy.Codecs.Xml/XmlScalars.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlScalars.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using System.Numerics;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Codecs.Xml;
+
+/// <summary>The text form of one scalar as an XML element value or attribute.</summary>
+internal interface IXmlScalar<T>
+{
+    string Format(T value);
+
+    T Parse(string value);
+}
+
+/// <summary>Compiles the <see cref="IXmlScalar{T}"/> for a scalar target and its member traits.</summary>
+internal static class XmlScalars
+{
+    internal static IXmlScalar<T> Compile<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait>? traits
+    ) => (IXmlScalar<T>)schema.Resolved.Accept(new Compiler(traits));
+
+    private sealed class Compiler(IReadOnlyDictionary<ShapeId, Trait>? traits)
+        : SchemaVisitor<object>
+    {
+        public override object VisitBoolean(Schema<bool> schema) =>
+            new Scalar<bool>(
+                static value => value ? "true" : "false",
+                static value => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+            );
+
+        public override object VisitByte(Schema<sbyte> schema) => Number<sbyte>(sbyte.Parse);
+
+        public override object VisitShort(Schema<short> schema) => Number<short>(short.Parse);
+
+        public override object VisitInteger(Schema<int> schema) => Number<int>(int.Parse);
+
+        public override object VisitLong(Schema<long> schema) => Number<long>(long.Parse);
+
+        public override object VisitFloat(Schema<float> schema) => Number<float>(float.Parse);
+
+        public override object VisitDouble(Schema<double> schema) => Number<double>(double.Parse);
+
+        public override object VisitBigInteger(Schema<BigInteger> schema) =>
+            Number<BigInteger>(BigInteger.Parse);
+
+        public override object VisitBigDecimal(Schema<decimal> schema) =>
+            Number<decimal>(decimal.Parse);
+
+        public override object VisitString(Schema<string> schema) =>
+            new Scalar<string>(static value => value, static value => value);
+
+        public override object VisitBlob(Schema<byte[]> schema) =>
+            new Scalar<byte[]>(Convert.ToBase64String, Convert.FromBase64String);
+
+        public override object VisitTimestamp(Schema<DateTimeOffset> schema) =>
+            XmlTraits.GetTimestampFormat(schema, traits) switch
+            {
+                "epoch-seconds" => new Scalar<DateTimeOffset>(
+                    static value =>
+                        (value.ToUnixTimeMilliseconds() / 1000.0).ToString(
+                            CultureInfo.InvariantCulture
+                        ),
+                    static value =>
+                        DateTimeOffset.FromUnixTimeMilliseconds(
+                            (long)(double.Parse(value, CultureInfo.InvariantCulture) * 1000)
+                        )
+                ),
+                "http-date" => new Scalar<DateTimeOffset>(
+                    static value => value.ToString("r", CultureInfo.InvariantCulture),
+                    static value =>
+                        DateTimeOffset.ParseExact(
+                            value,
+                            "r",
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.None
+                        )
+                ),
+                _ => new Scalar<DateTimeOffset>(
+                    static value =>
+                        value.UtcDateTime.ToString(
+                            "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'",
+                            CultureInfo.InvariantCulture
+                        ),
+                    static value =>
+                        DateTimeOffset.Parse(
+                            value,
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind
+                        )
+                ),
+            };
+
+        public override object VisitNullable<T>(NullableSchema<T> schema) =>
+            new NullableScalar<T>((IXmlScalar<T>)schema.TargetSchema.Resolved.Accept(this));
+
+        public override object VisitStringEnum<T>(StringEnumSchema<T> schema) =>
+            new Scalar<T>(static value => value.Value, schema.Create);
+
+        public override object VisitIntEnum<T>(IntEnumSchema<T> schema) =>
+            new Scalar<T>(
+                value => schema.GetIntegerValue(value).ToString(CultureInfo.InvariantCulture),
+                value => schema.Create(int.Parse(value, CultureInfo.InvariantCulture))
+            );
+
+        protected override object VisitDefault(Schema schema) =>
+            throw new InvalidOperationException(
+                $"XML scalar value cannot target schema kind '{schema.Kind}'."
+            );
+
+        private static Scalar<T> Number<T>(Func<string, IFormatProvider, T> parse)
+            where T : IFormattable =>
+            new(
+                static value => value.ToString(null, CultureInfo.InvariantCulture),
+                value => parse(value, CultureInfo.InvariantCulture)
+            );
+    }
+
+    private sealed class Scalar<T>(Func<T, string> format, Func<string, T> parse) : IXmlScalar<T>
+    {
+        public string Format(T value) => format(value);
+
+        public T Parse(string value) => parse(value);
+    }
+
+    private sealed class NullableScalar<T>(IXmlScalar<T> inner) : IXmlScalar<T?>
+        where T : struct
+    {
+        public string Format(T? value) => inner.Format(value!.Value);
+
+        public T? Parse(string value) => inner.Parse(value);
+    }
+}

--- a/packages/NSmithy.Codecs.Xml/XmlWire.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlWire.cs
@@ -8,7 +8,6 @@ namespace NSmithy.Codecs.Xml;
 
 internal static class XmlWire
 {
-    private static readonly ShapeId ClientOptionalTrait = new("smithy.api", "clientOptional");
     private static readonly ShapeId DefaultTrait = new("smithy.api", "default");
 
     /// <summary>
@@ -30,85 +29,24 @@ internal static class XmlWire
         out T? value
     )
     {
-        if (
-            traits.ContainsKey(ClientOptionalTrait)
-            || !traits.TryGetValue(DefaultTrait, out var trait)
-            || trait.Value.Kind == DocumentKind.Null
-        )
+        if (CompileDefault(schema, traits) is { } create)
         {
-            value = default;
-            return false;
+            value = create();
+            return true;
         }
 
-        value = CreateDefaultValue(schema, trait.Value);
-        return value is not null;
+        value = default;
+        return false;
     }
 
-    private static T? CreateDefaultValue<T>(Schema<T> schema, Document value)
-    {
-        var resolved = schema.Resolved;
-        if (resolved is INullableSchema nullable)
-        {
-            return (T?)CreateDefaultValue((dynamic)nullable.Target, value);
-        }
-
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (T)(object)value.AsBoolean(),
-            ShapeKind.Byte => (T)(object)(sbyte)value.AsNumber(),
-            ShapeKind.Short => (T)(object)(short)value.AsNumber(),
-            ShapeKind.Integer => (T)(object)(int)value.AsNumber(),
-            ShapeKind.Long => (T)(object)(long)value.AsNumber(),
-            ShapeKind.Float => (T)(object)(float)value.AsNumber(),
-            ShapeKind.Double => (T)(object)(double)value.AsNumber(),
-            ShapeKind.BigInteger => (T)(object)new BigInteger(value.AsNumber()),
-            ShapeKind.BigDecimal => (T)(object)value.AsNumber(),
-            ShapeKind.String => (T)(object)value.AsString(),
-            ShapeKind.Enum => (T)((IStringEnumSchema)resolved).CreateObject(value.AsString()),
-            ShapeKind.IntEnum => (T)((IIntEnumSchema)resolved).CreateObject((int)value.AsNumber()),
-            ShapeKind.Blob => (T)(object)Convert.FromBase64String(value.AsString()),
-            ShapeKind.Timestamp => (T)
-                (object)DateTimeOffset.FromUnixTimeSeconds((long)value.AsNumber()),
-            ShapeKind.List or ShapeKind.Set when resolved is IListSchema list => CreateDefaultList(
-                (dynamic)list,
-                value
-            ),
-            ShapeKind.Map when resolved is IMapSchema map => CreateDefaultMap((dynamic)map, value),
-            _ => null,
-        };
-    }
-
-    private static TCollection CreateDefaultList<TCollection, TElement, TBuilder>(
-        IListSchema<TCollection, TElement, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var item in value.AsArray())
-        {
-            schema.Add(builder, CreateDefaultValue(schema.TypedElementMember.TargetSchema, item)!);
-        }
-
-        return schema.Build(builder);
-    }
-
-    private static TDictionary CreateDefaultMap<TDictionary, TValue, TBuilder>(
-        IMapSchema<TDictionary, TValue, TBuilder> schema,
-        Document value
-    )
-    {
-        var builder = schema.CreateTypedBuilder();
-        foreach (var entry in value.AsObject())
-        {
-            schema.Add(
-                builder,
-                entry.Key,
-                CreateDefaultValue(schema.TypedValueMember.TargetSchema, entry.Value)!
-            );
-        }
-
-        return schema.Build(builder);
-    }
+    /// <summary>The member's <c>@default</c> as a factory, or null when it has none.</summary>
+    internal static Func<T>? CompileDefault<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    ) =>
+        DefaultValues.TryCompile(schema, traits, honorClientOptional: true, out var create)
+            ? create
+            : null;
 
     // Element lookups match on local name only: AWS restXml responses carry a default
     // xmlns on the root (via @xmlNamespace) that all descendants inherit, whereas the
@@ -121,133 +59,6 @@ internal static class XmlWire
 
     internal static XElement? ChildElement(XElement parent, string localName) =>
         ChildElements(parent, localName).FirstOrDefault();
-
-    internal static T ReadScalar<T>(
-        Schema<T> schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        var resolved = schema.Resolved;
-        if (resolved is INullableSchema nullable)
-        {
-            return (T)ReadScalar((dynamic)nullable.Target, traits, value);
-        }
-
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (T)
-                (object)string.Equals(value, "true", StringComparison.OrdinalIgnoreCase),
-            ShapeKind.Byte => (T)(object)sbyte.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Short => (T)(object)short.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Integer => (T)(object)int.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Long => (T)(object)long.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Float => (T)(object)float.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Double => (T)(object)double.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.BigInteger => (T)
-                (object)BigInteger.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.BigDecimal => (T)(object)decimal.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.String => (T)(object)value,
-            ShapeKind.Enum => (T)((IStringEnumSchema)resolved).CreateObject(value),
-            ShapeKind.IntEnum => (T)
-                ((IIntEnumSchema)resolved).CreateObject(
-                    int.Parse(value, CultureInfo.InvariantCulture)
-                ),
-            ShapeKind.Blob => (T)(object)Convert.FromBase64String(value),
-            ShapeKind.Timestamp => (T)(object)ParseTimestamp(resolved, traits, value),
-            _ => throw new InvalidOperationException(
-                $"XML attribute value cannot target schema kind '{resolved.Kind}'."
-            ),
-        };
-    }
-
-    internal static string FormatScalar<T>(
-        Schema<T> schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        T value
-    )
-    {
-        var resolved = schema.Resolved;
-        if (resolved is INullableSchema nullable)
-        {
-            return FormatScalar((dynamic)nullable.Target, traits, (dynamic)value!);
-        }
-
-        return resolved.Kind switch
-        {
-            ShapeKind.Boolean => (bool)(object)value! ? "true" : "false",
-            ShapeKind.Byte => ((sbyte)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Short => ((short)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Integer => ((int)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Long => ((long)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Float => ((float)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Double => ((double)(object)value!).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.BigInteger => ((BigInteger)(object)value!).ToString(
-                CultureInfo.InvariantCulture
-            ),
-            ShapeKind.BigDecimal => ((decimal)(object)value!).ToString(
-                CultureInfo.InvariantCulture
-            ),
-            ShapeKind.String => (string)(object)value!,
-            ShapeKind.Enum => ((IStringEnumValue)(object)value!).Value,
-            ShapeKind.IntEnum => ((IIntEnumSchema)resolved)
-                .GetIntegerValueObject(value!)
-                .ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Blob => Convert.ToBase64String((byte[])(object)value!),
-            ShapeKind.Timestamp => FormatTimestamp(
-                resolved,
-                traits,
-                (DateTimeOffset)(object)value!
-            ),
-            _ => throw new InvalidOperationException(
-                $"XML scalar value cannot target schema kind '{resolved.Kind}'."
-            ),
-        };
-    }
-
-    internal static string FormatTimestamp(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        DateTimeOffset value
-    )
-    {
-        return XmlTraits.GetTimestampFormat(schema, traits) switch
-        {
-            "epoch-seconds" => (value.ToUnixTimeMilliseconds() / 1000.0).ToString(
-                CultureInfo.InvariantCulture
-            ),
-            "http-date" => value.ToString("r", CultureInfo.InvariantCulture),
-            _ => value.UtcDateTime.ToString(
-                "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'",
-                CultureInfo.InvariantCulture
-            ),
-        };
-    }
-
-    internal static DateTimeOffset ParseTimestamp(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        return XmlTraits.GetTimestampFormat(schema, traits) switch
-        {
-            "epoch-seconds" => DateTimeOffset.FromUnixTimeMilliseconds(
-                (long)(double.Parse(value, CultureInfo.InvariantCulture) * 1000)
-            ),
-            "http-date" => DateTimeOffset.ParseExact(
-                value,
-                "r",
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None
-            ),
-            _ => DateTimeOffset.Parse(
-                value,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind
-            ),
-        };
-    }
 
     internal static string ListItemName(IListSchema schema) =>
         XmlTraits.GetXmlName(schema.ElementMember) ?? schema.Element.MemberName ?? "member";

--- a/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
@@ -318,11 +318,13 @@ internal sealed class ScalarXmlValueWriter<T>(
     IReadOnlyDictionary<ShapeId, Trait> traits
 ) : IXmlValueWriter<T>
 {
+    private readonly IXmlScalar<T> scalar = XmlScalars.Compile(schema, traits);
+
     public void Write(XElement element, T value)
     {
         if (value is not null)
         {
-            element.Value = FormatScalar(schema, traits, value);
+            element.Value = scalar.Format(value);
         }
     }
 }
@@ -376,20 +378,35 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
 
     private IXmlMemberPlan<TValue> CreateFlattenedPlan<TValue>(
         IMemberSchema<TContainer, TValue> member
-    )
+    ) => member.TargetSchema.Resolved.Accept(new FlattenedPlanCompiler<TValue>(this, member));
+
+    // A flattened member targets a list or map whose element type only comes into scope by
+    // visiting it; anything else flattens to a plain member.
+    private sealed class FlattenedPlanCompiler<TValue>(
+        XmlMemberWriterCompiler<TContainer> owner,
+        IMemberSchema<TContainer, TValue> member
+    ) : SchemaVisitor<IXmlMemberPlan<TValue>>
     {
-        var target = member.TargetSchema.Resolved;
-        return target switch
-        {
-            IListSchema list => CreateFlattenedListPlan(member, (dynamic)list),
-            IMapSchema map => CreateFlattenedMapPlan(member, (dynamic)map),
-            _ => new FlattenedXmlMemberPlan<TValue>(
-                member,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits),
-                materializeDefaults
-            ),
-        };
+        public override IXmlMemberPlan<TValue> VisitList<TCollection, TElement, TBuilder>(
+            IListSchema<TCollection, TElement, TBuilder> schema
+        ) => owner.CreateFlattenedListPlan(member, (IListSchema<TValue, TElement>)(object)schema);
+
+        public override IXmlMemberPlan<TValue> VisitMap<TDictionary, TMapValue, TBuilder>(
+            IMapSchema<TDictionary, TMapValue, TBuilder> schema
+        ) => owner.CreateFlattenedMapPlan(member, (IMapSchema<TValue, TMapValue>)(object)schema);
+
+        protected override IXmlMemberPlan<TValue> VisitDefault(Schema schema) =>
+            owner.CreateFlattenedValuePlan(member);
     }
+
+    private FlattenedXmlMemberPlan<TValue> CreateFlattenedValuePlan<TValue>(
+        IMemberSchema<TContainer, TValue> member
+    ) =>
+        new(
+            member,
+            compiler.CompileValue(member.TargetSchema, member.MemberTraits),
+            materializeDefaults
+        );
 
     private FlattenedListXmlMemberPlan<TValue, TElement> CreateFlattenedListPlan<TValue, TElement>(
         IMemberSchema<TContainer, TValue> member,
@@ -444,6 +461,9 @@ internal sealed class XmlMemberPlan<TValue>(
 ) : IXmlMemberPlan<TValue>
 {
     private readonly bool isRequired = member.IsRequired;
+    private readonly IXmlScalar<TValue>? attribute = XmlTraits.IsXmlAttribute(member)
+        ? XmlScalars.Compile(member.TargetSchema, member.MemberTraits)
+        : null;
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TValue? Value) memberDefault = ResolveDefault(
@@ -468,7 +488,7 @@ internal sealed class XmlMemberPlan<TValue>(
         {
             element.SetAttributeValue(
                 AttributeName(element, ElementName(member)),
-                FormatScalar(member.TargetSchema, member.MemberTraits, value)
+                attribute!.Format(value)
             );
             return;
         }

--- a/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
+++ b/packages/NSmithy.Codecs.Xml/XmlWriterCompiler.cs
@@ -102,7 +102,7 @@ internal sealed class XmlWriterCompiler : ISchemaVisitor<object>
             memberTraits.Count != 0
                 ? (IXmlValueWriter<T>)
                     resolved.Accept(new MemberTraitXmlWriterCompiler(this, memberTraits))
-                : cache.GetOrCompile<IXmlValueWriter<T>, DeferredXmlValueWriter<T>>(
+                : cache.GetOrCompile(
                     resolved,
                     static () => new DeferredXmlValueWriter<T>(),
                     target => (IXmlValueWriter<T>)target.Accept(this)
@@ -141,7 +141,7 @@ internal sealed class XmlWriterCompiler : ISchemaVisitor<object>
         throw new NotSupportedException("Smithy Document values are not supported in XML.");
 
     public object VisitNullable<T>(NullableSchema<T> schema)
-        where T : struct => new NullableXmlValueWriter<T>(CompileValue(schema.TargetSchema));
+        where T : struct => new NullableXmlValueWriter<T>(CompileValue(schema.TypedTarget));
 
     public object VisitStreamingBlob(Schema<Stream> schema) =>
         throw new NotSupportedException("XML codec does not support streaming blob schemas.");
@@ -155,7 +155,7 @@ internal sealed class XmlWriterCompiler : ISchemaVisitor<object>
         new ListXmlValueWriter<TCollection, TElement>(
             schema,
             CompileValue(
-                schema.TypedElementMember.TargetSchema,
+                schema.TypedElementMember.TypedTarget,
                 schema.TypedElementMember.MemberTraits
             )
         );
@@ -165,7 +165,7 @@ internal sealed class XmlWriterCompiler : ISchemaVisitor<object>
     ) =>
         new MapXmlValueWriter<TDictionary, TValue>(
             schema,
-            CompileValue(schema.TypedValueMember.TargetSchema, schema.TypedValueMember.MemberTraits)
+            CompileValue(schema.TypedValueMember.TypedTarget, schema.TypedValueMember.MemberTraits)
         );
 
     public object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema)
@@ -286,7 +286,7 @@ internal sealed class MemberTraitXmlWriterCompiler(
 
     public object VisitNullable<T>(NullableSchema<T> schema)
         where T : struct =>
-        new NullableXmlValueWriter<T>(inner.CompileValue(schema.TargetSchema, memberTraits));
+        new NullableXmlValueWriter<T>(inner.CompileValue(schema.TypedTarget, memberTraits));
 
     public object VisitStreamingBlob(Schema<Stream> schema) => inner.CompileValue(schema);
 
@@ -369,7 +369,7 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
             ? CreateFlattenedPlan(member)
             : new XmlMemberPlan<TValue>(
                 member,
-                compiler.CompileValue(member.TargetSchema, member.MemberTraits),
+                compiler.CompileValue(member.TypedTarget, member.MemberTraits),
                 materializeDefaults
             );
         plans.Add(plan);
@@ -378,14 +378,14 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
 
     private IXmlMemberPlan<TValue> CreateFlattenedPlan<TValue>(
         IMemberSchema<TContainer, TValue> member
-    ) => member.TargetSchema.Resolved.Accept(new FlattenedPlanCompiler<TValue>(this, member));
+    ) => member.TypedTarget.Resolved.Accept(new FlattenedPlanCompiler<TValue>(this, member));
 
     // A flattened member targets a list or map whose element type only comes into scope by
     // visiting it; anything else flattens to a plain member.
     private sealed class FlattenedPlanCompiler<TValue>(
         XmlMemberWriterCompiler<TContainer> owner,
         IMemberSchema<TContainer, TValue> member
-    ) : SchemaVisitor<IXmlMemberPlan<TValue>>
+    ) : PartialSchemaVisitor<IXmlMemberPlan<TValue>>
     {
         public override IXmlMemberPlan<TValue> VisitList<TCollection, TElement, TBuilder>(
             IListSchema<TCollection, TElement, TBuilder> schema
@@ -404,7 +404,7 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
     ) =>
         new(
             member,
-            compiler.CompileValue(member.TargetSchema, member.MemberTraits),
+            compiler.CompileValue(member.TypedTarget, member.MemberTraits),
             materializeDefaults
         );
 
@@ -416,7 +416,7 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
             member,
             list,
             compiler.CompileValue(
-                list.TypedElementMember.TargetSchema,
+                list.TypedElementMember.TypedTarget,
                 list.TypedElementMember.MemberTraits
             ),
             materializeDefaults
@@ -430,7 +430,7 @@ internal sealed class XmlMemberWriterCompiler<TContainer>(
             member,
             map,
             compiler.CompileValue(
-                map.TypedValueMember.TargetSchema,
+                map.TypedValueMember.TypedTarget,
                 map.TypedValueMember.MemberTraits
             ),
             materializeDefaults
@@ -455,19 +455,19 @@ internal sealed class FallbackXmlMemberWriter<TContainer, TValue>(
 }
 
 internal sealed class XmlMemberPlan<TValue>(
-    ITargetedMemberSchema<TValue> member,
+    ITypedTargetMemberSchema<TValue> member,
     IXmlValueWriter<TValue> valueWriter,
     bool materializeDefault
 ) : IXmlMemberPlan<TValue>
 {
     private readonly bool isRequired = member.IsRequired;
     private readonly IXmlScalar<TValue>? attribute = XmlTraits.IsXmlAttribute(member)
-        ? XmlScalars.Compile(member.TargetSchema, member.MemberTraits)
+        ? XmlScalars.Compile(member.TypedTarget, member.MemberTraits)
         : null;
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TValue? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );
@@ -507,7 +507,7 @@ internal sealed class XmlMemberPlan<TValue>(
 }
 
 internal sealed class FlattenedXmlMemberPlan<TValue>(
-    ITargetedMemberSchema<TValue> member,
+    ITypedTargetMemberSchema<TValue> member,
     IXmlValueWriter<TValue> valueWriter,
     bool materializeDefault
 ) : IXmlMemberPlan<TValue>
@@ -516,7 +516,7 @@ internal sealed class FlattenedXmlMemberPlan<TValue>(
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TValue? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );
@@ -540,7 +540,7 @@ internal sealed class FlattenedXmlMemberPlan<TValue>(
 }
 
 internal sealed class FlattenedListXmlMemberPlan<TCollection, TElement>(
-    ITargetedMemberSchema<TCollection> member,
+    ITypedTargetMemberSchema<TCollection> member,
     IListSchema<TCollection, TElement> list,
     IXmlValueWriter<TElement> elementWriter,
     bool materializeDefault
@@ -550,7 +550,7 @@ internal sealed class FlattenedListXmlMemberPlan<TCollection, TElement>(
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TCollection? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );
@@ -582,7 +582,7 @@ internal sealed class FlattenedListXmlMemberPlan<TCollection, TElement>(
 }
 
 internal sealed class FlattenedMapXmlMemberPlan<TDictionary, TValue>(
-    ITargetedMemberSchema<TDictionary> member,
+    ITypedTargetMemberSchema<TDictionary> member,
     IMapSchema<TDictionary, TValue> map,
     IXmlValueWriter<TValue> valueWriter,
     bool materializeDefault
@@ -594,7 +594,7 @@ internal sealed class FlattenedMapXmlMemberPlan<TDictionary, TValue>(
 
     // Constant per member, so resolved at compile time rather than per write.
     private readonly (bool Present, TDictionary? Value) memberDefault = ResolveDefault(
-        member.TargetSchema,
+        member.TypedTarget,
         member.MemberTraits,
         materializeDefault
     );

--- a/packages/NSmithy.Core/Document.cs
+++ b/packages/NSmithy.Core/Document.cs
@@ -4,6 +4,13 @@ using System.Text.Json;
 
 namespace NSmithy.Core;
 
+/// <summary>
+/// A Smithy document value: a JSON-shaped tree of null, boolean, string, number, array and object
+/// nodes with no schema of its own. Trait values are documents, as is any member targeting
+/// <c>smithy.api#Document</c>. <see cref="Kind"/> says which node this is; the <c>As*</c> accessors
+/// read it and throw when asked for a different kind. Numbers are held as <see cref="decimal"/>,
+/// which covers every Smithy numeric shape a trait can carry.
+/// </summary>
 public readonly record struct Document
 {
     private readonly object? value;

--- a/packages/NSmithy.Core/Serde/Codec.cs
+++ b/packages/NSmithy.Core/Serde/Codec.cs
@@ -40,10 +40,10 @@ public interface ICodecFactory
     /// default is correct for formats whose representation is controlled entirely by the target
     /// schema; trait-sensitive factories can override it.
     /// </summary>
-    ICodec<T> FromMember<T>(ITargetedMemberSchema<T> member, CodecFactoryOptions? options = null)
+    ICodec<T> FromMember<T>(ITypedTargetMemberSchema<T> member, CodecFactoryOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(member);
-        return FromSchema(member.TargetSchema, options);
+        return FromSchema(member.TypedTarget, options);
     }
 }
 

--- a/packages/NSmithy.Core/Serde/DefaultValues.cs
+++ b/packages/NSmithy.Core/Serde/DefaultValues.cs
@@ -50,7 +50,7 @@ public static class DefaultValues
     }
 
     // Returns a Func<T> for the visited Schema<T>, or null when the shape kind has no default form.
-    private sealed class Compiler(Document value) : SchemaVisitor<object?>
+    private sealed class Compiler(Document value) : PartialSchemaVisitor<object?>
     {
         protected override object? VisitDefault(Schema schema) => null;
 
@@ -92,7 +92,7 @@ public static class DefaultValues
         public override object? VisitDocument(Schema<Document> schema) => Constant(value);
 
         public override object? VisitNullable<T>(NullableSchema<T> schema) =>
-            schema.TargetSchema.Resolved.Accept(this) is Func<T> inner
+            schema.TypedTarget.Resolved.Accept(this) is Func<T> inner
                 ? new Func<T?>(() => inner())
                 : null;
 

--- a/packages/NSmithy.Core/Serde/DefaultValues.cs
+++ b/packages/NSmithy.Core/Serde/DefaultValues.cs
@@ -50,51 +50,53 @@ public static class DefaultValues
     }
 
     // Returns a Func<T> for the visited Schema<T>, or null when the shape kind has no default form.
-    private sealed class Compiler(Document value) : ISchemaVisitor<object?>
+    private sealed class Compiler(Document value) : SchemaVisitor<object?>
     {
-        public object? VisitBoolean(Schema<bool> schema) => Constant(value.AsBoolean());
+        protected override object? VisitDefault(Schema schema) => null;
 
-        public object? VisitByte(Schema<sbyte> schema) => Constant((sbyte)value.AsNumber());
+        public override object? VisitBoolean(Schema<bool> schema) => Constant(value.AsBoolean());
 
-        public object? VisitShort(Schema<short> schema) => Constant((short)value.AsNumber());
+        public override object? VisitByte(Schema<sbyte> schema) =>
+            Constant((sbyte)value.AsNumber());
 
-        public object? VisitInteger(Schema<int> schema) => Constant((int)value.AsNumber());
+        public override object? VisitShort(Schema<short> schema) =>
+            Constant((short)value.AsNumber());
 
-        public object? VisitLong(Schema<long> schema) => Constant((long)value.AsNumber());
+        public override object? VisitInteger(Schema<int> schema) => Constant((int)value.AsNumber());
 
-        public object? VisitFloat(Schema<float> schema) => Constant((float)value.AsNumber());
+        public override object? VisitLong(Schema<long> schema) => Constant((long)value.AsNumber());
 
-        public object? VisitDouble(Schema<double> schema) => Constant((double)value.AsNumber());
+        public override object? VisitFloat(Schema<float> schema) =>
+            Constant((float)value.AsNumber());
 
-        public object? VisitBigInteger(Schema<BigInteger> schema) =>
+        public override object? VisitDouble(Schema<double> schema) =>
+            Constant((double)value.AsNumber());
+
+        public override object? VisitBigInteger(Schema<BigInteger> schema) =>
             Constant(new BigInteger(value.AsNumber()));
 
-        public object? VisitBigDecimal(Schema<decimal> schema) => Constant(value.AsNumber());
+        public override object? VisitBigDecimal(Schema<decimal> schema) =>
+            Constant(value.AsNumber());
 
-        public object? VisitString(Schema<string> schema) => Constant(value.AsString());
+        public override object? VisitString(Schema<string> schema) => Constant(value.AsString());
 
-        public object? VisitBlob(Schema<byte[]> schema)
+        public override object? VisitBlob(Schema<byte[]> schema)
         {
             var text = value.AsString();
             return new Func<byte[]>(() => Convert.FromBase64String(text));
         }
 
-        public object? VisitStreamingBlob(Schema<Stream> schema) => null;
-
-        public object? VisitTimestamp(Schema<DateTimeOffset> schema) =>
+        public override object? VisitTimestamp(Schema<DateTimeOffset> schema) =>
             Constant(DateTimeOffset.FromUnixTimeSeconds((long)value.AsNumber()));
 
-        public object? VisitDocument(Schema<Document> schema) => Constant(value);
+        public override object? VisitDocument(Schema<Document> schema) => Constant(value);
 
-        public object? VisitNullable<T>(NullableSchema<T> schema)
-            where T : struct =>
+        public override object? VisitNullable<T>(NullableSchema<T> schema) =>
             schema.TargetSchema.Resolved.Accept(this) is Func<T> inner
                 ? new Func<T?>(() => inner())
                 : null;
 
-        public object? VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) => null;
-
-        public object? VisitList<TCollection, TElement, TBuilder>(
+        public override object? VisitList<TCollection, TElement, TBuilder>(
             IListSchema<TCollection, TElement, TBuilder> schema
         )
         {
@@ -125,7 +127,7 @@ public static class DefaultValues
             });
         }
 
-        public object? VisitMap<TDictionary, TValue, TBuilder>(
+        public override object? VisitMap<TDictionary, TValue, TBuilder>(
             IMapSchema<TDictionary, TValue, TBuilder> schema
         )
         {
@@ -156,15 +158,11 @@ public static class DefaultValues
             });
         }
 
-        public object? VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema) => null;
+        public override object? VisitStringEnum<T>(StringEnumSchema<T> schema) =>
+            Constant(schema.Create(value.AsString()));
 
-        public object? VisitUnion<T>(IUnionSchema<T> schema) => null;
-
-        public object? VisitStringEnum<T>(StringEnumSchema<T> schema)
-            where T : IStringEnumValue<T> => Constant(schema.Create(value.AsString()));
-
-        public object? VisitIntEnum<T>(IntEnumSchema<T> schema)
-            where T : struct, Enum => Constant(schema.Create((int)value.AsNumber()));
+        public override object? VisitIntEnum<T>(IntEnumSchema<T> schema) =>
+            Constant(schema.Create((int)value.AsNumber()));
 
         private static Func<T> Constant<T>(T constant) => () => constant;
     }

--- a/packages/NSmithy.Core/Serde/DefaultValues.cs
+++ b/packages/NSmithy.Core/Serde/DefaultValues.cs
@@ -1,0 +1,171 @@
+using System.Numerics;
+
+namespace NSmithy.Core.Serde;
+
+/// <summary>
+/// Resolves a member's <c>@default</c> into a typed factory, once, at compile time.
+/// </summary>
+/// <remarks>
+/// The result is a factory rather than a value because a default can be mutable (a blob, list, map
+/// or document); a reader that sets it into a builder must not alias one instance across objects.
+/// A writer that only compares against the default may call the factory once and keep the result.
+/// </remarks>
+public static class DefaultValues
+{
+    private static readonly ShapeId ClientOptionalTrait = new("smithy.api", "clientOptional");
+    private static readonly ShapeId DefaultTrait = new("smithy.api", "default");
+
+    /// <param name="honorClientOptional">
+    /// Whether a member carrying <c>@clientOptional</c> is treated as having no default, which is
+    /// what a body codec does so that a client does not fabricate a value the server never sent.
+    /// </param>
+    public static bool TryCompile<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait> traits,
+        bool honorClientOptional,
+        out Func<T> create
+    )
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(traits);
+
+        if (
+            (honorClientOptional && traits.ContainsKey(ClientOptionalTrait))
+            || !traits.TryGetValue(DefaultTrait, out var trait)
+            || trait.Value.Kind == DocumentKind.Null
+        )
+        {
+            create = null!;
+            return false;
+        }
+
+        if (schema.Resolved.Accept(new Compiler(trait.Value)) is Func<T> compiled)
+        {
+            create = compiled;
+            return true;
+        }
+
+        create = null!;
+        return false;
+    }
+
+    // Returns a Func<T> for the visited Schema<T>, or null when the shape kind has no default form.
+    private sealed class Compiler(Document value) : ISchemaVisitor<object?>
+    {
+        public object? VisitBoolean(Schema<bool> schema) => Constant(value.AsBoolean());
+
+        public object? VisitByte(Schema<sbyte> schema) => Constant((sbyte)value.AsNumber());
+
+        public object? VisitShort(Schema<short> schema) => Constant((short)value.AsNumber());
+
+        public object? VisitInteger(Schema<int> schema) => Constant((int)value.AsNumber());
+
+        public object? VisitLong(Schema<long> schema) => Constant((long)value.AsNumber());
+
+        public object? VisitFloat(Schema<float> schema) => Constant((float)value.AsNumber());
+
+        public object? VisitDouble(Schema<double> schema) => Constant((double)value.AsNumber());
+
+        public object? VisitBigInteger(Schema<BigInteger> schema) =>
+            Constant(new BigInteger(value.AsNumber()));
+
+        public object? VisitBigDecimal(Schema<decimal> schema) => Constant(value.AsNumber());
+
+        public object? VisitString(Schema<string> schema) => Constant(value.AsString());
+
+        public object? VisitBlob(Schema<byte[]> schema)
+        {
+            var text = value.AsString();
+            return new Func<byte[]>(() => Convert.FromBase64String(text));
+        }
+
+        public object? VisitStreamingBlob(Schema<Stream> schema) => null;
+
+        public object? VisitTimestamp(Schema<DateTimeOffset> schema) =>
+            Constant(DateTimeOffset.FromUnixTimeSeconds((long)value.AsNumber()));
+
+        public object? VisitDocument(Schema<Document> schema) => Constant(value);
+
+        public object? VisitNullable<T>(NullableSchema<T> schema)
+            where T : struct =>
+            schema.TargetSchema.Resolved.Accept(this) is Func<T> inner
+                ? new Func<T?>(() => inner())
+                : null;
+
+        public object? VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) => null;
+
+        public object? VisitList<TCollection, TElement, TBuilder>(
+            IListSchema<TCollection, TElement, TBuilder> schema
+        )
+        {
+            var items = new List<Func<TElement>>();
+            foreach (var item in value.AsArray())
+            {
+                if (
+                    schema.ElementSchema.Resolved.Accept(new Compiler(item))
+                    is not Func<TElement> element
+                )
+                {
+                    return null;
+                }
+
+                items.Add(element);
+            }
+
+            var elements = items.ToArray();
+            return new Func<TCollection>(() =>
+            {
+                var builder = schema.CreateTypedBuilder();
+                foreach (var element in elements)
+                {
+                    schema.Add(builder, element());
+                }
+
+                return schema.Build(builder);
+            });
+        }
+
+        public object? VisitMap<TDictionary, TValue, TBuilder>(
+            IMapSchema<TDictionary, TValue, TBuilder> schema
+        )
+        {
+            var entries = new List<KeyValuePair<string, Func<TValue>>>();
+            foreach (var entry in value.AsObject())
+            {
+                if (
+                    schema.ValueSchema.Resolved.Accept(new Compiler(entry.Value))
+                    is not Func<TValue> entryValue
+                )
+                {
+                    return null;
+                }
+
+                entries.Add(new(entry.Key, entryValue));
+            }
+
+            var values = entries.ToArray();
+            return new Func<TDictionary>(() =>
+            {
+                var builder = schema.CreateTypedBuilder();
+                foreach (var entry in values)
+                {
+                    schema.Add(builder, entry.Key, entry.Value());
+                }
+
+                return schema.Build(builder);
+            });
+        }
+
+        public object? VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema) => null;
+
+        public object? VisitUnion<T>(IUnionSchema<T> schema) => null;
+
+        public object? VisitStringEnum<T>(StringEnumSchema<T> schema)
+            where T : IStringEnumValue<T> => Constant(schema.Create(value.AsString()));
+
+        public object? VisitIntEnum<T>(IntEnumSchema<T> schema)
+            where T : struct, Enum => Constant(schema.Create((int)value.AsNumber()));
+
+        private static Func<T> Constant<T>(T constant) => () => constant;
+    }
+}

--- a/packages/NSmithy.Core/Serde/PartialSchemaVisitor.cs
+++ b/packages/NSmithy.Core/Serde/PartialSchemaVisitor.cs
@@ -7,7 +7,7 @@ namespace NSmithy.Core.Serde;
 /// one through <see cref="VisitDefault"/>, which by default refuses it. For a consumer that only
 /// admits, say, a map: override <see cref="VisitMap"/> and nothing else.
 /// </summary>
-public abstract class SchemaVisitor<TResult> : ISchemaVisitor<TResult>
+public abstract class PartialSchemaVisitor<TResult> : ISchemaVisitor<TResult>
 {
     protected virtual TResult VisitDefault(Schema schema) =>
         throw new NotSupportedException(

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -322,8 +322,6 @@ public sealed class NullableSchema<T> : Schema<T?>, INullableSchema
 
 public interface IStringEnumSchema
 {
-    object CreateObject(string value);
-
     /// <summary>Whether the value is one the model declares.</summary>
     bool Contains(string value);
 
@@ -379,8 +377,6 @@ public sealed class StringEnumSchema<T> : Schema<T>, IStringEnumSchema
 
     public T Create(string value) => T.FromValue(value);
 
-    public object CreateObject(string value) => T.FromValue(value)!;
-
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
@@ -388,14 +384,7 @@ public sealed class StringEnumSchema<T> : Schema<T>, IStringEnumSchema
     }
 }
 
-public interface IIntEnumSchema
-{
-    int GetIntegerValueObject(object value);
-
-    object CreateObject(int value);
-}
-
-public sealed class IntEnumSchema<T> : Schema<T>, IIntEnumSchema
+public sealed class IntEnumSchema<T> : Schema<T>
     where T : struct, Enum
 {
     internal IntEnumSchema(
@@ -418,10 +407,6 @@ public sealed class IntEnumSchema<T> : Schema<T>, IIntEnumSchema
     public int GetIntegerValue(T value) => Convert.ToInt32(value, CultureInfo.InvariantCulture);
 
     public T Create(int value) => (T)Enum.ToObject(typeof(T), value);
-
-    public int GetIntegerValueObject(object value) => GetIntegerValue((T)value);
-
-    public object CreateObject(int value) => Create(value);
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
@@ -540,14 +525,6 @@ public interface IListSchema
     IMemberSchema ElementMember { get; }
 
     Schema Element { get; }
-
-    IEnumerable<object?> GetElementsObject(object value);
-
-    object CreateBuilder();
-
-    void AddObject(object builder, object? value);
-
-    object BuildObject(object builder);
 }
 
 public interface IListSchema<TCollection, TElement> : IListSchema
@@ -579,14 +556,6 @@ public interface IMapSchema
     IMemberSchema KeyMember { get; }
 
     Schema Value { get; }
-
-    IEnumerable<KeyValuePair<string, object?>> GetEntriesObject(object value);
-
-    object CreateBuilder();
-
-    void AddObject(object builder, string key, object? value);
-
-    object BuildObject(object builder);
 }
 
 public interface IMapSchema<TDictionary, TValue> : IMapSchema
@@ -612,8 +581,6 @@ public interface IUnionSchema
     IReadOnlyList<IUnionCaseSchema> Cases { get; }
 
     IUnionCaseSchema? GetCase(string name);
-
-    IUnionCaseSchema GetCaseObject(object value);
 }
 
 public interface IUnionSchema<T> : IUnionSchema
@@ -635,8 +602,6 @@ public interface IUnionCaseSchema
     IReadOnlyDictionary<ShapeId, Trait> Traits { get; }
 
     Schema Target { get; }
-
-    bool MatchesObject(object value);
 }
 
 public interface IUnionCaseSchema<TUnion, TValue> : IUnionCaseSchema
@@ -672,14 +637,7 @@ public interface ITargetedMemberSchema<TValue> : IMemberSchema
     Schema<TValue> TargetSchema { get; }
 }
 
-public interface IStructMemberSchema : IMemberSchema
-{
-    object? GetObject(object container);
-
-    void SetObject(object builder, object? value);
-}
-
-public interface IMemberSchema<TContainer> : IStructMemberSchema
+public interface IMemberSchema<TContainer> : IMemberSchema
 {
     void Accept(IMemberVisitor<TContainer> visitor);
 }
@@ -792,68 +750,11 @@ public sealed class MapKeyMemberSchema : IMemberSchema
     public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
 
-public sealed class ListSchema<TElement>
-    : Schema<IReadOnlyList<TElement>>,
-        IListSchema<IReadOnlyList<TElement>, TElement, List<TElement>>
-{
-    internal ListSchema(
-        ShapeId id,
-        ShapeKind kind,
-        Schema<TElement> element,
-        IEnumerable<Trait>? traits = null,
-        IEnumerable<Trait>? elementTraits = null
-    )
-        : base(id, kind, traits)
-    {
-        ArgumentNullException.ThrowIfNull(element);
-        ElementSchema = element;
-        TypedElementMember = new CollectionMemberSchema<TElement>(
-            id.WithMember("member"),
-            element,
-            elementTraits
-        );
-    }
-
-    public ITargetedMemberSchema<TElement> TypedElementMember { get; }
-
-    public IMemberSchema ElementMember => TypedElementMember;
-
-    public Schema<TElement> ElementSchema { get; }
-
-    public Schema Element => ElementSchema;
-
-    public IEnumerable<TElement> GetElements(IReadOnlyList<TElement> value) => value;
-
-    public IEnumerable<object?> GetElementsObject(object value)
-    {
-        foreach (var element in (IReadOnlyList<TElement>)value)
-        {
-            yield return element;
-        }
-    }
-
-    public object CreateBuilder() => new List<TElement>();
-
-    public List<TElement> CreateTypedBuilder() => new();
-
-    public void Add(List<TElement> builder, TElement value) => builder.Add(value);
-
-    public void AddObject(object builder, object? value) =>
-        Add((List<TElement>)builder, (TElement)value!);
-
-    public IReadOnlyList<TElement> Build(List<TElement> builder) =>
-        new ReadOnlyCollection<TElement>(builder.ToArray());
-
-    public object BuildObject(object builder) => Build((List<TElement>)builder);
-
-    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        return visitor.VisitList(this);
-    }
-}
-
-public sealed class CollectionSchema<TCollection, TElement, TBuilder>
+/// <summary>
+/// A list or set. The C# collection is whatever the model's consumer wants it to be; the schema
+/// carries the four operations a codec needs to read one and enumerate one.
+/// </summary>
+public sealed class ListSchema<TCollection, TElement, TBuilder>
     : Schema<TCollection>,
         IListSchema<TCollection, TElement, TBuilder>
 {
@@ -862,7 +763,7 @@ public sealed class CollectionSchema<TCollection, TElement, TBuilder>
     private readonly Action<TBuilder, TElement> add;
     private readonly Func<TBuilder, TCollection> build;
 
-    internal CollectionSchema(
+    internal ListSchema(
         ShapeId id,
         ShapeKind kind,
         Schema<TElement> element,
@@ -903,27 +804,12 @@ public sealed class CollectionSchema<TCollection, TElement, TBuilder>
 
     public IEnumerable<TElement> GetElements(TCollection value) => getElements(value);
 
-    public IEnumerable<object?> GetElementsObject(object value)
-    {
-        foreach (var element in getElements((TCollection)value))
-        {
-            yield return element;
-        }
-    }
-
-    public object CreateBuilder() => createBuilder()!;
-
     public TBuilder CreateTypedBuilder() => createBuilder();
 
     public void Add(TBuilder builder, TElement value) => add(builder, value);
 
-    public void AddObject(object builder, object? value) =>
-        Add((TBuilder)builder, (TElement)value!);
-
     public TCollection Build(TBuilder builder) => build(builder);
 
-    public object BuildObject(object builder) => Build((TBuilder)builder)!;
-
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
@@ -931,132 +817,7 @@ public sealed class CollectionSchema<TCollection, TElement, TBuilder>
     }
 }
 
-public sealed class SetSchema<TElement>
-    : Schema<IReadOnlySet<TElement>>,
-        IListSchema<IReadOnlySet<TElement>, TElement, HashSet<TElement>>
-{
-    internal SetSchema(
-        ShapeId id,
-        Schema<TElement> element,
-        IEnumerable<Trait>? traits = null,
-        IEnumerable<Trait>? elementTraits = null
-    )
-        : base(id, ShapeKind.Set, traits)
-    {
-        ArgumentNullException.ThrowIfNull(element);
-        ElementSchema = element;
-        TypedElementMember = new CollectionMemberSchema<TElement>(
-            id.WithMember("member"),
-            element,
-            elementTraits
-        );
-    }
-
-    public ITargetedMemberSchema<TElement> TypedElementMember { get; }
-
-    public IMemberSchema ElementMember => TypedElementMember;
-
-    public Schema<TElement> ElementSchema { get; }
-
-    public Schema Element => ElementSchema;
-
-    public IEnumerable<TElement> GetElements(IReadOnlySet<TElement> value) => value;
-
-    public IEnumerable<object?> GetElementsObject(object value)
-    {
-        foreach (var element in (IReadOnlySet<TElement>)value)
-        {
-            yield return element;
-        }
-    }
-
-    public object CreateBuilder() => new HashSet<TElement>();
-
-    public HashSet<TElement> CreateTypedBuilder() => new();
-
-    public void Add(HashSet<TElement> builder, TElement value) => builder.Add(value);
-
-    public void AddObject(object builder, object? value) =>
-        Add((HashSet<TElement>)builder, (TElement)value!);
-
-    public IReadOnlySet<TElement> Build(HashSet<TElement> builder) => builder;
-
-    public object BuildObject(object builder) => Build((HashSet<TElement>)builder);
-
-    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        return visitor.VisitList(this);
-    }
-}
-
-public sealed class MapSchema<TValue>
-    : Schema<IReadOnlyDictionary<string, TValue>>,
-        IMapSchema<IReadOnlyDictionary<string, TValue>, TValue, Dictionary<string, TValue>>
-{
-    internal MapSchema(
-        ShapeId id,
-        Schema<TValue> value,
-        IEnumerable<Trait>? traits = null,
-        IEnumerable<Trait>? keyTraits = null,
-        IEnumerable<Trait>? valueTraits = null,
-        Schema? key = null
-    )
-        : base(id, ShapeKind.Map, traits)
-    {
-        ArgumentNullException.ThrowIfNull(value);
-        KeyMember = new MapKeyMemberSchema(id.WithMember("key"), key ?? Schemas.String, keyTraits);
-        TypedValueMember = new CollectionMemberSchema<TValue>(
-            id.WithMember("value"),
-            value,
-            valueTraits
-        );
-        ValueSchema = value;
-    }
-
-    public IMemberSchema KeyMember { get; }
-
-    public ITargetedMemberSchema<TValue> TypedValueMember { get; }
-
-    public Schema<TValue> ValueSchema { get; }
-
-    public Schema Value => ValueSchema;
-
-    public IEnumerable<KeyValuePair<string, TValue>> GetEntries(
-        IReadOnlyDictionary<string, TValue> value
-    ) => value;
-
-    public IEnumerable<KeyValuePair<string, object?>> GetEntriesObject(object value)
-    {
-        foreach (var entry in (IReadOnlyDictionary<string, TValue>)value)
-        {
-            yield return new KeyValuePair<string, object?>(entry.Key, entry.Value);
-        }
-    }
-
-    public object CreateBuilder() => new Dictionary<string, TValue>(StringComparer.Ordinal);
-
-    public Dictionary<string, TValue> CreateTypedBuilder() => new(StringComparer.Ordinal);
-
-    public void Add(Dictionary<string, TValue> builder, string key, TValue value) =>
-        builder.Add(key, value);
-
-    public void AddObject(object builder, string key, object? value) =>
-        Add((Dictionary<string, TValue>)builder, key, (TValue)value!);
-
-    public IReadOnlyDictionary<string, TValue> Build(Dictionary<string, TValue> builder) =>
-        new ReadOnlyDictionary<string, TValue>(builder);
-
-    public object BuildObject(object builder) => Build((Dictionary<string, TValue>)builder);
-
-    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        return visitor.VisitMap(this);
-    }
-}
-
-public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
+public sealed class MapSchema<TDictionary, TValue, TBuilder>
     : Schema<TDictionary>,
         IMapSchema<TDictionary, TValue, TBuilder>
 {
@@ -1065,7 +826,7 @@ public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
     private readonly Action<TBuilder, string, TValue> add;
     private readonly Func<TBuilder, TDictionary> build;
 
-    internal DictionarySchema(
+    internal MapSchema(
         ShapeId id,
         Schema<TValue> value,
         Func<TDictionary, IEnumerable<KeyValuePair<string, TValue>>> getEntries,
@@ -1109,26 +870,11 @@ public sealed class DictionarySchema<TDictionary, TValue, TBuilder>
     public IEnumerable<KeyValuePair<string, TValue>> GetEntries(TDictionary value) =>
         getEntries(value);
 
-    public IEnumerable<KeyValuePair<string, object?>> GetEntriesObject(object value)
-    {
-        foreach (var entry in getEntries((TDictionary)value))
-        {
-            yield return new KeyValuePair<string, object?>(entry.Key, entry.Value);
-        }
-    }
-
-    public object CreateBuilder() => createBuilder()!;
-
     public TBuilder CreateTypedBuilder() => createBuilder();
 
     public void Add(TBuilder builder, string key, TValue value) => add(builder, key, value);
 
-    public void AddObject(object builder, string key, object? value) =>
-        Add((TBuilder)builder, key, (TValue)value!);
-
     public TDictionary Build(TBuilder builder) => build(builder);
-
-    public object BuildObject(object builder) => Build((TBuilder)builder)!;
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
@@ -1191,8 +937,6 @@ public sealed class UnionCaseSchema<TUnion, TValue>
 
     public TUnion Create(TValue value) => create(value);
 
-    public bool MatchesObject(object value) => matches((TUnion)value);
-
     public void Accept(IUnionCaseVisitor<TUnion> visitor) => visitor.Visit(this);
 }
 
@@ -1218,19 +962,6 @@ public sealed class UnionSchema<T> : Schema<T>, IUnionSchema<T>
     {
         ArgumentNullException.ThrowIfNull(name);
         return casesByName.TryGetValue(name, out var @case) ? @case : null;
-    }
-
-    public IUnionCaseSchema GetCaseObject(object value)
-    {
-        foreach (var @case in cases)
-        {
-            if (@case.MatchesObject(value))
-            {
-                return @case;
-            }
-        }
-
-        throw new InvalidOperationException($"No union case matched '{typeof(T).Name}'.");
     }
 
     public void VisitCases(IUnionCaseVisitor<T> visitor)
@@ -1318,10 +1049,6 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
     public void Accept(IMemberVisitor<TContainer> visitor) => visitor.Visit(this);
 
     public void Accept(IMemberVisitor<TContainer, TBuilder> visitor) => visitor.Visit(this);
-
-    public object? GetObject(object container) => get((TContainer)container);
-
-    public void SetObject(object builder, object? value) => set((TBuilder)builder, (TValue)value!);
 
     public override Trait? GetTrait(ShapeId id) => FindTrait(MemberTraits, TargetSchema, id);
 
@@ -1839,18 +1566,26 @@ public static class Schemas
     public static UnionSchemaBuilder<T> Union<T>(ShapeId id, IEnumerable<Trait>? traits = null) =>
         new(id, traits);
 
-    public static ListSchema<TElement> List<TElement>(
+    /// <summary>A list read as <see cref="IReadOnlyList{T}"/>; the form a hand-written schema wants.</summary>
+    public static ListSchema<IReadOnlyList<TElement>, TElement, List<TElement>> List<TElement>(
         ShapeId id,
         Schema<TElement> element,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? elementTraits = null
-    ) => new(id, ShapeKind.List, element, traits, elementTraits);
+    ) =>
+        new(
+            id,
+            ShapeKind.List,
+            element,
+            static value => value,
+            static () => [],
+            static (builder, value) => builder.Add(value),
+            static builder => new ReadOnlyCollection<TElement>(builder.ToArray()),
+            traits,
+            elementTraits
+        );
 
-    public static CollectionSchema<TCollection, TElement, TBuilder> List<
-        TCollection,
-        TElement,
-        TBuilder
-    >(
+    public static ListSchema<TCollection, TElement, TBuilder> List<TCollection, TElement, TBuilder>(
         ShapeId id,
         Schema<TElement> element,
         Func<TCollection, IEnumerable<TElement>> getElements,
@@ -1872,18 +1607,25 @@ public static class Schemas
             elementTraits
         );
 
-    public static SetSchema<TElement> Set<TElement>(
+    public static ListSchema<IReadOnlySet<TElement>, TElement, HashSet<TElement>> Set<TElement>(
         ShapeId id,
         Schema<TElement> element,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? elementTraits = null
-    ) => new(id, element, traits, elementTraits);
+    ) =>
+        new(
+            id,
+            ShapeKind.Set,
+            element,
+            static value => value,
+            static () => [],
+            static (builder, value) => builder.Add(value),
+            static builder => builder,
+            traits,
+            elementTraits
+        );
 
-    public static CollectionSchema<TCollection, TElement, TBuilder> Set<
-        TCollection,
-        TElement,
-        TBuilder
-    >(
+    public static ListSchema<TCollection, TElement, TBuilder> Set<TCollection, TElement, TBuilder>(
         ShapeId id,
         Schema<TElement> element,
         Func<TCollection, IEnumerable<TElement>> getElements,
@@ -1910,20 +1652,32 @@ public static class Schemas
     /// shape of its own is; pass the modeled shape when the model gives it one, so a server can hold
     /// the key to what that shape says.
     /// </param>
-    public static MapSchema<TValue> Map<TValue>(
+    public static MapSchema<
+        IReadOnlyDictionary<string, TValue>,
+        TValue,
+        Dictionary<string, TValue>
+    > Map<TValue>(
         ShapeId id,
         Schema<TValue> value,
         IEnumerable<Trait>? traits = null,
         IEnumerable<Trait>? keyTraits = null,
         IEnumerable<Trait>? valueTraits = null,
         Schema? key = null
-    ) => new(id, value, traits, keyTraits, valueTraits, key);
+    ) =>
+        new(
+            id,
+            value,
+            static value => value,
+            static () => new Dictionary<string, TValue>(StringComparer.Ordinal),
+            static (builder, entryKey, entryValue) => builder.Add(entryKey, entryValue),
+            static builder => new ReadOnlyDictionary<string, TValue>(builder),
+            traits,
+            keyTraits,
+            valueTraits,
+            key
+        );
 
-    public static DictionarySchema<TDictionary, TValue, TBuilder> Map<
-        TDictionary,
-        TValue,
-        TBuilder
-    >(
+    public static MapSchema<TDictionary, TValue, TBuilder> Map<TDictionary, TValue, TBuilder>(
         ShapeId id,
         Schema<TValue> value,
         Func<TDictionary, IEnumerable<KeyValuePair<string, TValue>>> getEntries,
@@ -1981,31 +1735,6 @@ public static class Schemas
     {
         ArgumentNullException.ThrowIfNull(memberNames);
         return new(source, member => memberNames.Contains(member.Name));
-    }
-
-    public static StructProjection<T, TBuilder> Project<T, TBuilder>(
-        IStructSchema<T, TBuilder> source,
-        IReadOnlyList<IMemberSchema<T>> members
-    )
-    {
-        ArgumentNullException.ThrowIfNull(members);
-        var included = new HashSet<IMemberSchema>(members, ReferenceEqualityComparer.Instance);
-        return new(source, included.Contains);
-    }
-
-    public static IReadOnlyList<IMemberSchema<T>> GetMembers<T>(IStructSchema<T> schema)
-    {
-        ArgumentNullException.ThrowIfNull(schema);
-        var visitor = new MemberCollector<T>();
-        schema.VisitMembers(visitor);
-        return visitor.Members;
-    }
-
-    private sealed class MemberCollector<T> : IMemberVisitor<T>
-    {
-        public List<IMemberSchema<T>> Members { get; } = [];
-
-        public void Visit<TValue>(IMemberSchema<T, TValue> member) => Members.Add(member);
     }
 
     /// <summary>

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -16,12 +16,12 @@ public abstract class Schema
     {
         this.id = id;
         this.kind = kind;
-        this.traits = BuildTraits(traits);
+        this.traits = Trait.Index(traits);
     }
 
     protected Schema()
     {
-        traits = new Dictionary<ShapeId, Trait>();
+        traits = Trait.None;
     }
 
     public virtual ShapeId Id => id;
@@ -38,15 +38,10 @@ public abstract class Schema
 
     public string? MemberName => Id.MemberName;
 
-    // Virtual for one subclass: a member schema answers with its effective trait, which may sit on
-    // the shape it targets rather than in its own Traits.
     public virtual Trait? GetTrait(ShapeId id) =>
         Traits.TryGetValue(id, out var trait) ? trait : null;
 
     public virtual bool HasTrait(ShapeId id) => Traits.ContainsKey(id);
-
-    internal static IReadOnlyDictionary<ShapeId, Trait> BuildTraits(IEnumerable<Trait>? traits) =>
-        traits is null ? [] : traits.ToDictionary(t => t.Id);
 }
 
 public abstract class Schema<T> : Schema
@@ -680,7 +675,7 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
 
         Id = id;
         TargetSchema = target;
-        memberTraits = Schema.BuildTraits(traits);
+        memberTraits = Trait.Index(traits);
     }
 
     public ShapeId Id { get; }
@@ -721,7 +716,7 @@ public sealed class MapKeyMemberSchema : IMemberSchema
 
         Id = id;
         Target = target;
-        memberTraits = Schema.BuildTraits(traits);
+        memberTraits = Trait.Index(traits);
     }
 
     public ShapeId Id { get; }
@@ -900,7 +895,7 @@ public sealed class UnionCaseSchema<TUnion, TValue>
         ArgumentNullException.ThrowIfNull(create);
 
         Id = id;
-        Traits = Schema.BuildTraits(traits);
+        Traits = Trait.Index(traits);
         TargetSchema = target;
         this.matches = matches;
         this.get = get;
@@ -1343,7 +1338,7 @@ public sealed class OperationSchema<TInput, TOutput> : IOperationSchema
         Input = input;
         Output = output;
         Errors = WithImplicitValidationError(errors);
-        Traits = Schema.BuildTraits(traits);
+        Traits = Trait.Index(traits);
     }
 
     public ShapeId Id { get; }
@@ -1421,7 +1416,7 @@ public sealed class ServiceSchema
     {
         Id = id;
         Version = version ?? throw new ArgumentNullException(nameof(version));
-        Traits = Schema.BuildTraits(traits);
+        Traits = Trait.Index(traits);
     }
 
     public ShapeId Id { get; }

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -38,12 +38,23 @@ public abstract class Schema
 
     public string? MemberName => Id.MemberName;
 
-    public Trait? GetTrait(ShapeId id) => Traits.TryGetValue(id, out var trait) ? trait : null;
+    public virtual Trait? GetTrait(ShapeId id) =>
+        Traits.TryGetValue(id, out var trait) ? trait : null;
 
-    public bool HasTrait(ShapeId id) => Traits.ContainsKey(id);
+    public virtual bool HasTrait(ShapeId id) => Traits.ContainsKey(id);
 
     internal static IReadOnlyDictionary<ShapeId, Trait> BuildTraits(IEnumerable<Trait>? traits) =>
         traits is null ? [] : traits.ToDictionary(t => t.Id);
+
+    /// <summary>
+    /// Effective trait lookup for a member: a trait on the member wins over the same trait on the
+    /// shape it targets.
+    /// </summary>
+    internal static Trait? FindTrait(
+        IReadOnlyDictionary<ShapeId, Trait> memberTraits,
+        Schema target,
+        ShapeId id
+    ) => memberTraits.TryGetValue(id, out var trait) ? trait : target.GetTrait(id);
 }
 
 public abstract class Schema<T> : Schema
@@ -680,16 +691,20 @@ public interface IMemberSchema<TContainer, TValue>
     TValue GetValue(TContainer container);
 }
 
-public interface IMemberSchema<TContainer, TBuilder, TValue> : IMemberSchema<TContainer, TValue>
+/// <summary>
+/// A structure member whose builder type is known, which is what a reader needs to dispatch on the
+/// member without knowing its value type yet.
+/// </summary>
+public interface IStructMemberSchema<TContainer, TBuilder> : IMemberSchema<TContainer>
 {
-    void SetValue(TBuilder builder, TValue value);
-
     void Accept(IMemberVisitor<TContainer, TBuilder> visitor);
 }
 
-internal interface IBuilderMemberSchema<TContainer, TBuilder>
+public interface IMemberSchema<TContainer, TBuilder, TValue>
+    : IMemberSchema<TContainer, TValue>,
+        IStructMemberSchema<TContainer, TBuilder>
 {
-    void Accept(IMemberVisitor<TContainer, TBuilder> visitor);
+    void SetValue(TBuilder builder, TValue value);
 }
 
 public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValue>
@@ -730,8 +745,7 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
     // no absent case for a consumer to check.
     public bool IsRequired => true;
 
-    public Trait? GetTrait(ShapeId id) =>
-        MemberTraits.TryGetValue(id, out var trait) ? trait : TargetSchema.GetTrait(id);
+    public Trait? GetTrait(ShapeId id) => Schema.FindTrait(MemberTraits, TargetSchema, id);
 
     public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
@@ -773,8 +787,7 @@ public sealed class MapKeyMemberSchema : IMemberSchema
     // An entry's key is always present when the map holds the entry.
     public bool IsRequired => true;
 
-    public Trait? GetTrait(ShapeId id) =>
-        MemberTraits.TryGetValue(id, out var trait) ? trait : Target.GetTrait(id);
+    public Trait? GetTrait(ShapeId id) => Schema.FindTrait(MemberTraits, Target, id);
 
     public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
@@ -1256,8 +1269,7 @@ internal interface IUnionCaseSchema<TUnion>
 
 public sealed class MemberSchema<TContainer, TBuilder, TValue>
     : Schema<TValue>,
-        IMemberSchema<TContainer, TBuilder, TValue>,
-        IBuilderMemberSchema<TContainer, TBuilder>
+        IMemberSchema<TContainer, TBuilder, TValue>
 {
     private readonly Func<TContainer, TValue> get;
     private readonly Action<TBuilder, TValue> set;
@@ -1311,10 +1323,9 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
 
     public void SetObject(object builder, object? value) => set((TBuilder)builder, (TValue)value!);
 
-    public new Trait? GetTrait(ShapeId id) =>
-        MemberTraits.TryGetValue(id, out var trait) ? trait : TargetSchema.GetTrait(id);
+    public override Trait? GetTrait(ShapeId id) => FindTrait(MemberTraits, TargetSchema, id);
 
-    public new bool HasTrait(ShapeId id) => GetTrait(id) is not null;
+    public override bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
@@ -1327,14 +1338,14 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
 {
     private readonly Func<TBuilder> createBuilder;
     private readonly Func<TBuilder, T> build;
-    private readonly ReadOnlyCollection<IMemberSchema<T>> members;
+    private readonly IStructMemberSchema<T, TBuilder>[] members;
     private readonly Dictionary<string, IMemberSchema> membersByName;
 
     internal StructSchema(
         ShapeId id,
         Func<TBuilder> createBuilder,
         Func<TBuilder, T> build,
-        IReadOnlyList<IMemberSchema> members,
+        IReadOnlyList<IStructMemberSchema<T, TBuilder>> members,
         IEnumerable<Trait>? traits = null,
         IStructValueSerializer<T>? valueSerializer = null
     )
@@ -1342,9 +1353,7 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
     {
         this.createBuilder = createBuilder;
         this.build = build;
-        this.members = new ReadOnlyCollection<IMemberSchema<T>>(
-            members.Cast<IMemberSchema<T>>().ToArray()
-        );
+        this.members = [.. members];
         membersByName = BuildMembersByName(this.members);
         ValueSerializer = valueSerializer;
     }
@@ -1377,7 +1386,7 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
         ArgumentNullException.ThrowIfNull(visitor);
         foreach (var member in members)
         {
-            ((IBuilderMemberSchema<T, TBuilder>)member).Accept(visitor);
+            member.Accept(visitor);
         }
     }
 
@@ -1388,7 +1397,7 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
     }
 
     private static Dictionary<string, IMemberSchema> BuildMembersByName(
-        ReadOnlyCollection<IMemberSchema<T>> members
+        IStructMemberSchema<T, TBuilder>[] members
     )
     {
         var byName = new Dictionary<string, IMemberSchema>(StringComparer.Ordinal);
@@ -1401,61 +1410,66 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
     }
 }
 
+/// <summary>
+/// A subset of a structure's members, as a protocol sees a structure once it has bound some members
+/// elsewhere: the members it keeps are the ones the body codec reads and writes.
+/// </summary>
 public sealed class StructProjection<T, TBuilder>
 {
-    private readonly IStructSchema<T, TBuilder> source;
-    private readonly ReadOnlyCollection<IMemberSchema<T>> members;
-    private readonly Dictionary<string, IMemberSchema<T>> membersByName;
+    private readonly Func<IMemberSchema, bool> include;
 
-    internal StructProjection(
-        IStructSchema<T, TBuilder> source,
-        IReadOnlyList<IMemberSchema<T>> members
-    )
+    internal StructProjection(IStructSchema<T, TBuilder> source, Func<IMemberSchema, bool> include)
     {
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(members);
-        this.source = source;
-        this.members = new ReadOnlyCollection<IMemberSchema<T>>(members.ToArray());
-        membersByName = BuildMembersByName(this.members);
+        ArgumentNullException.ThrowIfNull(include);
+        Source = source;
+        this.include = include;
     }
 
-    public IStructSchema<T, TBuilder> Source => source;
+    public IStructSchema<T, TBuilder> Source { get; }
 
-    public IMemberSchema<T>? GetMember(string name)
+    public IMemberSchema? GetMember(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        return membersByName.TryGetValue(name, out var member) ? member : null;
+        return Source.GetMember(name) is { } member && include(member) ? member : null;
     }
 
     public void VisitMembers(IMemberVisitor<T> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
-        foreach (var member in members)
-        {
-            member.Accept(visitor);
-        }
+        Source.VisitMembers(new Filter(visitor, include));
     }
 
     public void VisitMembers(IMemberVisitor<T, TBuilder> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
-        foreach (var member in members)
+        Source.VisitMembers(new BuilderFilter(visitor, include));
+    }
+
+    private sealed class Filter(IMemberVisitor<T> inner, Func<IMemberSchema, bool> include)
+        : IMemberVisitor<T>
+    {
+        public void Visit<TValue>(IMemberSchema<T, TValue> member)
         {
-            ((IBuilderMemberSchema<T, TBuilder>)member).Accept(visitor);
+            if (include(member))
+            {
+                inner.Visit(member);
+            }
         }
     }
 
-    private static Dictionary<string, IMemberSchema<T>> BuildMembersByName(
-        ReadOnlyCollection<IMemberSchema<T>> members
-    )
+    private sealed class BuilderFilter(
+        IMemberVisitor<T, TBuilder> inner,
+        Func<IMemberSchema, bool> include
+    ) : IMemberVisitor<T, TBuilder>
     {
-        var byName = new Dictionary<string, IMemberSchema<T>>(StringComparer.Ordinal);
-        foreach (var member in members)
+        public void Visit<TValue>(IMemberSchema<T, TBuilder, TValue> member)
         {
-            byName.Add(member.Name, member);
+            if (include(member))
+            {
+                inner.Visit(member);
+            }
         }
-
-        return byName;
     }
 }
 
@@ -1463,7 +1477,7 @@ public sealed class StructSchemaBuilder<T, TBuilder>
 {
     private readonly ShapeId id;
     private readonly IReadOnlyList<Trait>? traits;
-    private readonly List<IMemberSchema> members = [];
+    private readonly List<IStructMemberSchema<T, TBuilder>> members = [];
 
     internal StructSchemaBuilder(ShapeId id, IEnumerable<Trait>? traits = null)
     {
@@ -1953,10 +1967,31 @@ public static class Schemas
         IEnumerable<Trait>? traits = null
     ) => new(id, version, traits);
 
+    /// <summary>The members of <paramref name="source"/> for which <paramref name="include"/> holds.</summary>
+    public static StructProjection<T, TBuilder> Project<T, TBuilder>(
+        IStructSchema<T, TBuilder> source,
+        Func<IMemberSchema, bool> include
+    ) => new(source, include);
+
+    /// <summary>The members of <paramref name="source"/> named in <paramref name="memberNames"/>.</summary>
+    public static StructProjection<T, TBuilder> Project<T, TBuilder>(
+        IStructSchema<T, TBuilder> source,
+        IReadOnlySet<string> memberNames
+    )
+    {
+        ArgumentNullException.ThrowIfNull(memberNames);
+        return new(source, member => memberNames.Contains(member.Name));
+    }
+
     public static StructProjection<T, TBuilder> Project<T, TBuilder>(
         IStructSchema<T, TBuilder> source,
         IReadOnlyList<IMemberSchema<T>> members
-    ) => new(source, members);
+    )
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        var included = new HashSet<IMemberSchema>(members, ReferenceEqualityComparer.Instance);
+        return new(source, included.Contains);
+    }
 
     public static IReadOnlyList<IMemberSchema<T>> GetMembers<T>(IStructSchema<T> schema)
     {
@@ -1971,5 +2006,52 @@ public static class Schemas
         public List<IMemberSchema<T>> Members { get; } = [];
 
         public void Visit<TValue>(IMemberSchema<T, TValue> member) => Members.Add(member);
+    }
+
+    /// <summary>
+    /// Compiles the function that names the case a union value holds, e.g. for an event stream's
+    /// <c>:event-type</c>.
+    /// </summary>
+    public static Func<TUnion, string> CompileCaseName<TUnion>(IUnionSchema<TUnion> schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        var collector = new CaseNameCollector<TUnion>();
+        schema.VisitCases(collector);
+        var cases = collector.Cases.ToArray();
+        return value =>
+        {
+            foreach (var @case in cases)
+            {
+                if (@case.Matches(value))
+                {
+                    return @case.Name;
+                }
+            }
+
+            throw new InvalidOperationException($"No union case matched '{typeof(TUnion).Name}'.");
+        };
+    }
+
+    private interface ICaseMatch<in TUnion>
+    {
+        string Name { get; }
+
+        bool Matches(TUnion value);
+    }
+
+    private sealed class CaseMatch<TUnion, TValue>(IUnionCaseSchema<TUnion, TValue> @case)
+        : ICaseMatch<TUnion>
+    {
+        public string Name => @case.Name;
+
+        public bool Matches(TUnion value) => @case.Matches(value);
+    }
+
+    private sealed class CaseNameCollector<TUnion> : IUnionCaseVisitor<TUnion>
+    {
+        public List<ICaseMatch<TUnion>> Cases { get; } = [];
+
+        public void Visit<TValue>(IUnionCaseSchema<TUnion, TValue> unionCase) =>
+            Cases.Add(new CaseMatch<TUnion, TValue>(unionCase));
     }
 }

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -38,6 +38,8 @@ public abstract class Schema
 
     public string? MemberName => Id.MemberName;
 
+    // Virtual for one subclass: a member schema answers with its effective trait, which may sit on
+    // the shape it targets rather than in its own Traits.
     public virtual Trait? GetTrait(ShapeId id) =>
         Traits.TryGetValue(id, out var trait) ? trait : null;
 
@@ -45,16 +47,6 @@ public abstract class Schema
 
     internal static IReadOnlyDictionary<ShapeId, Trait> BuildTraits(IEnumerable<Trait>? traits) =>
         traits is null ? [] : traits.ToDictionary(t => t.Id);
-
-    /// <summary>
-    /// Effective trait lookup for a member: a trait on the member wins over the same trait on the
-    /// shape it targets.
-    /// </summary>
-    internal static Trait? FindTrait(
-        IReadOnlyDictionary<ShapeId, Trait> memberTraits,
-        Schema target,
-        ShapeId id
-    ) => memberTraits.TryGetValue(id, out var trait) ? trait : target.GetTrait(id);
 }
 
 public abstract class Schema<T> : Schema
@@ -627,9 +619,11 @@ public interface IMemberSchema
 
     bool IsRequired { get; }
 
-    Trait? GetTrait(ShapeId id);
+    /// <summary>The effective trait: one on the member wins over the same trait on its target.</summary>
+    Trait? GetTrait(ShapeId id) =>
+        MemberTraits.TryGetValue(id, out var trait) ? trait : Target.GetTrait(id);
 
-    bool HasTrait(ShapeId id);
+    bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
 
 public interface ITargetedMemberSchema<TValue> : IMemberSchema
@@ -702,10 +696,6 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
     // A collection element or map entry is always present when the collection holds it; there is
     // no absent case for a consumer to check.
     public bool IsRequired => true;
-
-    public Trait? GetTrait(ShapeId id) => Schema.FindTrait(MemberTraits, TargetSchema, id);
-
-    public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
 
 /// <summary>
@@ -744,10 +734,6 @@ public sealed class MapKeyMemberSchema : IMemberSchema
 
     // An entry's key is always present when the map holds the entry.
     public bool IsRequired => true;
-
-    public Trait? GetTrait(ShapeId id) => Schema.FindTrait(MemberTraits, Target, id);
-
-    public bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 }
 
 /// <summary>
@@ -1050,7 +1036,8 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
 
     public void Accept(IMemberVisitor<TContainer, TBuilder> visitor) => visitor.Visit(this);
 
-    public override Trait? GetTrait(ShapeId id) => FindTrait(MemberTraits, TargetSchema, id);
+    public override Trait? GetTrait(ShapeId id) =>
+        MemberTraits.TryGetValue(id, out var trait) ? trait : TargetSchema.GetTrait(id);
 
     public override bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 

--- a/packages/NSmithy.Core/Serde/Schema.cs
+++ b/packages/NSmithy.Core/Serde/Schema.cs
@@ -112,6 +112,34 @@ public interface ISchemaVisitor<out TResult>
         where T : struct, Enum;
 }
 
+public sealed class LazySchema<T> : Schema<T>
+{
+    private readonly Lazy<Schema<T>> target;
+
+    internal LazySchema(Func<Schema<T>> resolve)
+        : base()
+    {
+        ArgumentNullException.ThrowIfNull(resolve);
+        target = new Lazy<Schema<T>>(resolve);
+    }
+
+    public Schema<T> TargetSchema => target.Value;
+
+    public override ShapeId Id => TargetSchema.Id;
+
+    public override ShapeKind Kind => TargetSchema.Kind;
+
+    public override IReadOnlyDictionary<ShapeId, Trait> Traits => TargetSchema.Traits;
+
+    public override Schema Resolved => TargetSchema.Resolved;
+
+    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        return TargetSchema.Accept(visitor);
+    }
+}
+
 public abstract class PrimitiveSchema<T> : Schema<T>
 {
     private protected PrimitiveSchema(ShapeId id, ShapeKind kind, IEnumerable<Trait>? traits = null)
@@ -258,6 +286,206 @@ public sealed class DocumentSchema(ShapeId id, IEnumerable<Trait>? traits = null
     }
 }
 
+public interface IMemberSchema
+{
+    ShapeId Id { get; }
+
+    string Name { get; }
+
+    IReadOnlyDictionary<ShapeId, Trait> MemberTraits { get; }
+
+    Schema Target { get; }
+
+    bool IsRequired { get; }
+
+    /// <summary>The effective trait: one on the member wins over the same trait on its target.</summary>
+    Trait? GetTrait(ShapeId id) =>
+        MemberTraits.TryGetValue(id, out var trait) ? trait : Target.GetTrait(id);
+
+    bool HasTrait(ShapeId id) => GetTrait(id) is not null;
+}
+
+public interface ITypedTargetMemberSchema<TValue> : IMemberSchema
+{
+    Schema<TValue> TypedTarget { get; }
+}
+
+public interface IMemberSchema<TContainer> : IMemberSchema
+{
+    void Accept(IMemberVisitor<TContainer> visitor);
+}
+
+public interface IMemberSchema<TContainer, TValue>
+    : IMemberSchema<TContainer>,
+        ITypedTargetMemberSchema<TValue>
+{
+    TValue GetValue(TContainer container);
+}
+
+/// <summary>
+/// A member whose builder type is known while its value type is erased, which is what a reader
+/// needs to dispatch without reflection or the runtime binder.
+/// </summary>
+public interface IBuilderMemberSchema<TContainer, TBuilder> : IMemberSchema<TContainer>
+{
+    void Accept(IMemberVisitor<TContainer, TBuilder> visitor);
+}
+
+public interface IMemberSchema<TContainer, TBuilder, TValue>
+    : IMemberSchema<TContainer, TValue>,
+        IBuilderMemberSchema<TContainer, TBuilder>
+{
+    void SetValue(TBuilder builder, TValue value);
+}
+
+public interface IMemberVisitor<TContainer>
+{
+    void Visit<TValue>(IMemberSchema<TContainer, TValue> member);
+}
+
+public interface IMemberVisitor<TContainer, TBuilder>
+{
+    void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member);
+}
+
+/// <summary>
+/// Receives statically typed structure members during serialization. Member indexes follow the
+/// structure schema's declaration order.
+/// </summary>
+public interface IStructMemberWriter
+{
+    void WriteMember<TValue>(int index, TValue value);
+}
+
+/// <summary>
+/// Supplies a structure's values directly to a wire-format serializer without using member getter
+/// delegates.
+/// </summary>
+public interface IStructValueSerializer<T>
+{
+    void WriteMembers<TWriter>(T value, ref TWriter writer)
+        where TWriter : struct, IStructMemberWriter;
+}
+
+public interface IStructSchema
+{
+    IMemberSchema? GetMember(string name);
+}
+
+public interface IStructSchema<T> : IStructSchema
+{
+    IStructValueSerializer<T>? ValueSerializer => null;
+
+    /// <summary>
+    /// Dispatches to <paramref name="visitor"/> with this structure's otherwise hidden builder type.
+    /// </summary>
+    TResult Accept<TResult>(IStructSchemaVisitor<T, TResult> visitor);
+
+    void VisitMembers(IMemberVisitor<T> visitor);
+
+    T BuildEmpty();
+}
+
+/// <summary>
+/// Recovers the builder type hidden by <see cref="IStructSchema{T}"/> without reflection or the
+/// runtime binder.
+/// </summary>
+public interface IStructSchemaVisitor<T, out TResult>
+{
+    TResult Visit<TBuilder>(IStructSchema<T, TBuilder> schema);
+}
+
+public interface IStructSchema<T, TBuilder> : IStructSchema<T>
+{
+    TBuilder CreateTypedBuilder();
+
+    T Build(TBuilder builder);
+
+    void VisitMembers(IMemberVisitor<T, TBuilder> visitor);
+}
+
+public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBuilder>
+{
+    private readonly Func<TBuilder> createBuilder;
+    private readonly Func<TBuilder, T> build;
+    private readonly IBuilderMemberSchema<T, TBuilder>[] members;
+    private readonly Dictionary<string, IMemberSchema> membersByName;
+
+    internal StructSchema(
+        ShapeId id,
+        Func<TBuilder> createBuilder,
+        Func<TBuilder, T> build,
+        IReadOnlyList<IBuilderMemberSchema<T, TBuilder>> members,
+        IEnumerable<Trait>? traits = null,
+        IStructValueSerializer<T>? valueSerializer = null
+    )
+        : base(id, ShapeKind.Structure, traits)
+    {
+        this.createBuilder = createBuilder;
+        this.build = build;
+        this.members = [.. members];
+        membersByName = BuildMembersByName(this.members);
+        ValueSerializer = valueSerializer;
+    }
+
+    public IStructValueSerializer<T>? ValueSerializer { get; }
+
+    public IMemberSchema? GetMember(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return membersByName.TryGetValue(name, out var member) ? member : null;
+    }
+
+    public TBuilder CreateTypedBuilder() => createBuilder();
+
+    public T Build(TBuilder builder) => build(builder);
+
+    public T BuildEmpty() => build(createBuilder());
+
+    public TResult Accept<TResult>(IStructSchemaVisitor<T, TResult> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        return visitor.Visit(this);
+    }
+
+    public void VisitMembers(IMemberVisitor<T> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        foreach (var member in members)
+        {
+            member.Accept(visitor);
+        }
+    }
+
+    public void VisitMembers(IMemberVisitor<T, TBuilder> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        foreach (var member in members)
+        {
+            member.Accept(visitor);
+        }
+    }
+
+    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        return visitor.VisitStruct(this);
+    }
+
+    private static Dictionary<string, IMemberSchema> BuildMembersByName(
+        IBuilderMemberSchema<T, TBuilder>[] members
+    )
+    {
+        var byName = new Dictionary<string, IMemberSchema>(StringComparer.Ordinal);
+        foreach (var member in members)
+        {
+            byName.Add(member.Name, member);
+        }
+
+        return byName;
+    }
+}
+
 public sealed class UnitSchema : Schema<SmithyUnit>, IStructSchema<SmithyUnit, SmithyUnit>
 {
     internal UnitSchema()
@@ -274,6 +502,12 @@ public sealed class UnitSchema : Schema<SmithyUnit>, IStructSchema<SmithyUnit, S
     public SmithyUnit Build(SmithyUnit builder) => SmithyUnit.Value;
 
     public SmithyUnit BuildEmpty() => SmithyUnit.Value;
+
+    public TResult Accept<TResult>(IStructSchemaVisitor<SmithyUnit, TResult> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        return visitor.Visit(this);
+    }
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
@@ -293,12 +527,12 @@ public sealed class NullableSchema<T> : Schema<T?>, INullableSchema
     internal NullableSchema(Schema<T> target)
         : base(target.Id, target.Kind, target.Traits.Values)
     {
-        TargetSchema = target;
+        TypedTarget = target;
     }
 
-    public Schema<T> TargetSchema { get; }
+    public Schema<T> TypedTarget { get; }
 
-    public Schema Target => TargetSchema;
+    public Schema Target => TypedTarget;
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
@@ -402,34 +636,6 @@ public sealed class IntEnumSchema<T> : Schema<T>
     }
 }
 
-public sealed class LazySchema<T> : Schema<T>
-{
-    private readonly Lazy<Schema<T>> target;
-
-    internal LazySchema(Func<Schema<T>> resolve)
-        : base()
-    {
-        ArgumentNullException.ThrowIfNull(resolve);
-        target = new Lazy<Schema<T>>(resolve);
-    }
-
-    public Schema<T> TargetSchema => target.Value;
-
-    public override ShapeId Id => TargetSchema.Id;
-
-    public override ShapeKind Kind => TargetSchema.Kind;
-
-    public override IReadOnlyDictionary<ShapeId, Trait> Traits => TargetSchema.Traits;
-
-    public override Schema Resolved => TargetSchema.Resolved;
-
-    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        return TargetSchema.Accept(visitor);
-    }
-}
-
 public interface IEventStreamSchema
 {
     Schema EventSchema { get; }
@@ -455,58 +661,6 @@ public sealed class EventStreamSchema<TEvent> : Schema<IAsyncEnumerable<TEvent>>
     }
 }
 
-public interface IStructSchema
-{
-    IMemberSchema? GetMember(string name);
-}
-
-public interface IStructSchema<T> : IStructSchema
-{
-    IStructValueSerializer<T>? ValueSerializer => null;
-
-    void VisitMembers(IMemberVisitor<T> visitor);
-
-    T BuildEmpty();
-}
-
-/// <summary>
-/// Receives statically typed structure members during serialization. Member indexes follow the
-/// structure schema's declaration order.
-/// </summary>
-public interface IStructMemberWriter
-{
-    void WriteMember<TValue>(int index, TValue value);
-}
-
-/// <summary>
-/// Supplies a structure's values directly to a wire-format serializer without using member getter
-/// delegates.
-/// </summary>
-public interface IStructValueSerializer<T>
-{
-    void WriteMembers<TWriter>(T value, ref TWriter writer)
-        where TWriter : struct, IStructMemberWriter;
-}
-
-public interface IStructSchema<T, TBuilder> : IStructSchema<T>
-{
-    TBuilder CreateTypedBuilder();
-
-    T Build(TBuilder builder);
-
-    void VisitMembers(IMemberVisitor<T, TBuilder> visitor);
-}
-
-public interface IMemberVisitor<TContainer>
-{
-    void Visit<TValue>(IMemberSchema<TContainer, TValue> member);
-}
-
-public interface IMemberVisitor<TContainer, TBuilder>
-{
-    void Visit<TValue>(IMemberSchema<TContainer, TBuilder, TValue> member);
-}
-
 public interface IListSchema
 {
     IMemberSchema ElementMember { get; }
@@ -516,7 +670,7 @@ public interface IListSchema
 
 public interface IListSchema<TCollection, TElement> : IListSchema
 {
-    ITargetedMemberSchema<TElement> TypedElementMember { get; }
+    ITypedTargetMemberSchema<TElement> TypedElementMember { get; }
 
     Schema<TElement> ElementSchema { get; }
 
@@ -547,7 +701,7 @@ public interface IMapSchema
 
 public interface IMapSchema<TDictionary, TValue> : IMapSchema
 {
-    ITargetedMemberSchema<TValue> TypedValueMember { get; }
+    ITypedTargetMemberSchema<TValue> TypedValueMember { get; }
 
     Schema<TValue> ValueSchema { get; }
 
@@ -561,23 +715,6 @@ public interface IMapSchema<TDictionary, TValue, TBuilder> : IMapSchema<TDiction
     void Add(TBuilder builder, string key, TValue value);
 
     TDictionary Build(TBuilder builder);
-}
-
-public interface IUnionSchema
-{
-    IReadOnlyList<IUnionCaseSchema> Cases { get; }
-
-    IUnionCaseSchema? GetCase(string name);
-}
-
-public interface IUnionSchema<T> : IUnionSchema
-{
-    void VisitCases(IUnionCaseVisitor<T> visitor);
-}
-
-public interface IUnionCaseVisitor<TUnion>
-{
-    void Visit<TValue>(IUnionCaseSchema<TUnion, TValue> unionCase);
 }
 
 public interface IUnionCaseSchema
@@ -602,59 +739,29 @@ public interface IUnionCaseSchema<TUnion, TValue> : IUnionCaseSchema
     TUnion Create(TValue value);
 }
 
-public interface IMemberSchema
+public interface IUnionCaseVisitor<TUnion>
 {
-    ShapeId Id { get; }
-
-    string Name { get; }
-
-    IReadOnlyDictionary<ShapeId, Trait> MemberTraits { get; }
-
-    Schema Target { get; }
-
-    bool IsRequired { get; }
-
-    /// <summary>The effective trait: one on the member wins over the same trait on its target.</summary>
-    Trait? GetTrait(ShapeId id) =>
-        MemberTraits.TryGetValue(id, out var trait) ? trait : Target.GetTrait(id);
-
-    bool HasTrait(ShapeId id) => GetTrait(id) is not null;
+    void Visit<TValue>(IUnionCaseSchema<TUnion, TValue> unionCase);
 }
 
-public interface ITargetedMemberSchema<TValue> : IMemberSchema
+internal interface IUnionCaseSchema<TUnion>
 {
-    Schema<TValue> TargetSchema { get; }
+    void Accept(IUnionCaseVisitor<TUnion> visitor);
 }
 
-public interface IMemberSchema<TContainer> : IMemberSchema
+public interface IUnionSchema
 {
-    void Accept(IMemberVisitor<TContainer> visitor);
+    IReadOnlyList<IUnionCaseSchema> Cases { get; }
+
+    IUnionCaseSchema? GetCase(string name);
 }
 
-public interface IMemberSchema<TContainer, TValue>
-    : IMemberSchema<TContainer>,
-        ITargetedMemberSchema<TValue>
+public interface IUnionSchema<T> : IUnionSchema
 {
-    TValue GetValue(TContainer container);
+    void VisitCases(IUnionCaseVisitor<T> visitor);
 }
 
-/// <summary>
-/// A structure member whose builder type is known, which is what a reader needs to dispatch on the
-/// member without knowing its value type yet.
-/// </summary>
-public interface IStructMemberSchema<TContainer, TBuilder> : IMemberSchema<TContainer>
-{
-    void Accept(IMemberVisitor<TContainer, TBuilder> visitor);
-}
-
-public interface IMemberSchema<TContainer, TBuilder, TValue>
-    : IMemberSchema<TContainer, TValue>,
-        IStructMemberSchema<TContainer, TBuilder>
-{
-    void SetValue(TBuilder builder, TValue value);
-}
-
-public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValue>
+public sealed class CollectionMemberSchema<TValue> : ITypedTargetMemberSchema<TValue>
 {
     private readonly IReadOnlyDictionary<ShapeId, Trait> memberTraits;
 
@@ -674,7 +781,7 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
         }
 
         Id = id;
-        TargetSchema = target;
+        TypedTarget = target;
         memberTraits = Trait.Index(traits);
     }
 
@@ -684,9 +791,9 @@ public sealed class CollectionMemberSchema<TValue> : ITargetedMemberSchema<TValu
 
     public IReadOnlyDictionary<ShapeId, Trait> MemberTraits => memberTraits;
 
-    public Schema<TValue> TargetSchema { get; }
+    public Schema<TValue> TypedTarget { get; }
 
-    public Schema Target => TargetSchema;
+    public Schema Target => TypedTarget;
 
     // A collection element or map entry is always present when the collection holds it; there is
     // no absent case for a consumer to check.
@@ -735,7 +842,7 @@ public sealed class MapKeyMemberSchema : IMemberSchema
 /// A list or set. The C# collection is whatever the model's consumer wants it to be; the schema
 /// carries the four operations a codec needs to read one and enumerate one.
 /// </summary>
-public sealed class ListSchema<TCollection, TElement, TBuilder>
+public sealed class CollectionSchema<TCollection, TElement, TBuilder>
     : Schema<TCollection>,
         IListSchema<TCollection, TElement, TBuilder>
 {
@@ -744,7 +851,7 @@ public sealed class ListSchema<TCollection, TElement, TBuilder>
     private readonly Action<TBuilder, TElement> add;
     private readonly Func<TBuilder, TCollection> build;
 
-    internal ListSchema(
+    internal CollectionSchema(
         ShapeId id,
         ShapeKind kind,
         Schema<TElement> element,
@@ -775,7 +882,7 @@ public sealed class ListSchema<TCollection, TElement, TBuilder>
         this.build = build;
     }
 
-    public ITargetedMemberSchema<TElement> TypedElementMember { get; }
+    public ITypedTargetMemberSchema<TElement> TypedElementMember { get; }
 
     public IMemberSchema ElementMember => TypedElementMember;
 
@@ -842,7 +949,7 @@ public sealed class MapSchema<TDictionary, TValue, TBuilder>
 
     public IMemberSchema KeyMember { get; }
 
-    public ITargetedMemberSchema<TValue> TypedValueMember { get; }
+    public ITypedTargetMemberSchema<TValue> TypedValueMember { get; }
 
     public Schema<TValue> ValueSchema { get; }
 
@@ -974,11 +1081,6 @@ public sealed class UnionSchema<T> : Schema<T>, IUnionSchema<T>
     }
 }
 
-internal interface IUnionCaseSchema<TUnion>
-{
-    void Accept(IUnionCaseVisitor<TUnion> visitor);
-}
-
 public sealed class MemberSchema<TContainer, TBuilder, TValue>
     : Schema<TValue>,
         IMemberSchema<TContainer, TBuilder, TValue>
@@ -1006,7 +1108,7 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
         }
 
         IsRequired = isRequired;
-        TargetSchema = target;
+        TypedTarget = target;
         this.get = get;
         this.set = set;
     }
@@ -1017,9 +1119,9 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
 
     public IReadOnlyDictionary<ShapeId, Trait> MemberTraits => base.Traits;
 
-    public Schema<TValue> TargetSchema { get; }
+    public Schema<TValue> TypedTarget { get; }
 
-    public Schema Target => TargetSchema;
+    public Schema Target => TypedTarget;
 
     public TValue GetValue(TContainer container) => get(container);
 
@@ -1032,90 +1134,14 @@ public sealed class MemberSchema<TContainer, TBuilder, TValue>
     public void Accept(IMemberVisitor<TContainer, TBuilder> visitor) => visitor.Visit(this);
 
     public override Trait? GetTrait(ShapeId id) =>
-        MemberTraits.TryGetValue(id, out var trait) ? trait : TargetSchema.GetTrait(id);
+        MemberTraits.TryGetValue(id, out var trait) ? trait : TypedTarget.GetTrait(id);
 
     public override bool HasTrait(ShapeId id) => GetTrait(id) is not null;
 
     public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
-        return TargetSchema.Accept(visitor);
-    }
-}
-
-public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBuilder>
-{
-    private readonly Func<TBuilder> createBuilder;
-    private readonly Func<TBuilder, T> build;
-    private readonly IStructMemberSchema<T, TBuilder>[] members;
-    private readonly Dictionary<string, IMemberSchema> membersByName;
-
-    internal StructSchema(
-        ShapeId id,
-        Func<TBuilder> createBuilder,
-        Func<TBuilder, T> build,
-        IReadOnlyList<IStructMemberSchema<T, TBuilder>> members,
-        IEnumerable<Trait>? traits = null,
-        IStructValueSerializer<T>? valueSerializer = null
-    )
-        : base(id, ShapeKind.Structure, traits)
-    {
-        this.createBuilder = createBuilder;
-        this.build = build;
-        this.members = [.. members];
-        membersByName = BuildMembersByName(this.members);
-        ValueSerializer = valueSerializer;
-    }
-
-    public IStructValueSerializer<T>? ValueSerializer { get; }
-
-    public IMemberSchema? GetMember(string name)
-    {
-        ArgumentNullException.ThrowIfNull(name);
-        return membersByName.TryGetValue(name, out var member) ? member : null;
-    }
-
-    public TBuilder CreateTypedBuilder() => createBuilder();
-
-    public T Build(TBuilder builder) => build(builder);
-
-    public T BuildEmpty() => build(createBuilder());
-
-    public void VisitMembers(IMemberVisitor<T> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        foreach (var member in members)
-        {
-            member.Accept(visitor);
-        }
-    }
-
-    public void VisitMembers(IMemberVisitor<T, TBuilder> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        foreach (var member in members)
-        {
-            member.Accept(visitor);
-        }
-    }
-
-    public override TResult Accept<TResult>(ISchemaVisitor<TResult> visitor)
-    {
-        ArgumentNullException.ThrowIfNull(visitor);
-        return visitor.VisitStruct(this);
-    }
-
-    private static Dictionary<string, IMemberSchema> BuildMembersByName(
-        IStructMemberSchema<T, TBuilder>[] members
-    )
-    {
-        var byName = new Dictionary<string, IMemberSchema>(StringComparer.Ordinal);
-        foreach (var member in members)
-        {
-            byName.Add(member.Name, member);
-        }
-
-        return byName;
+        return TypedTarget.Accept(visitor);
     }
 }
 
@@ -1125,14 +1151,22 @@ public sealed class StructSchema<T, TBuilder> : Schema<T>, IStructSchema<T, TBui
 /// </summary>
 public sealed class StructProjection<T, TBuilder>
 {
-    private readonly Func<IMemberSchema, bool> include;
+    private readonly IBuilderMemberSchema<T, TBuilder>[] members;
+    private readonly Dictionary<string, IMemberSchema> membersByName;
 
     internal StructProjection(IStructSchema<T, TBuilder> source, Func<IMemberSchema, bool> include)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(include);
         Source = source;
-        this.include = include;
+        var collector = new MemberCollector(include);
+        source.VisitMembers(collector);
+        members = [.. collector.Members];
+        membersByName = members.ToDictionary(
+            member => member.Name,
+            member => (IMemberSchema)member,
+            StringComparer.Ordinal
+        );
     }
 
     public IStructSchema<T, TBuilder> Source { get; }
@@ -1140,43 +1174,37 @@ public sealed class StructProjection<T, TBuilder>
     public IMemberSchema? GetMember(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        return Source.GetMember(name) is { } member && include(member) ? member : null;
+        return membersByName.TryGetValue(name, out var member) ? member : null;
     }
 
     public void VisitMembers(IMemberVisitor<T> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
-        Source.VisitMembers(new Filter(visitor, include));
+        foreach (var member in members)
+        {
+            member.Accept(visitor);
+        }
     }
 
     public void VisitMembers(IMemberVisitor<T, TBuilder> visitor)
     {
         ArgumentNullException.ThrowIfNull(visitor);
-        Source.VisitMembers(new BuilderFilter(visitor, include));
-    }
-
-    private sealed class Filter(IMemberVisitor<T> inner, Func<IMemberSchema, bool> include)
-        : IMemberVisitor<T>
-    {
-        public void Visit<TValue>(IMemberSchema<T, TValue> member)
+        foreach (var member in members)
         {
-            if (include(member))
-            {
-                inner.Visit(member);
-            }
+            member.Accept(visitor);
         }
     }
 
-    private sealed class BuilderFilter(
-        IMemberVisitor<T, TBuilder> inner,
-        Func<IMemberSchema, bool> include
-    ) : IMemberVisitor<T, TBuilder>
+    private sealed class MemberCollector(Func<IMemberSchema, bool> include)
+        : IMemberVisitor<T, TBuilder>
     {
+        public List<IBuilderMemberSchema<T, TBuilder>> Members { get; } = [];
+
         public void Visit<TValue>(IMemberSchema<T, TBuilder, TValue> member)
         {
             if (include(member))
             {
-                inner.Visit(member);
+                Members.Add(member);
             }
         }
     }
@@ -1186,7 +1214,7 @@ public sealed class StructSchemaBuilder<T, TBuilder>
 {
     private readonly ShapeId id;
     private readonly IReadOnlyList<Trait>? traits;
-    private readonly List<IStructMemberSchema<T, TBuilder>> members = [];
+    private readonly List<IBuilderMemberSchema<T, TBuilder>> members = [];
 
     internal StructSchemaBuilder(ShapeId id, IEnumerable<Trait>? traits = null)
     {
@@ -1322,6 +1350,24 @@ public interface IOperationSchema
     bool HasTrait(ShapeId id);
 }
 
+public interface IOperationErrorSchema
+{
+    ShapeId Id { get; }
+
+    Schema UntypedSchema { get; }
+
+    int HttpStatusCode { get; }
+
+    TResult Accept<TResult>(IOperationErrorSchemaVisitor<TResult> visitor);
+}
+
+/// <summary>Recovers a modeled error's exception type without runtime binder dispatch.</summary>
+public interface IOperationErrorSchemaVisitor<out TResult>
+{
+    TResult Visit<TError>(OperationErrorSchema<TError> schema)
+        where TError : Exception;
+}
+
 public sealed class OperationSchema<TInput, TOutput> : IOperationSchema
 {
     internal OperationSchema(
@@ -1375,15 +1421,6 @@ public sealed class OperationSchema<TInput, TOutput> : IOperationSchema
     }
 }
 
-public interface IOperationErrorSchema
-{
-    ShapeId Id { get; }
-
-    Schema UntypedSchema { get; }
-
-    int HttpStatusCode { get; }
-}
-
 public sealed class OperationErrorSchema<TError>(
     ShapeId id,
     Schema<TError> schema,
@@ -1399,6 +1436,12 @@ public sealed class OperationErrorSchema<TError>(
     public Schema UntypedSchema => Schema;
 
     public int HttpStatusCode { get; } = httpStatusCode;
+
+    public TResult Accept<TResult>(IOperationErrorSchemaVisitor<TResult> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        return visitor.Visit(this);
+    }
 }
 
 /// <summary>
@@ -1549,7 +1592,11 @@ public static class Schemas
         new(id, traits);
 
     /// <summary>A list read as <see cref="IReadOnlyList{T}"/>; the form a hand-written schema wants.</summary>
-    public static ListSchema<IReadOnlyList<TElement>, TElement, List<TElement>> List<TElement>(
+    public static CollectionSchema<
+        IReadOnlyList<TElement>,
+        TElement,
+        List<TElement>
+    > List<TElement>(
         ShapeId id,
         Schema<TElement> element,
         IEnumerable<Trait>? traits = null,
@@ -1567,7 +1614,11 @@ public static class Schemas
             elementTraits
         );
 
-    public static ListSchema<TCollection, TElement, TBuilder> List<TCollection, TElement, TBuilder>(
+    public static CollectionSchema<TCollection, TElement, TBuilder> List<
+        TCollection,
+        TElement,
+        TBuilder
+    >(
         ShapeId id,
         Schema<TElement> element,
         Func<TCollection, IEnumerable<TElement>> getElements,
@@ -1589,7 +1640,11 @@ public static class Schemas
             elementTraits
         );
 
-    public static ListSchema<IReadOnlySet<TElement>, TElement, HashSet<TElement>> Set<TElement>(
+    public static CollectionSchema<
+        IReadOnlySet<TElement>,
+        TElement,
+        HashSet<TElement>
+    > Set<TElement>(
         ShapeId id,
         Schema<TElement> element,
         IEnumerable<Trait>? traits = null,
@@ -1607,7 +1662,11 @@ public static class Schemas
             elementTraits
         );
 
-    public static ListSchema<TCollection, TElement, TBuilder> Set<TCollection, TElement, TBuilder>(
+    public static CollectionSchema<TCollection, TElement, TBuilder> Set<
+        TCollection,
+        TElement,
+        TBuilder
+    >(
         ShapeId id,
         Schema<TElement> element,
         Func<TCollection, IEnumerable<TElement>> getElements,

--- a/packages/NSmithy.Core/Serde/SchemaVisitor.cs
+++ b/packages/NSmithy.Core/Serde/SchemaVisitor.cs
@@ -1,0 +1,69 @@
+using System.Numerics;
+
+namespace NSmithy.Core.Serde;
+
+/// <summary>
+/// An <see cref="ISchemaVisitor{TResult}"/> that handles a few shape kinds and answers every other
+/// one through <see cref="VisitDefault"/>, which by default refuses it. For a consumer that only
+/// admits, say, a map: override <see cref="VisitMap"/> and nothing else.
+/// </summary>
+public abstract class SchemaVisitor<TResult> : ISchemaVisitor<TResult>
+{
+    protected virtual TResult VisitDefault(Schema schema) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not support schema kind '{schema.Kind}'."
+        );
+
+    public virtual TResult VisitBoolean(Schema<bool> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitByte(Schema<sbyte> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitShort(Schema<short> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitInteger(Schema<int> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitLong(Schema<long> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitFloat(Schema<float> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitDouble(Schema<double> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitBigInteger(Schema<BigInteger> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitBigDecimal(Schema<decimal> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitString(Schema<string> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitBlob(Schema<byte[]> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitStreamingBlob(Schema<Stream> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitTimestamp(Schema<DateTimeOffset> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitDocument(Schema<Document> schema) => VisitDefault(schema);
+
+    public virtual TResult VisitNullable<T>(NullableSchema<T> schema)
+        where T : struct => VisitDefault(schema);
+
+    public virtual TResult VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) =>
+        VisitDefault(schema);
+
+    public virtual TResult VisitList<TCollection, TElement, TBuilder>(
+        IListSchema<TCollection, TElement, TBuilder> schema
+    ) => VisitDefault((Schema)schema);
+
+    public virtual TResult VisitMap<TDictionary, TValue, TBuilder>(
+        IMapSchema<TDictionary, TValue, TBuilder> schema
+    ) => VisitDefault((Schema)schema);
+
+    public virtual TResult VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema) =>
+        VisitDefault((Schema)schema);
+
+    public virtual TResult VisitUnion<T>(IUnionSchema<T> schema) => VisitDefault((Schema)schema);
+
+    public virtual TResult VisitStringEnum<T>(StringEnumSchema<T> schema)
+        where T : IStringEnumValue<T> => VisitDefault(schema);
+
+    public virtual TResult VisitIntEnum<T>(IntEnumSchema<T> schema)
+        where T : struct, Enum => VisitDefault(schema);
+}

--- a/packages/NSmithy.Core/Trait.cs
+++ b/packages/NSmithy.Core/Trait.cs
@@ -12,4 +12,11 @@ public readonly record struct Trait(ShapeId Id, Document Value)
         : this(id, Document.Null) { }
 
     public bool HasValue => Value.Kind != DocumentKind.Null;
+
+    internal static readonly IReadOnlyDictionary<ShapeId, Trait> None =
+        new Dictionary<ShapeId, Trait>();
+
+    /// <summary>The traits by id, which is how every consumer reads them; null means none.</summary>
+    internal static IReadOnlyDictionary<ShapeId, Trait> Index(IEnumerable<Trait>? traits) =>
+        traits is null ? None : traits.ToDictionary(t => t.Id);
 }

--- a/packages/NSmithy.Core/Validation/SchemaEqualityComparer.cs
+++ b/packages/NSmithy.Core/Validation/SchemaEqualityComparer.cs
@@ -61,7 +61,7 @@ internal static class SchemaEqualityComparer
         public object VisitDocument(Schema<Document> schema) => EqualityComparer<Document>.Default;
 
         public object VisitNullable<T>(NullableSchema<T> schema)
-            where T : struct => new NullableComparer<T>(For(schema.TargetSchema));
+            where T : struct => new NullableComparer<T>(For(schema.TypedTarget));
 
         public object VisitList<TCollection, TElement, TBuilder>(
             IListSchema<TCollection, TElement, TBuilder> schema
@@ -229,7 +229,7 @@ internal sealed class StructComparer<T> : IEqualityComparer<T>, IMemberVisitor<T
     public void Visit<TValue>(IMemberSchema<T, TValue> member)
     {
         members.Add(
-            new MemberComparer<T, TValue>(member, SchemaEqualityComparer.For(member.TargetSchema))
+            new MemberComparer<T, TValue>(member, SchemaEqualityComparer.For(member.TypedTarget))
         );
     }
 

--- a/packages/NSmithy.Core/Validation/SmithyValidator.cs
+++ b/packages/NSmithy.Core/Validation/SmithyValidator.cs
@@ -223,7 +223,7 @@ internal static class ValidatorCompiler
         public object VisitDocument(Schema<Document> schema) => NoOpValidator<Document>.Instance;
 
         public object VisitNullable<T>(NullableSchema<T> schema)
-            where T : struct => new NullableValidator<T>(Compile(schema.TargetSchema));
+            where T : struct => new NullableValidator<T>(Compile(schema.TypedTarget));
 
         public object VisitStreamingBlob(Schema<Stream> schema) => NoOpValidator<Stream>.Instance;
 
@@ -284,7 +284,7 @@ internal static class ValidatorCompiler
         public bool VisitDocument(Schema<Document> schema) => false;
 
         public bool VisitNullable<T>(NullableSchema<T> schema)
-            where T : struct => RequiresValidation(schema.TargetSchema, visited);
+            where T : struct => RequiresValidation(schema.TypedTarget, visited);
 
         public bool VisitStreamingBlob(Schema<Stream> schema) => false;
 
@@ -353,7 +353,7 @@ internal static class ValidatorCompiler
         );
 
     internal static MemberValueValidator<TValue> CompileMember<TValue>(
-        ITargetedMemberSchema<TValue> member
+        ITypedTargetMemberSchema<TValue> member
     ) =>
         new(
             // The member's own traits are compiled against the target's kind: a member schema is
@@ -362,9 +362,9 @@ internal static class ValidatorCompiler
             ConstraintValidator<TValue>.FromTraits(
                 member.MemberTraits,
                 member.Id,
-                member.TargetSchema
+                member.TypedTarget
             ),
-            Compile(member.TargetSchema)
+            Compile(member.TypedTarget)
         );
 }
 

--- a/packages/NSmithy.Http/ModeledErrorSerializer.cs
+++ b/packages/NSmithy.Http/ModeledErrorSerializer.cs
@@ -21,9 +21,9 @@ public sealed class ModeledErrorSerializer
 
     /// <summary>
     /// Compiles the operation's modeled errors into a matcher. <paramref name="compile"/> maps one
-    /// modeled error to its CLR exception type and a serializer; a protocol implements it by
-    /// dispatching to a generic method (typically via <c>(dynamic)error</c>) that closes over the
-    /// protocol's own error-body encoding.
+    /// modeled error to its CLR exception type and a serializer; a protocol can use
+    /// <see cref="IOperationErrorSchema.Accept{TResult}(IOperationErrorSchemaVisitor{TResult})"/> to
+    /// recover that type without reflection or the runtime binder.
     /// </summary>
     public static ModeledErrorSerializer Compile(
         IReadOnlyList<IOperationErrorSchema> errors,

--- a/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsJson/AwsJsonProtocol.cs
@@ -150,7 +150,15 @@ public abstract class AwsJsonProtocol(string contentType) : IProtocol
 
         private static HttpOperationError[] CompileErrors(
             IReadOnlyList<IOperationErrorSchema> errors
-        ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
+        ) => errors.Select(error => error.Accept(ErrorCompiler.Instance)).ToArray();
+
+        private sealed class ErrorCompiler : IOperationErrorSchemaVisitor<HttpOperationError>
+        {
+            public static ErrorCompiler Instance { get; } = new();
+
+            public HttpOperationError Visit<TError>(OperationErrorSchema<TError> error)
+                where TError : Exception => CompileError(error);
+        }
 
         private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
             where TError : Exception

--- a/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
@@ -164,7 +164,15 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
         }
 
         private static QueryError[] CompileErrors(IReadOnlyList<IOperationErrorSchema> schemas) =>
-            schemas.Select(error => (QueryError)CompileError((dynamic)error)).ToArray();
+            schemas.Select(error => error.Accept(QueryErrorCompiler.Instance)).ToArray();
+
+        private sealed class QueryErrorCompiler : IOperationErrorSchemaVisitor<QueryError>
+        {
+            public static QueryErrorCompiler Instance { get; } = new();
+
+            public QueryError Visit<TError>(OperationErrorSchema<TError> error)
+                where TError : Exception => CompileError(error);
+        }
 
         private static QueryError CompileError<TError>(OperationErrorSchema<TError> error)
             where TError : Exception

--- a/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/AwsQueryProtocol.cs
@@ -64,8 +64,7 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
         : IClientOperationProtocol<TInput, TOutput>
     {
         private readonly string action;
-        private readonly string version;
-        private readonly Schema<TInput> inputSchema;
+        private readonly QueryFormSerializer<TInput> requestSerializer;
         private readonly Schema<TOutput> outputSchema;
         private readonly ICodec<TOutput> responseCodec;
         private readonly bool outputIsSmithyUnit;
@@ -81,8 +80,12 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
         )
         {
             action = operation.Id.Name;
-            version = service.Version;
-            inputSchema = operation.Input;
+            requestSerializer = new QueryFormSerializer<TInput>(
+                kind,
+                action,
+                service.Version,
+                operation.Input
+            );
             outputSchema = operation.Output;
             responseCodec = CodecFactory.FromSchema(operation.Output);
             outputIsSmithyUnit = typeof(TOutput) == typeof(SmithyUnit);
@@ -99,9 +102,7 @@ public abstract class QueryProtocol(bool ec2Query) : IProtocol
         {
             var request = new SmithyHttpRequest(HttpMethod.Post, "/")
             {
-                Body = new SmithyHttpBody.Bytes(
-                    new QueryFormSerializer(kind).Serialize(action, version, inputSchema, input)
-                ),
+                Body = new SmithyHttpBody.Bytes(requestSerializer.Serialize(input)),
                 ContentType = FormContentType,
             };
             request.Headers["Accept"] = ["text/xml"];

--- a/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
@@ -108,7 +108,7 @@ internal sealed class QueryFormWriterCompiler(QueryProtocolKind kind)
     private sealed class Visitor(
         QueryFormWriterCompiler owner,
         IReadOnlyDictionary<ShapeId, Trait>? traits
-    ) : SchemaVisitor<object>
+    ) : PartialSchemaVisitor<object>
     {
         public override object VisitBoolean(Schema<bool> schema) =>
             new ScalarWriter<bool>(static value => value ? "true" : "false");
@@ -173,7 +173,7 @@ internal sealed class QueryFormWriterCompiler(QueryProtocolKind kind)
             );
 
         public override object VisitNullable<T>(NullableSchema<T> schema) =>
-            new NullableWriter<T>((IQueryFormWriter<T>)schema.TargetSchema.Resolved.Accept(this));
+            new NullableWriter<T>((IQueryFormWriter<T>)schema.TypedTarget.Resolved.Accept(this));
 
         public override object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema) =>
             owner.cache.GetOrCompile<IQueryFormWriter<T>, DeferredWriter<T>>(
@@ -275,7 +275,7 @@ internal sealed class QueryFormWriterCompiler(QueryProtocolKind kind)
                 new MemberWriter<T, TValue>(
                     member,
                     owner.MemberName(member),
-                    owner.Compile(member.TargetSchema, member.MemberTraits)
+                    owner.Compile(member.TypedTarget, member.MemberTraits)
                 )
             );
     }

--- a/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
+++ b/packages/NSmithy.Protocols.AwsQuery/QueryFormSerializer.cs
@@ -12,25 +12,45 @@ internal enum QueryProtocolKind
     Ec2Query,
 }
 
-internal sealed class QueryFormSerializer(QueryProtocolKind kind)
+/// <summary>Writes one value's <c>application/x-www-form-urlencoded</c> parameters under a prefix.</summary>
+internal interface IQueryFormWriter<in T>
 {
-    private static readonly ShapeId Ec2QueryName = ShapeId.Parse("aws.protocols#ec2QueryName");
-    private static readonly ShapeId TimestampFormat = ShapeId.Parse("smithy.api#timestampFormat");
-    private static readonly ShapeId XmlFlattened = ShapeId.Parse("smithy.api#xmlFlattened");
-    private static readonly ShapeId XmlName = ShapeId.Parse("smithy.api#xmlName");
+    void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value);
+}
 
-    private readonly List<KeyValuePair<string, string>> parameters = [];
+/// <summary>
+/// Serializes an operation input as an AWS Query / EC2 Query form body. The writer tree is compiled
+/// once per operation; a request only walks it.
+/// </summary>
+internal sealed class QueryFormSerializer<T>
+{
+    private readonly string action;
+    private readonly string version;
+    private readonly IQueryFormWriter<T> writer;
 
-    public byte[] Serialize<T>(string action, string version, Schema<T> schema, T value)
+    public QueryFormSerializer(
+        QueryProtocolKind kind,
+        string action,
+        string version,
+        Schema<T> schema
+    )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(action);
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
         ArgumentNullException.ThrowIfNull(schema);
+        this.action = action;
+        this.version = version;
+        writer = new QueryFormWriterCompiler(kind).Compile(schema, memberTraits: null);
+    }
 
-        parameters.Clear();
-        parameters.Add(new KeyValuePair<string, string>("Action", action));
-        parameters.Add(new KeyValuePair<string, string>("Version", version));
-        WriteValue(schema, value, string.Empty, traits: null);
+    public byte[] Serialize(T value)
+    {
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("Action", action),
+            new("Version", version),
+        };
+        writer.Write(parameters, string.Empty, value);
 
         return Encoding.UTF8.GetBytes(
             string.Join(
@@ -41,233 +61,40 @@ internal sealed class QueryFormSerializer(QueryProtocolKind kind)
             )
         );
     }
+}
 
-    private void WriteValue(
-        Schema schema,
-        object? value,
-        string prefix,
-        IReadOnlyDictionary<ShapeId, Trait>? traits
-    )
-    {
-        if (value is null)
-        {
-            return;
-        }
+internal sealed class QueryFormWriterCompiler(QueryProtocolKind kind)
+{
+    private readonly QueryProtocolKind kind = kind;
+    private static readonly ShapeId Ec2QueryName = ShapeId.Parse("aws.protocols#ec2QueryName");
+    private static readonly ShapeId TimestampFormat = ShapeId.Parse("smithy.api#timestampFormat");
+    private static readonly ShapeId XmlFlattened = ShapeId.Parse("smithy.api#xmlFlattened");
+    private static readonly ShapeId XmlName = ShapeId.Parse("smithy.api#xmlName");
 
-        schema = UnwrapNullable(schema);
-        switch (schema)
-        {
-            case IStructSchema structure:
-                WriteStruct((dynamic)structure, value, prefix);
-                return;
-            case IListSchema list:
-                WriteList(list, value, prefix, traits);
-                return;
-            case IMapSchema map:
-                WriteMap(map, value, prefix, traits);
-                return;
-            case IUnionSchema:
-                throw Unsupported(schema);
-        }
+    // Structures are the only recursive shape, and the only one whose writer ignores the member's
+    // traits, so they alone are memoized.
+    private readonly SchemaCompilationCache cache = new();
 
-        if (prefix.Length == 0)
-        {
-            return;
-        }
-
-        parameters.Add(
-            new KeyValuePair<string, string>(prefix, FormatScalar(schema, traits, value))
-        );
-    }
-
-    private void WriteStruct<T>(IStructSchema<T> schema, object value, string prefix)
-    {
-        schema.VisitMembers(new StructWriter<T>(this, (T)value, prefix));
-    }
-
-    private void WriteList(
-        IListSchema schema,
-        object value,
-        string prefix,
-        IReadOnlyDictionary<ShapeId, Trait>? traits
-    )
-    {
-        var elements = schema.GetElementsObject(value).ToArray();
-        var flattened = kind == QueryProtocolKind.Ec2Query || HasDirectTrait(traits, XmlFlattened);
-        if (elements.Length == 0)
-        {
-            if (kind == QueryProtocolKind.AwsQuery && !flattened)
-            {
-                parameters.Add(new KeyValuePair<string, string>(prefix, string.Empty));
-            }
-            return;
-        }
-
-        var itemName =
-            kind == QueryProtocolKind.AwsQuery && !flattened
-                ? DirectStringTrait(schema.ElementMember.MemberTraits, XmlName) ?? "member"
-                : null;
-        for (var index = 0; index < elements.Length; index++)
-        {
-            var itemPrefix = Join(
-                prefix,
-                itemName,
-                (index + 1).ToString(CultureInfo.InvariantCulture)
-            );
-            WriteValue(
-                schema.Element,
-                elements[index],
-                itemPrefix,
-                schema.ElementMember.MemberTraits
-            );
-        }
-    }
-
-    private void WriteMap(
-        IMapSchema schema,
-        object value,
-        string prefix,
-        IReadOnlyDictionary<ShapeId, Trait>? traits
-    )
-    {
-        var entries = schema.GetEntriesObject(value).ToArray();
-        if (entries.Length == 0)
-        {
-            return;
-        }
-        if (kind == QueryProtocolKind.Ec2Query)
-        {
-            throw new NotSupportedException("EC2 Query does not support map input shapes.");
-        }
-
-        var flattened = HasDirectTrait(traits, XmlFlattened);
-        var keyName = DirectStringTrait(schema.KeyMember.MemberTraits, XmlName) ?? "key";
-        var valueMember = FindMapValueMember(schema);
-        var valueName = DirectStringTrait(valueMember.MemberTraits, XmlName) ?? "value";
-        for (var index = 0; index < entries.Length; index++)
-        {
-            var entryPrefix = Join(
-                prefix,
-                flattened ? null : "entry",
-                (index + 1).ToString(CultureInfo.InvariantCulture)
-            );
-            parameters.Add(
-                new KeyValuePair<string, string>(Join(entryPrefix, keyName), entries[index].Key)
-            );
-            WriteValue(
-                schema.Value,
-                entries[index].Value,
-                Join(entryPrefix, valueName),
-                valueMember.MemberTraits
-            );
-        }
-    }
-
-    private static IMemberSchema FindMapValueMember(IMapSchema schema) =>
-        (IMemberSchema)((dynamic)schema).TypedValueMember;
+    public IQueryFormWriter<T> Compile<T>(
+        Schema<T> schema,
+        IReadOnlyDictionary<ShapeId, Trait>? memberTraits
+    ) => (IQueryFormWriter<T>)schema.Resolved.Accept(new Visitor(this, memberTraits));
 
     private string MemberName(IMemberSchema member)
     {
         if (kind == QueryProtocolKind.AwsQuery)
         {
-            return DirectStringTrait(member.MemberTraits, XmlName) ?? member.Name;
+            return StringTrait(member.MemberTraits, XmlName) ?? member.Name;
         }
 
-        var ec2Name = DirectStringTrait(member.MemberTraits, Ec2QueryName);
-        if (ec2Name is not null)
-        {
-            return ec2Name;
-        }
-
-        return UppercaseFirst(DirectStringTrait(member.MemberTraits, XmlName) ?? member.Name);
+        return StringTrait(member.MemberTraits, Ec2QueryName)
+            ?? UppercaseFirst(StringTrait(member.MemberTraits, XmlName) ?? member.Name);
     }
 
-    private static string FormatScalar(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    ) =>
-        schema.Kind switch
-        {
-            ShapeKind.Boolean => (bool)value ? "true" : "false",
-            ShapeKind.Byte => ((sbyte)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Short => ((short)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Integer => ((int)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Long => ((long)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Float => ((float)value).ToString("R", CultureInfo.InvariantCulture),
-            ShapeKind.Double => ((double)value).ToString("R", CultureInfo.InvariantCulture),
-            ShapeKind.BigInteger => ((BigInteger)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.BigDecimal => ((decimal)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.String => (string)value,
-            ShapeKind.Enum => ((IStringEnumValue)value).Value,
-            ShapeKind.IntEnum => ((IIntEnumSchema)schema)
-                .GetIntegerValueObject(value)
-                .ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Blob when value is byte[] bytes => Convert.ToBase64String(bytes),
-            ShapeKind.Timestamp => FormatTimestamp(schema, traits, (DateTimeOffset)value),
-            _ => throw Unsupported(schema),
-        };
-
-    private static string FormatTimestamp(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        DateTimeOffset value
-    ) =>
-        TraitValue(schema, traits, TimestampFormat) switch
-        {
-            null or "date-time" => FormatRfc3339(value),
-            "epoch-seconds" => FormatEpochSeconds(value),
-            "http-date" => value.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture),
-            var format => throw new NotSupportedException(
-                $"Timestamp format '{format}' is not supported by AWS Query."
-            ),
-        };
-
-    private static string FormatRfc3339(DateTimeOffset value)
-    {
-        var utc = value.ToUniversalTime();
-        return utc.Ticks % TimeSpan.TicksPerSecond == 0
-            ? utc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture)
-            : utc.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'", CultureInfo.InvariantCulture);
-    }
-
-    private static string FormatEpochSeconds(DateTimeOffset value)
-    {
-        var unixSeconds = value.ToUnixTimeSeconds();
-        var fractionalTicks = value.ToUniversalTime().Ticks % TimeSpan.TicksPerSecond;
-        if (fractionalTicks == 0)
-        {
-            return unixSeconds.ToString(CultureInfo.InvariantCulture);
-        }
-
-        var fractional = ((decimal)fractionalTicks / TimeSpan.TicksPerSecond).ToString(
-            "0.################",
-            CultureInfo.InvariantCulture
-        );
-        return $"{unixSeconds}{fractional[1..]}";
-    }
-
-    private static string? TraitValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        ShapeId id
-    ) =>
-        DirectStringTrait(traits, id)
-        ?? (schema.GetTrait(id) is { HasValue: true } trait ? trait.Value.AsString() : null);
-
-    private static string? DirectStringTrait(
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        ShapeId id
-    ) =>
+    private static string? StringTrait(IReadOnlyDictionary<ShapeId, Trait>? traits, ShapeId id) =>
         traits is not null && traits.TryGetValue(id, out var trait) && trait.HasValue
             ? trait.Value.AsString()
             : null;
-
-    private static bool HasDirectTrait(IReadOnlyDictionary<ShapeId, Trait>? traits, ShapeId id) =>
-        traits?.ContainsKey(id) == true;
-
-    private static Schema UnwrapNullable(Schema schema) =>
-        schema.Resolved is INullableSchema nullable ? nullable.Target.Resolved : schema.Resolved;
 
     private static string Join(string first, params string?[] parts)
     {
@@ -278,26 +105,346 @@ internal sealed class QueryFormSerializer(QueryProtocolKind kind)
     private static string UppercaseFirst(string value) =>
         value.Length == 0 ? value : char.ToUpperInvariant(value[0]) + value[1..];
 
-    private static NotSupportedException Unsupported(Schema schema) =>
-        new($"AWS Query does not support schema kind '{schema.Kind}' on shape '{schema.Id}'.");
-
-    private sealed class StructWriter<T>(QueryFormSerializer owner, T value, string prefix)
-        : IMemberVisitor<T>
+    private sealed class Visitor(
+        QueryFormWriterCompiler owner,
+        IReadOnlyDictionary<ShapeId, Trait>? traits
+    ) : SchemaVisitor<object>
     {
-        public void Visit<TValue>(IMemberSchema<T, TValue> member)
+        public override object VisitBoolean(Schema<bool> schema) =>
+            new ScalarWriter<bool>(static value => value ? "true" : "false");
+
+        public override object VisitByte(Schema<sbyte> schema) => Number<sbyte>();
+
+        public override object VisitShort(Schema<short> schema) => Number<short>();
+
+        public override object VisitInteger(Schema<int> schema) => Number<int>();
+
+        public override object VisitLong(Schema<long> schema) => Number<long>();
+
+        public override object VisitFloat(Schema<float> schema) =>
+            new ScalarWriter<float>(static value =>
+                value.ToString("R", CultureInfo.InvariantCulture)
+            );
+
+        public override object VisitDouble(Schema<double> schema) =>
+            new ScalarWriter<double>(static value =>
+                value.ToString("R", CultureInfo.InvariantCulture)
+            );
+
+        public override object VisitBigInteger(Schema<BigInteger> schema) => Number<BigInteger>();
+
+        public override object VisitBigDecimal(Schema<decimal> schema) => Number<decimal>();
+
+        public override object VisitString(Schema<string> schema) =>
+            new ScalarWriter<string>(static value => value);
+
+        public override object VisitBlob(Schema<byte[]> schema) =>
+            new ScalarWriter<byte[]>(Convert.ToBase64String);
+
+        public override object VisitTimestamp(Schema<DateTimeOffset> schema)
         {
-            var memberValue = member.GetValue(value);
-            if (memberValue is null)
+            var format =
+                StringTrait(traits, TimestampFormat)
+                ?? (
+                    schema.GetTrait(TimestampFormat) is { HasValue: true } trait
+                        ? trait.Value.AsString()
+                        : null
+                );
+            return new ScalarWriter<DateTimeOffset>(
+                format switch
+                {
+                    null or "date-time" => FormatRfc3339,
+                    "epoch-seconds" => FormatEpochSeconds,
+                    "http-date" => static value =>
+                        value.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture),
+                    _ => throw new NotSupportedException(
+                        $"Timestamp format '{format}' is not supported by AWS Query."
+                    ),
+                }
+            );
+        }
+
+        public override object VisitStringEnum<T>(StringEnumSchema<T> schema) =>
+            new ScalarWriter<T>(static value => value.Value);
+
+        public override object VisitIntEnum<T>(IntEnumSchema<T> schema) =>
+            new ScalarWriter<T>(value =>
+                schema.GetIntegerValue(value).ToString(CultureInfo.InvariantCulture)
+            );
+
+        public override object VisitNullable<T>(NullableSchema<T> schema) =>
+            new NullableWriter<T>((IQueryFormWriter<T>)schema.TargetSchema.Resolved.Accept(this));
+
+        public override object VisitStruct<T, TBuilder>(IStructSchema<T, TBuilder> schema) =>
+            owner.cache.GetOrCompile<IQueryFormWriter<T>, DeferredWriter<T>>(
+                (Schema)schema,
+                static () => new DeferredWriter<T>(),
+                _ =>
+                {
+                    var members = new MemberCompiler<T>(owner);
+                    schema.VisitMembers(members);
+                    return new StructWriter<T>([.. members.Writers]);
+                }
+            );
+
+        public override object VisitList<TCollection, TElement, TBuilder>(
+            IListSchema<TCollection, TElement, TBuilder> schema
+        )
+        {
+            var flattened =
+                owner.kind == QueryProtocolKind.Ec2Query
+                || traits?.ContainsKey(XmlFlattened) == true;
+            var itemName =
+                owner.kind == QueryProtocolKind.AwsQuery && !flattened
+                    ? StringTrait(schema.ElementMember.MemberTraits, XmlName) ?? "member"
+                    : null;
+            return new ListWriter<TCollection, TElement>(
+                schema.GetElements,
+                owner.Compile(schema.ElementSchema, schema.ElementMember.MemberTraits),
+                writeEmptyMarker: owner.kind == QueryProtocolKind.AwsQuery && !flattened,
+                itemName
+            );
+        }
+
+        public override object VisitMap<TDictionary, TValue, TBuilder>(
+            IMapSchema<TDictionary, TValue, TBuilder> schema
+        )
+        {
+            if (owner.kind == QueryProtocolKind.Ec2Query)
+            {
+                return new Ec2MapWriter<TDictionary, TValue>(schema.GetEntries);
+            }
+
+            var valueMember = schema.TypedValueMember;
+            return new MapWriter<TDictionary, TValue>(
+                schema.GetEntries,
+                owner.Compile(schema.ValueSchema, valueMember.MemberTraits),
+                entryName: traits?.ContainsKey(XmlFlattened) == true ? null : "entry",
+                keyName: StringTrait(schema.KeyMember.MemberTraits, XmlName) ?? "key",
+                valueName: StringTrait(valueMember.MemberTraits, XmlName) ?? "value"
+            );
+        }
+
+        public override object VisitUnion<T>(IUnionSchema<T> schema) =>
+            new UnsupportedWriter<T>((Schema)schema);
+
+        public override object VisitDocument(Schema<Document> schema) =>
+            new UnsupportedWriter<Document>(schema);
+
+        public override object VisitStreamingBlob(Schema<Stream> schema) =>
+            new UnsupportedWriter<Stream>(schema);
+
+        public override object VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema) =>
+            new UnsupportedWriter<IAsyncEnumerable<TEvent>>(schema);
+
+        private static ScalarWriter<T> Number<T>()
+            where T : IFormattable =>
+            new(static value => value.ToString(null, CultureInfo.InvariantCulture));
+
+        private static string FormatRfc3339(DateTimeOffset value)
+        {
+            var utc = value.ToUniversalTime();
+            return utc.Ticks % TimeSpan.TicksPerSecond == 0
+                ? utc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture)
+                : utc.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'", CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatEpochSeconds(DateTimeOffset value)
+        {
+            var unixSeconds = value.ToUnixTimeSeconds();
+            var fractionalTicks = value.ToUniversalTime().Ticks % TimeSpan.TicksPerSecond;
+            if (fractionalTicks == 0)
+            {
+                return unixSeconds.ToString(CultureInfo.InvariantCulture);
+            }
+
+            var fractional = ((decimal)fractionalTicks / TimeSpan.TicksPerSecond).ToString(
+                "0.################",
+                CultureInfo.InvariantCulture
+            );
+            return $"{unixSeconds}{fractional[1..]}";
+        }
+    }
+
+    private sealed class MemberCompiler<T>(QueryFormWriterCompiler owner) : IMemberVisitor<T>
+    {
+        public List<IQueryFormWriter<T>> Writers { get; } = [];
+
+        public void Visit<TValue>(IMemberSchema<T, TValue> member) =>
+            Writers.Add(
+                new MemberWriter<T, TValue>(
+                    member,
+                    owner.MemberName(member),
+                    owner.Compile(member.TargetSchema, member.MemberTraits)
+                )
+            );
+    }
+
+    // A scalar at the root has no name to be written under.
+    private sealed class ScalarWriter<T>(Func<T, string> format) : IQueryFormWriter<T>
+    {
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value)
+        {
+            if (value is not null && prefix.Length > 0)
+            {
+                parameters.Add(new(prefix, format(value)));
+            }
+        }
+    }
+
+    private sealed class NullableWriter<T>(IQueryFormWriter<T> inner) : IQueryFormWriter<T?>
+        where T : struct
+    {
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T? value)
+        {
+            if (value is { } present)
+            {
+                inner.Write(parameters, prefix, present);
+            }
+        }
+    }
+
+    private sealed class StructWriter<T>(IQueryFormWriter<T>[] members) : IQueryFormWriter<T>
+    {
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value)
+        {
+            if (value is null)
             {
                 return;
             }
 
-            owner.WriteValue(
-                member.TargetSchema,
-                memberValue,
-                Join(prefix, owner.MemberName(member)),
-                member.MemberTraits
-            );
+            foreach (var member in members)
+            {
+                member.Write(parameters, prefix, value);
+            }
         }
+    }
+
+    private sealed class MemberWriter<T, TValue>(
+        IMemberSchema<T, TValue> member,
+        string name,
+        IQueryFormWriter<TValue> target
+    ) : IQueryFormWriter<T>
+    {
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value)
+        {
+            if (member.GetValue(value) is { } memberValue)
+            {
+                target.Write(parameters, Join(prefix, name), memberValue);
+            }
+        }
+    }
+
+    private sealed class ListWriter<TCollection, TElement>(
+        Func<TCollection, IEnumerable<TElement>> elements,
+        IQueryFormWriter<TElement> element,
+        bool writeEmptyMarker,
+        string? itemName
+    ) : IQueryFormWriter<TCollection>
+    {
+        public void Write(
+            List<KeyValuePair<string, string>> parameters,
+            string prefix,
+            TCollection value
+        )
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            var index = 0;
+            foreach (var item in elements(value))
+            {
+                index++;
+                element.Write(
+                    parameters,
+                    Join(prefix, itemName, index.ToString(CultureInfo.InvariantCulture)),
+                    item
+                );
+            }
+
+            if (index == 0 && writeEmptyMarker)
+            {
+                parameters.Add(new(prefix, string.Empty));
+            }
+        }
+    }
+
+    private sealed class MapWriter<TDictionary, TValue>(
+        Func<TDictionary, IEnumerable<KeyValuePair<string, TValue>>> entries,
+        IQueryFormWriter<TValue> value,
+        string? entryName,
+        string keyName,
+        string valueName
+    ) : IQueryFormWriter<TDictionary>
+    {
+        public void Write(
+            List<KeyValuePair<string, string>> parameters,
+            string prefix,
+            TDictionary map
+        )
+        {
+            if (map is null)
+            {
+                return;
+            }
+
+            var index = 0;
+            foreach (var entry in entries(map))
+            {
+                index++;
+                var entryPrefix = Join(
+                    prefix,
+                    entryName,
+                    index.ToString(CultureInfo.InvariantCulture)
+                );
+                parameters.Add(new(Join(entryPrefix, keyName), entry.Key));
+                value.Write(parameters, Join(entryPrefix, valueName), entry.Value);
+            }
+        }
+    }
+
+    // EC2 Query has no map form; an empty map is still nothing to write.
+    private sealed class Ec2MapWriter<TDictionary, TValue>(
+        Func<TDictionary, IEnumerable<KeyValuePair<string, TValue>>> entries
+    ) : IQueryFormWriter<TDictionary>
+    {
+        public void Write(
+            List<KeyValuePair<string, string>> parameters,
+            string prefix,
+            TDictionary map
+        )
+        {
+            if (map is not null && entries(map).Any())
+            {
+                throw new NotSupportedException("EC2 Query does not support map input shapes.");
+            }
+        }
+    }
+
+    private sealed class UnsupportedWriter<T>(Schema schema) : IQueryFormWriter<T>
+    {
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value)
+        {
+            if (value is not null)
+            {
+                throw new NotSupportedException(
+                    $"AWS Query does not support schema kind '{schema.Kind}' on shape '{schema.Id}'."
+                );
+            }
+        }
+    }
+
+    private sealed class DeferredWriter<T>
+        : IQueryFormWriter<T>,
+            IDeferredCompilation<IQueryFormWriter<T>>
+    {
+        private IQueryFormWriter<T>? compiled;
+
+        public void Complete(IQueryFormWriter<T> writer) => compiled = writer;
+
+        public void Write(List<KeyValuePair<string, string>> parameters, string prefix, T value) =>
+            compiled!.Write(parameters, prefix, value);
     }
 }

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -78,14 +78,9 @@ public sealed class GrpcProtocol : IProtocol
             var inputValidator = validateInput ? SmithyValidator.FromSchema(operation.Input) : null;
 
             // Each direction is chosen independently; the four call shapes are their cross product.
-            var inputEvent = FindEventStreamEventSchema(operation.Input);
-            var outputEvent = FindEventStreamEventSchema(operation.Output);
-            RequestStrategy<TInput> request = inputEvent is null
-                ? UnaryRequest(operation.Input)
-                : StreamingRequest(operation.Input, (dynamic)inputEvent);
-            ResponseStrategy<TOutput> response = outputEvent is null
-                ? UnaryResponse(operation.Output)
-                : StreamingResponse(operation.Output, (dynamic)outputEvent);
+            var request = CompileStreamingRequest(operation.Input) ?? UnaryRequest(operation.Input);
+            var response =
+                CompileStreamingResponse(operation.Output) ?? UnaryResponse(operation.Output);
 
             return new OperationProtocol<TInput, TOutput>(
                 service,
@@ -154,6 +149,49 @@ public sealed class GrpcProtocol : IProtocol
         );
     }
 
+    private static RequestStrategy<TInput>? CompileStreamingRequest<TInput>(
+        Schema<TInput> inputSchema
+    )
+    {
+        if (inputSchema.Resolved is not IStructSchema<TInput> structure)
+        {
+            return null;
+        }
+
+        var visitor = new StreamingRequestMemberVisitor<TInput>(inputSchema);
+        structure.VisitMembers(visitor);
+        return visitor.Strategy;
+    }
+
+    private sealed class StreamingRequestMemberVisitor<TInput>(Schema<TInput> inputSchema)
+        : IMemberVisitor<TInput>
+    {
+        public RequestStrategy<TInput>? Strategy { get; private set; }
+
+        public void Visit<TValue>(IMemberSchema<TInput, TValue> member)
+        {
+            if (member.Target is not IEventStreamSchema)
+            {
+                return;
+            }
+
+            if (Strategy is not null)
+            {
+                throw new InvalidOperationException("Operation shape has multiple event streams.");
+            }
+
+            Strategy = member.Target.Accept(new StreamingRequestCompiler<TInput>(inputSchema));
+        }
+    }
+
+    private sealed class StreamingRequestCompiler<TInput>(Schema<TInput> inputSchema)
+        : PartialSchemaVisitor<RequestStrategy<TInput>>
+    {
+        public override RequestStrategy<TInput> VisitEventStream<TEvent>(
+            EventStreamSchema<TEvent> schema
+        ) => StreamingRequest(inputSchema, schema.TypedEventSchema);
+    }
+
     private static ResponseStrategy<TOutput> UnaryResponse<TOutput>(Schema<TOutput> outputSchema)
     {
         if (IsUnit<TOutput>(outputSchema))
@@ -205,6 +243,49 @@ public sealed class GrpcProtocol : IProtocol
         );
     }
 
+    private static ResponseStrategy<TOutput>? CompileStreamingResponse<TOutput>(
+        Schema<TOutput> outputSchema
+    )
+    {
+        if (outputSchema.Resolved is not IStructSchema<TOutput> structure)
+        {
+            return null;
+        }
+
+        var visitor = new StreamingResponseMemberVisitor<TOutput>(outputSchema);
+        structure.VisitMembers(visitor);
+        return visitor.Strategy;
+    }
+
+    private sealed class StreamingResponseMemberVisitor<TOutput>(Schema<TOutput> outputSchema)
+        : IMemberVisitor<TOutput>
+    {
+        public ResponseStrategy<TOutput>? Strategy { get; private set; }
+
+        public void Visit<TValue>(IMemberSchema<TOutput, TValue> member)
+        {
+            if (member.Target is not IEventStreamSchema)
+            {
+                return;
+            }
+
+            if (Strategy is not null)
+            {
+                throw new InvalidOperationException("Operation shape has multiple event streams.");
+            }
+
+            Strategy = member.Target.Accept(new StreamingResponseCompiler<TOutput>(outputSchema));
+        }
+    }
+
+    private sealed class StreamingResponseCompiler<TOutput>(Schema<TOutput> outputSchema)
+        : PartialSchemaVisitor<ResponseStrategy<TOutput>>
+    {
+        public override ResponseStrategy<TOutput> VisitEventStream<TEvent>(
+            EventStreamSchema<TEvent> schema
+        ) => StreamingResponse(outputSchema, schema.TypedEventSchema);
+    }
+
     private sealed class OperationProtocol<TInput, TOutput>(
         ServiceSchema service,
         OperationSchema<TInput, TOutput> operation,
@@ -219,7 +300,7 @@ public sealed class GrpcProtocol : IProtocol
 
         private readonly ModeledErrorSerializer serverErrors = ModeledErrorSerializer.Compile(
             operation.Errors,
-            error => CompileServerError((dynamic)error)
+            error => error.Accept(ServerErrorCompiler.Instance)
         );
 
         public IReadOnlyList<HttpOperationError> HttpErrors { get; } =
@@ -313,6 +394,17 @@ public sealed class GrpcProtocol : IProtocol
                 )
         );
 
+    private sealed class ServerErrorCompiler
+        : IOperationErrorSchemaVisitor<(Type, Func<Exception, SmithyHttpServerResponse>)>
+    {
+        public static ServerErrorCompiler Instance { get; } = new();
+
+        public (Type, Func<Exception, SmithyHttpServerResponse>) Visit<TError>(
+            OperationErrorSchema<TError> schema
+        )
+            where TError : Exception => CompileServerError(schema);
+    }
+
     private static SmithyHttpServerResponse SerializeGrpcError<TError>(
         Schema<TError> errorSchema,
         TError value,
@@ -335,7 +427,15 @@ public sealed class GrpcProtocol : IProtocol
 
     private static HttpOperationError[] CompileErrors(
         IReadOnlyList<IOperationErrorSchema> errors
-    ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
+    ) => errors.Select(error => error.Accept(ErrorCompiler.Instance)).ToArray();
+
+    private sealed class ErrorCompiler : IOperationErrorSchemaVisitor<HttpOperationError>
+    {
+        public static ErrorCompiler Instance { get; } = new();
+
+        public HttpOperationError Visit<TError>(OperationErrorSchema<TError> schema)
+            where TError : Exception => CompileError(schema);
+    }
 
     private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
         where TError : Exception
@@ -755,36 +855,4 @@ public sealed class GrpcProtocol : IProtocol
 
     private static bool IsUnit<T>(Schema schema) =>
         typeof(T) == typeof(SmithyUnit) || Schemas.IsSyntheticUnit(schema);
-
-    private static Schema? FindEventStreamEventSchema<T>(Schema<T> schema)
-    {
-        if (schema.Resolved is not IStructSchema<T> structure)
-        {
-            return null;
-        }
-
-        var visitor = new EventStreamSchemaVisitor<T>();
-        structure.VisitMembers(visitor);
-        return visitor.EventSchema;
-    }
-
-    private sealed class EventStreamSchemaVisitor<T> : IMemberVisitor<T>
-    {
-        public Schema? EventSchema { get; private set; }
-
-        public void Visit<TValue>(IMemberSchema<T, TValue> member)
-        {
-            if (member.Target is not IEventStreamSchema eventStream)
-            {
-                return;
-            }
-
-            if (EventSchema is not null)
-            {
-                throw new InvalidOperationException("Operation shape has multiple event streams.");
-            }
-
-            EventSchema = eventStream.EventSchema;
-        }
-    }
 }

--- a/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
+++ b/packages/NSmithy.Protocols.Grpc/GrpcProtocol.cs
@@ -756,13 +756,13 @@ public sealed class GrpcProtocol : IProtocol
     private static bool IsUnit<T>(Schema schema) =>
         typeof(T) == typeof(SmithyUnit) || Schemas.IsSyntheticUnit(schema);
 
-    private static Schema? FindEventStreamEventSchema(Schema schema) =>
-        schema.Resolved is IStructSchema structure
-            ? FindEventStreamEventSchemaCore((dynamic)structure)
-            : null;
-
-    private static Schema? FindEventStreamEventSchemaCore<T>(IStructSchema<T> structure)
+    private static Schema? FindEventStreamEventSchema<T>(Schema<T> schema)
     {
+        if (schema.Resolved is not IStructSchema<T> structure)
+        {
+            return null;
+        }
+
         var visitor = new EventStreamSchemaVisitor<T>();
         structure.VisitMembers(visitor);
         return visitor.EventSchema;

--- a/packages/NSmithy.Protocols.Rest/HttpBindingCompiler.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpBindingCompiler.cs
@@ -33,7 +33,7 @@ internal interface IHttpValueCodec<T>
 
 /// <summary>Compiles the <see cref="IHttpValueCodec{T}"/> for a bound member's target.</summary>
 internal sealed class HttpBindingCompiler(IReadOnlyDictionary<ShapeId, Trait>? memberTraits)
-    : SchemaVisitor<object>
+    : PartialSchemaVisitor<object>
 {
     internal static IHttpValueCodec<T> Compile<T>(
         Schema<T> target,
@@ -75,7 +75,7 @@ internal sealed class HttpBindingCompiler(IReadOnlyDictionary<ShapeId, Trait>? m
         new TimestampHttpCodec(TimestampFormat(schema));
 
     public override object VisitNullable<T>(NullableSchema<T> schema) =>
-        new NullableHttpCodec<T>((IHttpValueCodec<T>)schema.TargetSchema.Resolved.Accept(this));
+        new NullableHttpCodec<T>((IHttpValueCodec<T>)schema.TypedTarget.Resolved.Accept(this));
 
     public override object VisitList<TCollection, TElement, TBuilder>(
         IListSchema<TCollection, TElement, TBuilder> schema

--- a/packages/NSmithy.Protocols.Rest/HttpBindingCompiler.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpBindingCompiler.cs
@@ -1,0 +1,330 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Protocols.Rest;
+
+/// <summary>
+/// The text forms of one HTTP-bound value type, compiled once per member from its target schema and
+/// member traits. A scalar codec reads and writes one string; a list codec spreads its elements
+/// over the several forms a header or query string can hold.
+/// </summary>
+internal interface IHttpValueCodec<T>
+{
+    /// <summary>The single text form: a label, a prefix-header value, one query value.</summary>
+    string Format(T value);
+
+    /// <summary>Reads the single text form; a caller's malformed text is a structured 400.</summary>
+    T Parse(string value);
+
+    /// <summary>The header form: a scalar as is, a list joined with quoting where needed.</summary>
+    string FormatHeader(T value);
+
+    T ParseHeader(string value);
+
+    /// <summary>Appends the query pairs the value contributes: one per scalar, one per list element.</summary>
+    void AppendQuery(HttpUriBuilder uri, string name, T value);
+
+    /// <summary>Reads the values a query string carried under one name.</summary>
+    T ParseMany(IReadOnlyList<string> values);
+}
+
+/// <summary>Compiles the <see cref="IHttpValueCodec{T}"/> for a bound member's target.</summary>
+internal sealed class HttpBindingCompiler(IReadOnlyDictionary<ShapeId, Trait>? memberTraits)
+    : SchemaVisitor<object>
+{
+    internal static IHttpValueCodec<T> Compile<T>(
+        Schema<T> target,
+        IReadOnlyDictionary<ShapeId, Trait>? memberTraits
+    ) => (IHttpValueCodec<T>)target.Resolved.Accept(new HttpBindingCompiler(memberTraits));
+
+    public override object VisitBoolean(Schema<bool> schema) => new BooleanHttpCodec();
+
+    public override object VisitByte(Schema<sbyte> schema) =>
+        new NumberHttpCodec<sbyte>(ShapeKind.Byte, sbyte.Parse);
+
+    public override object VisitShort(Schema<short> schema) =>
+        new NumberHttpCodec<short>(ShapeKind.Short, short.Parse);
+
+    public override object VisitInteger(Schema<int> schema) =>
+        new NumberHttpCodec<int>(ShapeKind.Integer, int.Parse);
+
+    public override object VisitLong(Schema<long> schema) =>
+        new NumberHttpCodec<long>(ShapeKind.Long, long.Parse);
+
+    public override object VisitFloat(Schema<float> schema) => new FloatHttpCodec();
+
+    public override object VisitDouble(Schema<double> schema) => new DoubleHttpCodec();
+
+    public override object VisitBigInteger(Schema<BigInteger> schema) =>
+        new NumberHttpCodec<BigInteger>(ShapeKind.BigInteger, BigInteger.Parse);
+
+    public override object VisitBigDecimal(Schema<decimal> schema) =>
+        new NumberHttpCodec<decimal>(ShapeKind.BigDecimal, decimal.Parse);
+
+    public override object VisitString(Schema<string> schema) =>
+        HasTrait(schema, RestTraits.MediaType)
+            ? new Base64StringHttpCodec()
+            : new StringHttpCodec();
+
+    public override object VisitBlob(Schema<byte[]> schema) => new BlobHttpCodec();
+
+    public override object VisitTimestamp(Schema<DateTimeOffset> schema) =>
+        new TimestampHttpCodec(TimestampFormat(schema));
+
+    public override object VisitNullable<T>(NullableSchema<T> schema) =>
+        new NullableHttpCodec<T>((IHttpValueCodec<T>)schema.TargetSchema.Resolved.Accept(this));
+
+    public override object VisitList<TCollection, TElement, TBuilder>(
+        IListSchema<TCollection, TElement, TBuilder> schema
+    )
+    {
+        // The member's traits apply to each element: a header list of timestamps is a list of
+        // http-dates, a @mediaType string list is a list of base64 strings.
+        var element = (IHttpValueCodec<TElement>)schema.ElementSchema.Resolved.Accept(this);
+        var elementKind = HttpBindingPlans.UnwrapNullable(schema.ElementSchema).Kind;
+        return new ListHttpCodec<TCollection, TElement, TBuilder>(schema, element, elementKind);
+    }
+
+    public override object VisitStringEnum<T>(StringEnumSchema<T> schema) =>
+        new StringEnumHttpCodec<T>(schema);
+
+    public override object VisitIntEnum<T>(IntEnumSchema<T> schema) =>
+        new IntEnumHttpCodec<T>(schema);
+
+    protected override object VisitDefault(Schema schema) =>
+        throw new NotSupportedException(
+            $"HTTP bindings do not support schema kind '{schema.Kind}'."
+        );
+
+    private bool HasTrait(Schema schema, ShapeId id) =>
+        memberTraits?.ContainsKey(id) == true || schema.HasTrait(id);
+
+    private string TimestampFormat(Schema schema)
+    {
+        if (memberTraits?.TryGetValue(RestTraits.TimestampFormat, out var trait) == true)
+        {
+            return trait.Value.AsString();
+        }
+
+        if (schema.GetTrait(RestTraits.TimestampFormat) is { } shapeTrait)
+        {
+            return shapeTrait.Value.AsString();
+        }
+
+        return HasTrait(schema, RestTraits.HttpHeader) ? "http-date" : "date-time";
+    }
+}
+
+/// <summary>
+/// A codec for one text value. The list forms coincide with the single form, and a parse failure
+/// is the caller's mistake: on a server a structured 400 rather than a fault.
+/// </summary>
+internal abstract class ScalarHttpCodec<T>(ShapeKind kind) : IHttpValueCodec<T>
+{
+    public abstract string Format(T value);
+
+    protected abstract T ParseText(string value);
+
+    public T Parse(string value)
+    {
+        try
+        {
+            return ParseText(value);
+        }
+        catch (Exception exception)
+            when (exception is FormatException or OverflowException or ArgumentException)
+        {
+            throw MalformedRequestException.Serialization(
+                $"Value '{value}' is not a valid {kind.ToString().ToLowerInvariant()}."
+            );
+        }
+    }
+
+    public string FormatHeader(T value) => Format(value);
+
+    public T ParseHeader(string value) => Parse(value);
+
+    public void AppendQuery(HttpUriBuilder uri, string name, T value) =>
+        uri.AppendQuery(name, Format(value));
+
+    public T ParseMany(IReadOnlyList<string> values) => Parse(values[0]);
+}
+
+internal sealed class BooleanHttpCodec() : ScalarHttpCodec<bool>(ShapeKind.Boolean)
+{
+    public override string Format(bool value) => value ? "true" : "false";
+
+    // Only the two literals the model means. bool.Parse also accepts "True" and " TRUE ", which
+    // would let a caller coerce a string into a boolean the model never declared.
+    protected override bool ParseText(string value) =>
+        value switch
+        {
+            "true" => true,
+            "false" => false,
+            _ => throw new FormatException($"'{value}' is not a boolean."),
+        };
+}
+
+internal sealed class NumberHttpCodec<T>(ShapeKind kind, Func<string, IFormatProvider, T> parse)
+    : ScalarHttpCodec<T>(kind)
+    where T : IFormattable
+{
+    public override string Format(T value) => value.ToString(null, CultureInfo.InvariantCulture);
+
+    protected override T ParseText(string value) => parse(value, CultureInfo.InvariantCulture);
+}
+
+internal sealed class FloatHttpCodec() : ScalarHttpCodec<float>(ShapeKind.Float)
+{
+    public override string Format(float value) => HttpValueText.FormatFloat(value);
+
+    protected override float ParseText(string value) => HttpValueText.ParseFloat(value);
+}
+
+internal sealed class DoubleHttpCodec() : ScalarHttpCodec<double>(ShapeKind.Double)
+{
+    public override string Format(double value) => HttpValueText.FormatDouble(value);
+
+    protected override double ParseText(string value) => HttpValueText.ParseDouble(value);
+}
+
+internal sealed class StringHttpCodec() : ScalarHttpCodec<string>(ShapeKind.String)
+{
+    public override string Format(string value) => value;
+
+    protected override string ParseText(string value) => value;
+}
+
+/// <summary>A <c>@mediaType</c> string travels base64-encoded in headers and labels.</summary>
+internal sealed class Base64StringHttpCodec() : ScalarHttpCodec<string>(ShapeKind.String)
+{
+    public override string Format(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+
+    protected override string ParseText(string value) =>
+        Encoding.UTF8.GetString(Convert.FromBase64String(value));
+}
+
+internal sealed class BlobHttpCodec() : ScalarHttpCodec<byte[]>(ShapeKind.Blob)
+{
+    public override string Format(byte[] value) => Convert.ToBase64String(value);
+
+    protected override byte[] ParseText(string value) => Convert.FromBase64String(value);
+}
+
+internal sealed class TimestampHttpCodec(string format)
+    : ScalarHttpCodec<DateTimeOffset>(ShapeKind.Timestamp)
+{
+    public override string Format(DateTimeOffset value) =>
+        HttpValueText.FormatTimestamp(format, value);
+
+    protected override DateTimeOffset ParseText(string value) =>
+        HttpValueText.ParseTimestamp(format, value);
+}
+
+internal sealed class StringEnumHttpCodec<T>(StringEnumSchema<T> schema)
+    : ScalarHttpCodec<T>(ShapeKind.Enum)
+    where T : IStringEnumValue<T>
+{
+    public override string Format(T value) => value.Value ?? string.Empty;
+
+    protected override T ParseText(string value) => schema.Create(value);
+}
+
+internal sealed class IntEnumHttpCodec<T>(IntEnumSchema<T> schema)
+    : ScalarHttpCodec<T>(ShapeKind.IntEnum)
+    where T : struct, Enum
+{
+    public override string Format(T value) =>
+        schema.GetIntegerValue(value).ToString(CultureInfo.InvariantCulture);
+
+    protected override T ParseText(string value) =>
+        schema.Create(int.Parse(value, CultureInfo.InvariantCulture));
+}
+
+/// <summary>An optional value type; a caller checks for null before formatting.</summary>
+internal sealed class NullableHttpCodec<T>(IHttpValueCodec<T> inner) : IHttpValueCodec<T?>
+    where T : struct
+{
+    public string Format(T? value) => inner.Format(value!.Value);
+
+    public T? Parse(string value) => inner.Parse(value);
+
+    public string FormatHeader(T? value) => inner.FormatHeader(value!.Value);
+
+    public T? ParseHeader(string value) => inner.ParseHeader(value);
+
+    public void AppendQuery(HttpUriBuilder uri, string name, T? value) =>
+        inner.AppendQuery(uri, name, value!.Value);
+
+    public T? ParseMany(IReadOnlyList<string> values) => inner.ParseMany(values);
+}
+
+/// <summary>
+/// A list bound to a header or query parameter: one header joining the elements, or one query pair
+/// per element. Null elements are not written.
+/// </summary>
+internal sealed class ListHttpCodec<TCollection, TElement, TBuilder>(
+    IListSchema<TCollection, TElement, TBuilder> schema,
+    IHttpValueCodec<TElement> element,
+    ShapeKind elementKind
+) : IHttpValueCodec<TCollection>
+{
+    private readonly bool quoteElements = elementKind is ShapeKind.String or ShapeKind.Enum;
+
+    public string Format(TCollection value) =>
+        throw new NotSupportedException("A list has no single HTTP text form.");
+
+    public TCollection Parse(string value) =>
+        throw new NotSupportedException("A list has no single HTTP text form.");
+
+    public string FormatHeader(TCollection value)
+    {
+        var builder = new StringBuilder();
+        foreach (var item in schema.GetElements(value))
+        {
+            if (item is null)
+            {
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append(", ");
+            }
+
+            var text = element.Format(item);
+            builder.Append(quoteElements ? HttpValueText.QuoteHeaderListElement(text) : text);
+        }
+
+        return builder.ToString();
+    }
+
+    public TCollection ParseHeader(string value) =>
+        ParseMany(HttpValueText.SplitHeaderList(value, elementKind).ToArray());
+
+    public void AppendQuery(HttpUriBuilder uri, string name, TCollection value)
+    {
+        foreach (var item in schema.GetElements(value))
+        {
+            if (item is not null)
+            {
+                element.AppendQuery(uri, name, item);
+            }
+        }
+    }
+
+    public TCollection ParseMany(IReadOnlyList<string> values)
+    {
+        var builder = schema.CreateTypedBuilder();
+        foreach (var value in values)
+        {
+            schema.Add(builder, element.Parse(value));
+        }
+
+        return schema.Build(builder);
+    }
+}

--- a/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
@@ -196,7 +196,7 @@ internal sealed class QueryPlan<T, TBuilder, TValue>(
 internal sealed class MapBindingPlanCompiler<T, TBuilder, TValue>(
     IMemberSchema<T, TBuilder, TValue> member,
     string prefix
-) : SchemaVisitor<IMapBindingPlan<T, TBuilder>>
+) : PartialSchemaVisitor<IMapBindingPlan<T, TBuilder>>
 {
     public override IMapBindingPlan<T, TBuilder> VisitMap<TDictionary, TMapValue, TMapBuilder>(
         IMapSchema<TDictionary, TMapValue, TMapBuilder> schema

--- a/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
@@ -1,0 +1,349 @@
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Protocols.Rest;
+
+// One plan per bound member, compiled once from the member schema and its value codec. A plan
+// knows its member's value type; the binding that holds it only knows the container and builder,
+// so the per-request loops stay monomorphic without ever boxing a value.
+
+internal interface IHttpLabelWriter<in T>
+{
+    void Write(HttpUriBuilder uri, T container);
+}
+
+internal interface IHttpLabelReader<in TBuilder>
+{
+    string Name { get; }
+
+    bool IsRequired { get; }
+
+    void Read(TBuilder builder, string value);
+}
+
+/// <summary>Where a request header lands: the transport owns the content headers.</summary>
+internal enum HeaderSlot
+{
+    Headers,
+    ContentType,
+    ContentHeaders,
+}
+
+internal interface IHttpHeaderWriter<in T>
+{
+    string Name { get; }
+
+    HeaderSlot Slot { get; }
+
+    string? Format(T container);
+}
+
+internal interface IHttpHeaderReader<in TBuilder>
+{
+    string Name { get; }
+
+    string MemberName { get; }
+
+    bool IsRequired { get; }
+
+    void Read(TBuilder builder, string value);
+}
+
+internal interface IHttpQueryWriter<in T>
+{
+    void Write(HttpUriBuilder uri, T container);
+}
+
+internal interface IHttpQueryReader<in TBuilder>
+{
+    string Name { get; }
+
+    string MemberName { get; }
+
+    bool IsRequired { get; }
+
+    void Read(TBuilder builder, IReadOnlyList<string> values);
+}
+
+internal interface IHttpPrefixHeaderWriter<in T>
+{
+    void Write(IDictionary<string, IReadOnlyList<string>> headers, T container);
+}
+
+internal interface IHttpPrefixHeaderReader<in TBuilder>
+{
+    void Read(TBuilder builder, IEnumerable<KeyValuePair<string, IReadOnlyList<string>>> headers);
+}
+
+internal interface IHttpQueryParamsWriter<in T>
+{
+    void Write(HttpUriBuilder uri, T container, HashSet<string> excludedNames);
+}
+
+internal interface IHttpQueryParamsReader<in TBuilder>
+{
+    void Read(TBuilder builder, Dictionary<string, IReadOnlyList<string>> query);
+}
+
+internal interface IHttpStatusCodeWriter<in T>
+{
+    int? Get(T container);
+}
+
+internal interface IHttpStatusCodeReader<in TBuilder>
+{
+    void Read(TBuilder builder, int statusCode);
+}
+
+internal sealed class LabelPlan<T, TBuilder, TValue>(
+    IMemberSchema<T, TBuilder, TValue> member,
+    IHttpValueCodec<TValue> codec,
+    bool greedy
+) : IHttpLabelWriter<T>, IHttpLabelReader<TBuilder>
+{
+    private readonly string placeholder = greedy
+        ? "{" + member.Name + "+}"
+        : "{" + member.Name + "}";
+
+    public string Name => member.Name;
+
+    public bool IsRequired => member.IsRequired;
+
+    public void Write(HttpUriBuilder uri, T container)
+    {
+        if (member.GetValue(container) is not { } value)
+        {
+            throw new InvalidOperationException(
+                $"HTTP label member '{member.Name}' cannot be null."
+            );
+        }
+
+        var text = codec.Format(value);
+        uri.ReplaceLabel(
+            placeholder,
+            greedy ? HttpValueText.EscapeGreedyLabel(text) : Uri.EscapeDataString(text)
+        );
+    }
+
+    public void Read(TBuilder builder, string value) =>
+        member.SetValue(builder, codec.Parse(value));
+}
+
+internal sealed class HeaderPlan<T, TBuilder, TValue>(
+    IMemberSchema<T, TBuilder, TValue> member,
+    IHttpValueCodec<TValue> codec,
+    string name
+) : IHttpHeaderWriter<T>, IHttpHeaderReader<TBuilder>
+{
+    public string Name => name;
+
+    public string MemberName => member.Name;
+
+    public bool IsRequired => member.IsRequired;
+
+    public HeaderSlot Slot { get; } =
+        string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase)
+            ? HeaderSlot.ContentType
+        : string.Equals(name, "Content-Encoding", StringComparison.OrdinalIgnoreCase)
+            ? HeaderSlot.ContentHeaders
+        : HeaderSlot.Headers;
+
+    public string? Format(T container) =>
+        member.GetValue(container) is { } value ? codec.FormatHeader(value) : null;
+
+    public void Read(TBuilder builder, string value) =>
+        member.SetValue(builder, codec.ParseHeader(value));
+}
+
+internal sealed class QueryPlan<T, TBuilder, TValue>(
+    IMemberSchema<T, TBuilder, TValue> member,
+    IHttpValueCodec<TValue> codec,
+    string name
+) : IHttpQueryWriter<T>, IHttpQueryReader<TBuilder>
+{
+    public string Name => name;
+
+    public string MemberName => member.Name;
+
+    public bool IsRequired => member.IsRequired;
+
+    public void Write(HttpUriBuilder uri, T container)
+    {
+        if (member.GetValue(container) is { } value)
+        {
+            codec.AppendQuery(uri, name, value);
+        }
+    }
+
+    public void Read(TBuilder builder, IReadOnlyList<string> values) =>
+        member.SetValue(builder, codec.ParseMany(values));
+}
+
+/// <summary>
+/// An <c>@httpPrefixHeaders</c> or <c>@httpQueryParams</c> member targets a map; the map's own
+/// types only come into scope by visiting it, which is what this does.
+/// </summary>
+internal sealed class MapBindingPlanCompiler<T, TBuilder, TValue>(
+    IMemberSchema<T, TBuilder, TValue> member,
+    string prefix
+) : SchemaVisitor<object>
+{
+    public override object VisitMap<TDictionary, TMapValue, TMapBuilder>(
+        IMapSchema<TDictionary, TMapValue, TMapBuilder> schema
+    ) =>
+        new MapBindingPlan<T, TBuilder, TDictionary, TMapValue, TMapBuilder>(
+            (IMemberSchema<T, TBuilder, TDictionary>)(object)member,
+            schema,
+            HttpBindingCompiler.Compile(schema.ValueSchema, memberTraits: null),
+            prefix
+        );
+
+    protected override object VisitDefault(Schema schema) =>
+        throw new InvalidOperationException(
+            $"HTTP binding member '{member.Name}' must target a map schema."
+        );
+}
+
+internal sealed class MapBindingPlan<T, TBuilder, TDictionary, TValue, TMapBuilder>(
+    IMemberSchema<T, TBuilder, TDictionary> member,
+    IMapSchema<TDictionary, TValue, TMapBuilder> map,
+    IHttpValueCodec<TValue> value,
+    string prefix
+)
+    : IHttpPrefixHeaderWriter<T>,
+        IHttpPrefixHeaderReader<TBuilder>,
+        IHttpQueryParamsWriter<T>,
+        IHttpQueryParamsReader<TBuilder>
+{
+    public void Write(IDictionary<string, IReadOnlyList<string>> headers, T container)
+    {
+        if (member.GetValue(container) is not { } entries)
+        {
+            return;
+        }
+
+        foreach (var entry in map.GetEntries(entries))
+        {
+            if (entry.Value is null)
+            {
+                continue;
+            }
+
+            var headerName = prefix + entry.Key;
+            if (!headers.ContainsKey(headerName))
+            {
+                headers[headerName] = [value.Format(entry.Value)];
+            }
+        }
+    }
+
+    public void Read(
+        TBuilder builder,
+        IEnumerable<KeyValuePair<string, IReadOnlyList<string>>> headers
+    )
+    {
+        var entries = map.CreateTypedBuilder();
+        foreach (var header in headers)
+        {
+            if (
+                !header.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                || (prefix.Length == 0 && IsTransportManagedHeader(header.Key))
+                || header.Value.Count == 0
+            )
+            {
+                continue;
+            }
+
+            map.Add(entries, header.Key[prefix.Length..], value.Parse(header.Value[0]));
+        }
+
+        member.SetValue(builder, map.Build(entries));
+    }
+
+    public void Write(HttpUriBuilder uri, T container, HashSet<string> excludedNames)
+    {
+        if (member.GetValue(container) is not { } entries)
+        {
+            return;
+        }
+
+        foreach (var entry in map.GetEntries(entries))
+        {
+            if (entry.Value is not null && !excludedNames.Contains(entry.Key))
+            {
+                value.AppendQuery(uri, entry.Key, entry.Value);
+            }
+        }
+    }
+
+    public void Read(TBuilder builder, Dictionary<string, IReadOnlyList<string>> query)
+    {
+        var entries = map.CreateTypedBuilder();
+        foreach (var entry in query)
+        {
+            if (entry.Value.Count > 0)
+            {
+                map.Add(entries, entry.Key, value.ParseMany(entry.Value));
+            }
+        }
+
+        member.SetValue(builder, map.Build(entries));
+    }
+
+    private static bool IsTransportManagedHeader(string name) =>
+        name.Equals("Host", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary><c>@httpResponseCode</c> targets an integer, optional or not.</summary>
+internal sealed class StatusCodePlan<T, TBuilder>
+{
+    internal static (
+        IHttpStatusCodeWriter<T> Writer,
+        IHttpStatusCodeReader<TBuilder> Reader
+    ) Compile<TValue>(IMemberSchema<T, TBuilder, TValue> member)
+    {
+        if (member is IMemberSchema<T, TBuilder, int> required)
+        {
+            var plan = new Required(required);
+            return (plan, plan);
+        }
+
+        if (member is IMemberSchema<T, TBuilder, int?> optional)
+        {
+            var plan = new Optional(optional);
+            return (plan, plan);
+        }
+
+        throw new InvalidOperationException(
+            $"@httpResponseCode member '{member.Name}' must target an integer."
+        );
+    }
+
+    private sealed class Required(IMemberSchema<T, TBuilder, int> member)
+        : IHttpStatusCodeWriter<T>,
+            IHttpStatusCodeReader<TBuilder>
+    {
+        public int? Get(T container) => member.GetValue(container);
+
+        public void Read(TBuilder builder, int statusCode) => member.SetValue(builder, statusCode);
+    }
+
+    private sealed class Optional(IMemberSchema<T, TBuilder, int?> member)
+        : IHttpStatusCodeWriter<T>,
+            IHttpStatusCodeReader<TBuilder>
+    {
+        public int? Get(T container) => member.GetValue(container);
+
+        public void Read(TBuilder builder, int statusCode) => member.SetValue(builder, statusCode);
+    }
+}
+
+internal static class HttpBindingPlans
+{
+    internal static Schema UnwrapNullable(Schema schema)
+    {
+        var resolved = schema.Resolved;
+        return resolved is INullableSchema nullable ? nullable.Target.Resolved : resolved;
+    }
+}

--- a/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpBindingPlans.cs
@@ -85,6 +85,16 @@ internal interface IHttpQueryParamsReader<in TBuilder>
     void Read(TBuilder builder, Dictionary<string, IReadOnlyList<string>> query);
 }
 
+/// <summary>
+/// The plan for a map-valued binding, which serves as either side of <c>@httpPrefixHeaders</c> or
+/// <c>@httpQueryParams</c>.
+/// </summary>
+internal interface IMapBindingPlan<in T, in TBuilder>
+    : IHttpPrefixHeaderWriter<T>,
+        IHttpPrefixHeaderReader<TBuilder>,
+        IHttpQueryParamsWriter<T>,
+        IHttpQueryParamsReader<TBuilder>;
+
 internal interface IHttpStatusCodeWriter<in T>
 {
     int? Get(T container);
@@ -186,9 +196,9 @@ internal sealed class QueryPlan<T, TBuilder, TValue>(
 internal sealed class MapBindingPlanCompiler<T, TBuilder, TValue>(
     IMemberSchema<T, TBuilder, TValue> member,
     string prefix
-) : SchemaVisitor<object>
+) : SchemaVisitor<IMapBindingPlan<T, TBuilder>>
 {
-    public override object VisitMap<TDictionary, TMapValue, TMapBuilder>(
+    public override IMapBindingPlan<T, TBuilder> VisitMap<TDictionary, TMapValue, TMapBuilder>(
         IMapSchema<TDictionary, TMapValue, TMapBuilder> schema
     ) =>
         new MapBindingPlan<T, TBuilder, TDictionary, TMapValue, TMapBuilder>(
@@ -198,7 +208,7 @@ internal sealed class MapBindingPlanCompiler<T, TBuilder, TValue>(
             prefix
         );
 
-    protected override object VisitDefault(Schema schema) =>
+    protected override IMapBindingPlan<T, TBuilder> VisitDefault(Schema schema) =>
         throw new InvalidOperationException(
             $"HTTP binding member '{member.Name}' must target a map schema."
         );
@@ -209,11 +219,7 @@ internal sealed class MapBindingPlan<T, TBuilder, TDictionary, TValue, TMapBuild
     IMapSchema<TDictionary, TValue, TMapBuilder> map,
     IHttpValueCodec<TValue> value,
     string prefix
-)
-    : IHttpPrefixHeaderWriter<T>,
-        IHttpPrefixHeaderReader<TBuilder>,
-        IHttpQueryParamsWriter<T>,
-        IHttpQueryParamsReader<TBuilder>
+) : IMapBindingPlan<T, TBuilder>
 {
     public void Write(IDictionary<string, IReadOnlyList<string>> headers, T container)
     {

--- a/packages/NSmithy.Protocols.Rest/HttpValueText.cs
+++ b/packages/NSmithy.Protocols.Rest/HttpValueText.cs
@@ -1,0 +1,241 @@
+using System.Globalization;
+using System.Text;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Protocols.Rest;
+
+/// <summary>Text forms of HTTP-bound values: what a label, query parameter or header carries.</summary>
+internal static class HttpValueText
+{
+    internal static string FormatFloat(float value)
+    {
+        if (float.IsNaN(value))
+        {
+            return "NaN";
+        }
+
+        if (float.IsPositiveInfinity(value))
+        {
+            return "Infinity";
+        }
+
+        if (float.IsNegativeInfinity(value))
+        {
+            return "-Infinity";
+        }
+
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    internal static string FormatDouble(double value)
+    {
+        if (double.IsNaN(value))
+        {
+            return "NaN";
+        }
+
+        if (double.IsPositiveInfinity(value))
+        {
+            return "Infinity";
+        }
+
+        if (double.IsNegativeInfinity(value))
+        {
+            return "-Infinity";
+        }
+
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    internal static float ParseFloat(string value) =>
+        value switch
+        {
+            "NaN" => float.NaN,
+            "Infinity" => float.PositiveInfinity,
+            "-Infinity" => float.NegativeInfinity,
+            _ => float.Parse(value, CultureInfo.InvariantCulture),
+        };
+
+    internal static double ParseDouble(string value) =>
+        value switch
+        {
+            "NaN" => double.NaN,
+            "Infinity" => double.PositiveInfinity,
+            "-Infinity" => double.NegativeInfinity,
+            _ => double.Parse(value, CultureInfo.InvariantCulture),
+        };
+
+    internal static string FormatTimestamp(string format, DateTimeOffset value) =>
+        format switch
+        {
+            "epoch-seconds" => FormatEpochSeconds(value),
+            "http-date" => value
+                .ToUniversalTime()
+                .ToString("ddd, dd MMM yyyy HH':'mm':'ss 'GMT'", CultureInfo.InvariantCulture),
+            "date-time" => FormatRfc3339(value),
+            _ => throw new NotSupportedException($"Timestamp format '{format}' is not supported."),
+        };
+
+    internal static DateTimeOffset ParseTimestamp(string format, string value) =>
+        format switch
+        {
+            "epoch-seconds" => ParseEpochSeconds(value),
+            "http-date" => DateTimeOffset.ParseExact(value, "r", CultureInfo.InvariantCulture),
+            // A label, query parameter, or header is only ever read from a request, so there is no
+            // looser peer to accommodate here the way there is in a response body.
+            "date-time" => Rfc3339.Parse(value, WireReadMode.Strict),
+            _ => throw new NotSupportedException($"Timestamp format '{format}' is not supported."),
+        };
+
+    private static string FormatRfc3339(DateTimeOffset value)
+    {
+        var utc = value.ToUniversalTime();
+        return utc.Ticks % TimeSpan.TicksPerSecond == 0
+            ? utc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture)
+            : utc.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTimeOffset ParseEpochSeconds(string value)
+    {
+        var seconds = decimal.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+        var wholeSeconds = decimal.Truncate(seconds);
+        var fractionalSeconds = seconds - wholeSeconds;
+        return DateTimeOffset
+            .FromUnixTimeSeconds((long)wholeSeconds)
+            .AddTicks((long)(fractionalSeconds * TimeSpan.TicksPerSecond));
+    }
+
+    private static string FormatEpochSeconds(DateTimeOffset value)
+    {
+        var unixSeconds = value.ToUnixTimeSeconds();
+        var fractionalTicks = value.ToUniversalTime().Ticks % TimeSpan.TicksPerSecond;
+        if (fractionalTicks == 0)
+        {
+            return unixSeconds.ToString(CultureInfo.InvariantCulture);
+        }
+
+        var fractional = ((decimal)fractionalTicks / TimeSpan.TicksPerSecond).ToString(
+            "0.################",
+            CultureInfo.InvariantCulture
+        );
+        return $"{unixSeconds}{fractional[1..]}";
+    }
+
+    internal static IEnumerable<string> SplitHeaderList(string value, ShapeKind elementKind)
+    {
+        if (
+            elementKind == ShapeKind.Timestamp
+            && value.Contains("GMT,", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            var segments = value.Split("GMT,", StringSplitOptions.None);
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var segment = segments[i].Trim();
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+
+                yield return i < segments.Length - 1 ? segment + " GMT" : segment;
+            }
+
+            yield break;
+        }
+
+        if (
+            elementKind is ShapeKind.String or ShapeKind.Enum
+            && value.Contains('"', StringComparison.Ordinal)
+        )
+        {
+            foreach (var part in ParseQuotedHeaderList(value))
+            {
+                yield return part;
+            }
+
+            yield break;
+        }
+
+        foreach (var part in value.Split(','))
+        {
+            yield return part.Trim();
+        }
+    }
+
+    private static IEnumerable<string> ParseQuotedHeaderList(string value)
+    {
+        var builder = new StringBuilder();
+        var inQuotes = false;
+        var escaping = false;
+        foreach (var ch in value)
+        {
+            if (escaping)
+            {
+                builder.Append(ch);
+                escaping = false;
+                continue;
+            }
+
+            if (ch == '\\' && inQuotes)
+            {
+                escaping = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (ch == ',' && !inQuotes)
+            {
+                yield return builder.ToString().Trim();
+                builder.Clear();
+                continue;
+            }
+
+            builder.Append(ch);
+        }
+
+        if (builder.Length > 0 || (value.Length > 0 && value[^1] == ','))
+        {
+            yield return builder.ToString().Trim();
+        }
+    }
+
+    /// <summary>A header list element, quoted when a bare one would be split or misread.</summary>
+    internal static string QuoteHeaderListElement(string value) =>
+        value.Length == 0
+        || value.Any(ch => ch == ',' || ch == '"' || ch == '\\' || char.IsWhiteSpace(ch))
+            ? "\""
+                + value
+                    .Replace("\\", "\\\\", StringComparison.Ordinal)
+                    .Replace("\"", "\\\"", StringComparison.Ordinal)
+                + "\""
+            : value;
+
+    internal static string EscapeGreedyLabel(string value) =>
+        string.Join("/", value.Split('/').Select(Uri.EscapeDataString));
+}
+
+/// <summary>A request URI under construction; query pairs are appended in the order written.</summary>
+internal sealed class HttpUriBuilder(string template)
+{
+    private readonly StringBuilder uri = new(template);
+    private bool hasQuery = template.Contains('?', StringComparison.Ordinal);
+
+    internal void ReplaceLabel(string placeholder, string value) => uri.Replace(placeholder, value);
+
+    internal void AppendQuery(string name, string value)
+    {
+        uri.Append(hasQuery ? '&' : '?');
+        hasQuery = true;
+        uri.Append(Uri.EscapeDataString(name));
+        uri.Append('=');
+        uri.Append(Uri.EscapeDataString(value));
+    }
+
+    public override string ToString() => uri.ToString();
+}

--- a/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
@@ -10,8 +10,6 @@ namespace NSmithy.Protocols.Rest;
 /// and reused for every call — nothing is recompiled per request.
 /// </summary>
 public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder>
-    where TInputBuilder : notnull
-    where TOutputBuilder : notnull
 {
     public required HttpMethod HttpMethod { get; init; }
     public required string UriTemplate { get; init; }
@@ -224,9 +222,7 @@ public static class RestOperationBinding
         IRestBodyCodecFactory codecFactory,
         bool rawStringPayloads,
         bool requiresDeclaredContentType = true
-    )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull =>
+    ) =>
         RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder>.CreateFrom(
             operation,
             inputSchema,
@@ -235,33 +231,4 @@ public static class RestOperationBinding
             rawStringPayloads,
             requiresDeclaredContentType
         );
-
-    public static dynamic From<TInput, TOutput>(
-        OperationSchema<TInput, TOutput> operation,
-        IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads,
-        bool requiresDeclaredContentType = true
-    )
-    {
-        ArgumentNullException.ThrowIfNull(operation);
-        var inputSchema =
-            operation.Input.Resolved as IStructSchema<TInput>
-            ?? throw new InvalidOperationException(
-                $"Operation '{operation.Id}' input must be a structure schema."
-            );
-        var outputSchema =
-            operation.Output.Resolved as IStructSchema<TOutput>
-            ?? throw new InvalidOperationException(
-                $"Operation '{operation.Id}' output must be a structure schema."
-            );
-
-        return From(
-            (dynamic)operation,
-            (dynamic)inputSchema,
-            (dynamic)outputSchema,
-            codecFactory,
-            rawStringPayloads,
-            requiresDeclaredContentType
-        );
-    }
 }

--- a/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationBinding.cs
@@ -4,16 +4,10 @@ using NSmithy.Core.Serde;
 
 namespace NSmithy.Protocols.Rest;
 
-public readonly record struct QueryMemberBinding(IStructMemberSchema Member, string QueryName);
-
-public readonly record struct HeaderMemberBinding(IStructMemberSchema Member, string HeaderName);
-
-public readonly record struct PrefixHeaderMemberBinding(IStructMemberSchema Member, string Prefix);
-
 /// <summary>
 /// Everything <see cref="RestProtocol"/> needs to (de)serialize one operation, derived once from
-/// the operation's <c>@http</c> trait. The body/payload codecs and payload (de)serialize delegates
-/// are <em>compiled here</em> and reused for every call — nothing is recompiled per request.
+/// the operation's <c>@http</c> trait. Every binding plan and body codec is <em>compiled here</em>
+/// and reused for every call — nothing is recompiled per request.
 /// </summary>
 public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder>
     where TInputBuilder : notnull
@@ -59,38 +53,9 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
     /// <summary>True when the response payload is a streaming blob and must not be buffered.</summary>
     public required bool OutputHasStreamingPayload { get; init; }
 
-    // Input
-    public required IStructSchema<TInput, TInputBuilder> InputSchema { get; init; }
-    public required IReadOnlyList<IStructMemberSchema> LabelMembers { get; init; }
-    public required IReadOnlyList<QueryMemberBinding> QueryMembers { get; init; }
-    public IStructMemberSchema? QueryParamsMember { get; init; }
-    public required IReadOnlyList<HeaderMemberBinding> RequestHeaderMembers { get; init; }
-    public PrefixHeaderMemberBinding? RequestPrefixHeadersMember { get; init; }
-    public required HashSet<string> BoundQueryNames { get; init; }
+    internal RestStructBinding<TInput, TInputBuilder> Input { get; init; } = null!;
 
-    /// <summary>Compiled codec for the request body projection (null when there is no body / a payload).</summary>
-    public IProjectionCodec<TInput, TInputBuilder>? InputBodyCodec { get; init; }
-
-    /// <summary>Writes the <c>@httpPayload</c> input to a body (null when there is no payload member).</summary>
-    public Func<TInput, RestBody>? InputPayloadWriter { get; init; }
-
-    /// <summary>Reads the <c>@httpPayload</c> input from a body into the builder.</summary>
-    public RestPayloadReader? InputPayloadReader { get; init; }
-
-    // Output
-    public required IStructSchema<TOutput, TOutputBuilder> OutputSchema { get; init; }
-    public IStructMemberSchema? ResponseCodeMember { get; init; }
-    public required IReadOnlyList<HeaderMemberBinding> ResponseHeaderMembers { get; init; }
-    public PrefixHeaderMemberBinding? ResponsePrefixHeadersMember { get; init; }
-
-    /// <summary>Compiled codec for the response body projection (null for unit / payload outputs).</summary>
-    public IProjectionCodec<TOutput, TOutputBuilder>? OutputBodyCodec { get; init; }
-
-    /// <summary>Writes the <c>@httpPayload</c> output to a body (null when there is no payload member).</summary>
-    public Func<TOutput, RestBody>? OutputPayloadWriter { get; init; }
-
-    /// <summary>Reads the <c>@httpPayload</c> output from a body into the builder.</summary>
-    public RestPayloadReader? OutputPayloadReader { get; init; }
+    internal RestStructBinding<TOutput, TOutputBuilder> Output { get; init; } = null!;
 
     internal static RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> CreateFrom(
         OperationSchema<TInput, TOutput> operation,
@@ -127,133 +92,61 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
             || operation.Input.Resolved is UnitSchema
             || Schemas.IsSyntheticUnit(operation.Input);
 
-        // Partition input members in a single pass
-        var labelMembers = new List<IStructMemberSchema>();
-        var queryMembers = new List<QueryMemberBinding>();
-        IStructMemberSchema? queryParamsMember = null;
-        var requestHeaderMembers = new List<HeaderMemberBinding>();
-        PrefixHeaderMemberBinding? requestPrefixHeadersMember = null;
-        IMemberSchema<TInput>? inputPayloadMember = null;
-        var inputBodyMembers = new List<IMemberSchema<TInput>>();
-        var boundQueryNames = new HashSet<string>(StringComparer.Ordinal);
-        var inputMemberCount = 0;
-
-        foreach (var member in Schemas.GetMembers(inputSchema))
-        {
-            inputMemberCount++;
-            if (member.MemberTraits.ContainsKey(RestTraits.HttpLabel))
-            {
-                labelMembers.Add(member);
-            }
-            else if (member.MemberTraits.TryGetValue(RestTraits.HttpQuery, out var queryTrait))
-            {
-                var name = queryTrait.Value.AsString();
-                queryMembers.Add(new QueryMemberBinding(member, name));
-                boundQueryNames.Add(name);
-            }
-            else if (member.MemberTraits.ContainsKey(RestTraits.HttpQueryParams))
-            {
-                queryParamsMember = member;
-            }
-            else if (member.MemberTraits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
-            {
-                requestHeaderMembers.Add(
-                    new HeaderMemberBinding(member, headerTrait.Value.AsString())
-                );
-            }
-            else if (
-                member.MemberTraits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait)
-            )
-            {
-                requestPrefixHeadersMember = new PrefixHeaderMemberBinding(
-                    member,
-                    prefixTrait.Value.AsString()
-                );
-            }
-            else if (member.MemberTraits.ContainsKey(RestTraits.HttpPayload))
-            {
-                inputPayloadMember = member;
-            }
-            else
-            {
-                inputBodyMembers.Add(member);
-            }
-        }
+        var input = RestStructBinding<TInput, TInputBuilder>.Compile(
+            inputSchema,
+            HttpBindingSide.Request,
+            codecFactory,
+            rawStringPayloads,
+            emptyStructOnNullPayload: true,
+            uriTemplate
+        );
+        var output = RestStructBinding<TOutput, TOutputBuilder>.Compile(
+            outputSchema,
+            HttpBindingSide.Response,
+            codecFactory,
+            rawStringPayloads,
+            emptyStructOnNullPayload: false
+        );
 
         // A structure the model declares still has a body when every member is bound elsewhere —
         // an empty object — but a synthetic unit has none, and an input whose members are all bound
         // to the URI or headers leaves nothing for the body to carry.
         var inputHasBody =
-            inputPayloadMember is null
+            input.PayloadMember is null
             && !inputIsUnit
-            && (inputBodyMembers.Count > 0 || inputMemberCount == 0);
+            && (input.BodyMemberNames.Count > 0 || input.MemberCount == 0);
 
         // Request bodies don't materialize top-level defaults (the client sends only what was set).
-        IProjectionCodec<TInput, TInputBuilder>? inputBodyCodec =
-            inputPayloadMember is null && inputBodyMembers.Count > 0
-                ? codecFactory.FromProjection(
-                    Schemas.Project(inputSchema, inputBodyMembers),
-                    new CodecFactoryOptions
-                    {
-                        MaterializeTopLevelDefaults = false,
-                        DefaultRootName = operation.Id.Name + "Request",
-                    }
-                )
-                : null;
-
-        // Partition output members in a single pass
-        IStructMemberSchema? responseCodeMember = null;
-        var responseHeaderMembers = new List<HeaderMemberBinding>();
-        PrefixHeaderMemberBinding? responsePrefixHeadersMember = null;
-        IMemberSchema<TOutput>? outputPayloadMember = null;
-        var outputBodyMembers = new List<IMemberSchema<TOutput>>();
-
-        foreach (var member in Schemas.GetMembers(outputSchema))
+        if (input.PayloadMember is null && input.BodyMemberNames.Count > 0)
         {
-            if (member.MemberTraits.ContainsKey(RestTraits.HttpResponseCode))
-            {
-                responseCodeMember = member;
-            }
-            else if (member.MemberTraits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
-            {
-                responseHeaderMembers.Add(
-                    new HeaderMemberBinding(member, headerTrait.Value.AsString())
-                );
-            }
-            else if (
-                member.MemberTraits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait)
-            )
-            {
-                responsePrefixHeadersMember = new PrefixHeaderMemberBinding(
-                    member,
-                    prefixTrait.Value.AsString()
-                );
-            }
-            else if (member.MemberTraits.ContainsKey(RestTraits.HttpPayload))
-            {
-                outputPayloadMember = member;
-            }
-            else
-            {
-                outputBodyMembers.Add(member);
-            }
+            input.BodyCodec = input.CompileBodyCodec(
+                codecFactory,
+                new CodecFactoryOptions
+                {
+                    MaterializeTopLevelDefaults = false,
+                    DefaultRootName = operation.Id.Name + "Request",
+                }
+            );
         }
 
-        // A modeled (non-Unit) structure output always serializes a JSON body — at minimum `{}` —
-        // even when every member is bound to a header/status, so build the codec regardless of
-        // member count. Unit outputs and payload-bound outputs are handled separately. Responses
+        // A modeled (non-Unit) structure output always serializes a body — at minimum `{}` — even
+        // when every member is bound to a header/status, so build the codec regardless of member
+        // count. Unit outputs and payload-bound outputs are handled separately. Responses
         // materialize top-level defaults.
-        IProjectionCodec<TOutput, TOutputBuilder>? outputBodyCodec =
-            outputPayloadMember is null && !outputIsUnit
-                ? codecFactory.FromProjection(
-                    Schemas.Project(outputSchema, outputBodyMembers),
-                    new CodecFactoryOptions
-                    {
-                        MaterializeTopLevelDefaults = true,
-                        DefaultRootName = operation.Id.Name + "Response",
-                    }
-                )
-                : null;
+        if (output.PayloadMember is null && !outputIsUnit)
+        {
+            output.BodyCodec = output.CompileBodyCodec(
+                codecFactory,
+                new CodecFactoryOptions
+                {
+                    MaterializeTopLevelDefaults = true,
+                    DefaultRootName = operation.Id.Name + "Response",
+                }
+            );
+        }
+
+        var inputPayload = input.PayloadMember;
+        var outputPayload = output.PayloadMember;
 
         return new RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder>
         {
@@ -262,86 +155,39 @@ public sealed class RestOperationBinding<TInput, TOutput, TInputBuilder, TOutput
             SuccessStatusCode = successStatusCode,
             OutputIsUnit = outputIsUnit,
             BodyContentType = codecFactory.ContentType,
-            AcceptType = outputPayloadMember is null
+            AcceptType = outputPayload is null
                 ? codecFactory.ContentType
                 : RestProtocol.PayloadContentType(
-                    outputPayloadMember.Target,
-                    outputPayloadMember.MemberTraits,
+                    outputPayload.Target,
+                    outputPayload.MemberTraits,
                     codecFactory,
                     rawStringPayloads
                 ),
             RequestContentType =
-                inputPayloadMember is not null
+                inputPayload is not null
                     ? RestProtocol.PayloadContentType(
-                        inputPayloadMember.Target,
-                        inputPayloadMember.MemberTraits,
+                        inputPayload.Target,
+                        inputPayload.MemberTraits,
                         codecFactory,
                         rawStringPayloads
                     )
                 : inputHasBody ? codecFactory.ContentType
                 : null,
             RequestMediaTypeIsOpaque =
-                inputPayloadMember is not null
-                && RestProtocol.IsOpaquePayload(
-                    inputPayloadMember.Target,
-                    inputPayloadMember.MemberTraits
-                ),
+                inputPayload is not null
+                && RestProtocol.IsOpaquePayload(inputPayload.Target, inputPayload.MemberTraits),
             ResponseMediaTypeIsOpaque =
-                outputPayloadMember is not null
-                && RestProtocol.IsOpaquePayload(
-                    outputPayloadMember.Target,
-                    outputPayloadMember.MemberTraits
-                ),
+                outputPayload is not null
+                && RestProtocol.IsOpaquePayload(outputPayload.Target, outputPayload.MemberTraits),
             RequiresDeclaredContentType = requiresDeclaredContentType,
             OutputHasStreamingPayload =
-                outputPayloadMember is not null
+                outputPayload is not null
                 && (
-                    outputPayloadMember.Target.Resolved is IEventStreamSchema
-                    || outputPayloadMember.MemberTraits.ContainsKey(RestTraits.Streaming)
+                    outputPayload.Target.Resolved is IEventStreamSchema
+                    || outputPayload.MemberTraits.ContainsKey(RestTraits.Streaming)
                 ),
-            InputSchema = inputSchema,
-            LabelMembers = labelMembers,
-            QueryMembers = queryMembers,
-            QueryParamsMember = queryParamsMember,
-            RequestHeaderMembers = requestHeaderMembers,
-            RequestPrefixHeadersMember = requestPrefixHeadersMember,
-            BoundQueryNames = boundQueryNames,
-            InputBodyCodec = inputBodyCodec,
-            InputPayloadWriter = inputPayloadMember is null
-                ? null
-                : RestProtocol.BuildPayloadWriter(
-                    inputPayloadMember,
-                    codecFactory,
-                    rawStringPayloads,
-                    emptyStructOnNull: true
-                ),
-            InputPayloadReader = inputPayloadMember is null
-                ? null
-                : RestProtocol.BuildPayloadReader(
-                    inputPayloadMember,
-                    codecFactory,
-                    rawStringPayloads
-                ),
-            OutputSchema = outputSchema,
-            ResponseCodeMember = responseCodeMember,
-            ResponseHeaderMembers = responseHeaderMembers,
-            ResponsePrefixHeadersMember = responsePrefixHeadersMember,
-            OutputBodyCodec = outputBodyCodec,
-            OutputPayloadWriter = outputPayloadMember is null
-                ? null
-                : RestProtocol.BuildPayloadWriter(
-                    outputPayloadMember,
-                    codecFactory,
-                    rawStringPayloads,
-                    emptyStructOnNull: false
-                ),
-            OutputPayloadReader = outputPayloadMember is null
-                ? null
-                : RestProtocol.BuildPayloadReader(
-                    outputPayloadMember,
-                    codecFactory,
-                    rawStringPayloads
-                ),
+            Input = input,
+            Output = output,
         };
     }
 

--- a/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestOperationProtocol.cs
@@ -76,19 +76,83 @@ public sealed class RestServiceProtocol(
                 $"Operation '{operation.Id}' output must be a structure schema."
             );
 
-        return CreateOperation(
-            operation,
-            (dynamic)inputSchema,
-            (dynamic)outputSchema,
-            modeledErrors,
-            codecFactory,
-            errorDiscriminator,
-            rawStringPayloads,
-            errorTypeHeader,
-            requestTransform,
-            inputValidator,
-            requiresDeclaredContentType
+        return inputSchema.Accept(
+            new InputSchemaCompiler<TInput, TOutput>(
+                operation,
+                outputSchema,
+                modeledErrors,
+                codecFactory,
+                errorDiscriminator,
+                rawStringPayloads,
+                errorTypeHeader,
+                requestTransform,
+                inputValidator,
+                requiresDeclaredContentType
+            )
         );
+    }
+
+    private sealed class InputSchemaCompiler<TInput, TOutput>(
+        OperationSchema<TInput, TOutput> operation,
+        IStructSchema<TOutput> outputSchema,
+        IReadOnlyList<IOperationErrorSchema> modeledErrors,
+        IRestBodyCodecFactory codecFactory,
+        Func<SmithyHttpClientResponse, string?> errorDiscriminator,
+        bool rawStringPayloads,
+        string? errorTypeHeader,
+        Action<SmithyHttpRequest>? requestTransform,
+        ISmithyValidator<TInput>? inputValidator,
+        bool requiresDeclaredContentType
+    ) : IStructSchemaVisitor<TInput, IOperationProtocol<TInput, TOutput>>
+    {
+        public IOperationProtocol<TInput, TOutput> Visit<TInputBuilder>(
+            IStructSchema<TInput, TInputBuilder> inputSchema
+        ) =>
+            outputSchema.Accept(
+                new OutputSchemaCompiler<TInput, TOutput, TInputBuilder>(
+                    operation,
+                    inputSchema,
+                    modeledErrors,
+                    codecFactory,
+                    errorDiscriminator,
+                    rawStringPayloads,
+                    errorTypeHeader,
+                    requestTransform,
+                    inputValidator,
+                    requiresDeclaredContentType
+                )
+            );
+    }
+
+    private sealed class OutputSchemaCompiler<TInput, TOutput, TInputBuilder>(
+        OperationSchema<TInput, TOutput> operation,
+        IStructSchema<TInput, TInputBuilder> inputSchema,
+        IReadOnlyList<IOperationErrorSchema> modeledErrors,
+        IRestBodyCodecFactory codecFactory,
+        Func<SmithyHttpClientResponse, string?> errorDiscriminator,
+        bool rawStringPayloads,
+        string? errorTypeHeader,
+        Action<SmithyHttpRequest>? requestTransform,
+        ISmithyValidator<TInput>? inputValidator,
+        bool requiresDeclaredContentType
+    ) : IStructSchemaVisitor<TOutput, IOperationProtocol<TInput, TOutput>>
+    {
+        public IOperationProtocol<TInput, TOutput> Visit<TOutputBuilder>(
+            IStructSchema<TOutput, TOutputBuilder> outputSchema
+        ) =>
+            CreateOperation(
+                operation,
+                inputSchema,
+                outputSchema,
+                modeledErrors,
+                codecFactory,
+                errorDiscriminator,
+                rawStringPayloads,
+                errorTypeHeader,
+                requestTransform,
+                inputValidator,
+                requiresDeclaredContentType
+            );
     }
 
     private static RestOperationProtocol<
@@ -108,9 +172,7 @@ public sealed class RestServiceProtocol(
         Action<SmithyHttpRequest>? requestTransform,
         ISmithyValidator<TInput>? inputValidator,
         bool requiresDeclaredContentType
-    )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull =>
+    ) =>
         new RestOperationProtocol<TInput, TOutput, TInputBuilder, TOutputBuilder>(
             RestOperationBinding.From(
                 operation,
@@ -145,8 +207,6 @@ public sealed class RestOperationProtocol<TInput, TOutput, TInputBuilder, TOutpu
     Action<SmithyHttpRequest>? requestTransform = null,
     ISmithyValidator<TInput>? inputValidator = null
 ) : IOperationProtocol<TInput, TOutput>
-    where TInputBuilder : notnull
-    where TOutputBuilder : notnull
 {
     public ISmithyValidator<TInput>? InputValidator { get; } = inputValidator;
 
@@ -160,8 +220,23 @@ public sealed class RestOperationProtocol<TInput, TOutput, TInputBuilder, TOutpu
         : ModeledErrorSerializer.Compile(
             modeledErrors,
             error =>
-                CompileServerError((dynamic)error, codecFactory, rawStringPayloads, errorTypeHeader)
+                error.Accept(
+                    new ServerErrorCompiler(codecFactory, rawStringPayloads, errorTypeHeader)
+                )
         );
+
+    private sealed class ServerErrorCompiler(
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads,
+        string errorTypeHeader
+    ) : IOperationErrorSchemaVisitor<(Type, Func<Exception, SmithyHttpServerResponse>)>
+    {
+        public (Type, Func<Exception, SmithyHttpServerResponse>) Visit<TError>(
+            OperationErrorSchema<TError> error
+        )
+            where TError : Exception =>
+            CompileServerError(error, codecFactory, rawStringPayloads, errorTypeHeader);
+    }
 
     public SmithyHttpRequest SerializeRequest(
         TInput input,

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -25,9 +25,6 @@ public interface IRestBodyCodecFactory : IProjectionCodecFactory
     byte[] PrepareErrorBody(byte[] content) => content;
 }
 
-public delegate void RestPayloadReader(byte[]? content, Stream? streamingContent, object builder);
-
-/// <summary>A serialized REST body: buffered bytes or a stream plus the Content-Type to advertise.</summary>
 /// <summary>
 /// An error-response writer with every schema-derived decision already made. Produced by
 /// <c>RestProtocol.CompileErrorSerializer</c> once per error shape and invoked per response.
@@ -72,37 +69,66 @@ public static class RestProtocol
         where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
+        var bound = binding.Input;
 
-        var requestUri = BuildRequestUri(binding.UriTemplate, binding.LabelMembers, input!);
+        var uri = new HttpUriBuilder(binding.UriTemplate);
+        foreach (var label in bound.LabelWriters)
+        {
+            label.Write(uri, input);
+        }
 
-        foreach (var (member, queryName) in binding.QueryMembers)
-            requestUri = AppendQuery(requestUri, queryName, member, input!);
-        if (binding.QueryParamsMember is { } qpMember)
-            requestUri = AppendQueryParams(requestUri, qpMember, input!, binding.BoundQueryNames);
+        foreach (var query in bound.QueryWriters)
+        {
+            query.Write(uri, input);
+        }
 
-        var request = new SmithyHttpRequest(binding.HttpMethod, requestUri);
+        bound.QueryParamsWriter?.Write(uri, input, bound.BoundQueryNames);
+
+        var request = new SmithyHttpRequest(binding.HttpMethod, uri.ToString());
         request.Headers["Accept"] = [binding.AcceptType];
         request.ExpectStreamingResponse = binding.OutputHasStreamingPayload;
 
-        foreach (var (member, headerName) in binding.RequestHeaderMembers)
-            AddRequestHeader(request, headerName, member, input!);
-        if (binding.RequestPrefixHeadersMember is { } phMember)
-            AddPrefixedHeaders(request.Headers, phMember.Prefix, phMember.Member, input!);
-
-        if (binding.InputPayloadWriter is { } writePayload)
+        foreach (var header in bound.HeaderWriters)
         {
-            var body = writePayload(input!);
+            if (header.Format(input) is not { } value)
+            {
+                continue;
+            }
+
+            switch (header.Slot)
+            {
+                case HeaderSlot.ContentType:
+                    request.ContentType = value;
+                    break;
+                case HeaderSlot.ContentHeaders:
+                    request.ContentHeaders[header.Name] = [value];
+                    break;
+                default:
+                    request.Headers[header.Name] = [value];
+                    break;
+            }
+        }
+
+        bound.PrefixHeaderWriter?.Write(request.Headers, input);
+
+        if (bound.PayloadWriter is { } writePayload)
+        {
+            var body = writePayload(input);
             if (body.HasContent)
             {
                 request.Body = ToHttpBody(body);
                 if (body.ContentType is not null)
+                {
                     SetContentTypeIfMissing(request, body.ContentType);
+                }
             }
+
             return request;
         }
-        if (binding.InputBodyCodec is { } codec)
+
+        if (bound.BodyCodec is { } codec)
         {
-            request.Body = ToHttpBody(codec.Serialize(input!));
+            request.Body = ToHttpBody(codec.Serialize(input));
             SetContentTypeIfMissing(request, binding.BodyContentType);
         }
 
@@ -122,7 +148,8 @@ public static class RestProtocol
         CheckContentType(binding, request);
         CheckAccept(binding, request);
 
-        var builder = binding.InputSchema.CreateTypedBuilder();
+        var bound = binding.Input;
+        var builder = bound.Schema.CreateTypedBuilder();
         var labels = ExtractLabels(binding.UriTemplate, request.RequestUri);
         var query = ParseQuery(request.RequestUri);
 
@@ -130,55 +157,62 @@ public static class RestProtocol
         // place its absence is still observable: once the builder is finalized a missing value-type
         // member has already defaulted, and neither the finalizer nor the validator can tell it from
         // a value the caller actually sent.
-        foreach (var member in binding.LabelMembers)
+        foreach (var label in bound.LabelReaders)
         {
-            if (labels.TryGetValue(member.Name, out var labelValue))
-                member.SetObject(
-                    builder,
-                    ParseHttpValue(member.Target, member.MemberTraits, labelValue)
-                );
-            else if (member.IsRequired)
-                throw new MissingRequiredMemberException(member.Name);
+            if (labels.TryGetValue(label.Name, out var value))
+            {
+                label.Read(builder, value);
+            }
+            else if (label.IsRequired)
+            {
+                throw new MissingRequiredMemberException(label.Name);
+            }
         }
-        foreach (var (member, headerName) in binding.RequestHeaderMembers)
+
+        foreach (var header in bound.HeaderReaders)
         {
-            if (TryGetFirstHeader(request.Headers, headerName, out var header))
-                member.SetObject(
-                    builder,
-                    ParseHttpBindingValue(member.Target, member.MemberTraits, header)
-                );
-            else if (member.IsRequired)
-                throw new MissingRequiredMemberException(member.Name);
+            if (TryGetFirstHeader(request.Headers, header.Name, out var value))
+            {
+                header.Read(builder, value);
+            }
+            else if (header.IsRequired)
+            {
+                throw new MissingRequiredMemberException(header.MemberName);
+            }
         }
-        if (binding.RequestPrefixHeadersMember is { } reqPhMember)
-            reqPhMember.Member.SetObject(
-                builder,
-                ReadPrefixedHeaders(reqPhMember.Member, request.Headers, reqPhMember.Prefix)
-            );
-        foreach (var (member, queryName) in binding.QueryMembers)
+
+        bound.PrefixHeaderReader?.Read(builder, request.Headers);
+
+        foreach (var parameter in bound.QueryReaders)
         {
-            if (query.TryGetValue(queryName, out var values) && values.Count > 0)
-                member.SetObject(
-                    builder,
-                    ParseHttpBindingValues(member.Target, member.MemberTraits, values)
-                );
-            else if (member.IsRequired)
-                throw new MissingRequiredMemberException(member.Name);
+            if (query.TryGetValue(parameter.Name, out var values) && values.Count > 0)
+            {
+                parameter.Read(builder, values);
+            }
+            else if (parameter.IsRequired)
+            {
+                throw new MissingRequiredMemberException(parameter.MemberName);
+            }
         }
-        if (binding.QueryParamsMember is { } qpMember)
-            // On clients, explicitly bound @httpQuery members take precedence over entries in an
-            // @httpQueryParams map. On servers the map represents the request as received and must
-            // include every query parameter, including names that are also explicitly bound.
-            qpMember.SetObject(builder, ReadQueryParams(qpMember, query));
-        if (binding.InputPayloadReader is { } readPayload)
+
+        // On clients, explicitly bound @httpQuery members take precedence over entries in an
+        // @httpQueryParams map. On servers the map represents the request as received and must
+        // include every query parameter, including names that are also explicitly bound.
+        bound.QueryParamsReader?.Read(builder, query);
+
+        if (bound.PayloadReader is { } readPayload)
+        {
             readPayload(BodyBytesOrNull(request.Body), BodyStreamOrNull(request.Body), builder);
+        }
         else if (
-            binding.InputBodyCodec is { } codec
+            bound.BodyCodec is { } codec
             && BodyBytesOrNull(request.Body) is { Length: > 0 } content
         )
+        {
             codec.ReadInto(content, builder);
+        }
 
-        return binding.InputSchema.Build(builder);
+        return bound.Schema.Build(builder);
     }
 
     public static SmithyHttpServerResponse SerializeResponse<
@@ -191,37 +225,30 @@ public static class RestProtocol
         where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
+        var bound = binding.Output;
 
         var headers = new Dictionary<string, IReadOnlyList<string>>(
             StringComparer.OrdinalIgnoreCase
         );
+        var statusCode = bound.StatusCodeWriter?.Get(output) ?? binding.SuccessStatusCode;
+        WriteHeaders(bound, output, headers);
+
         var contentHeaders = new Dictionary<string, IReadOnlyList<string>>(
             StringComparer.OrdinalIgnoreCase
         );
-        var statusCode = binding.SuccessStatusCode;
-
-        if (binding.ResponseCodeMember is { } codeMember)
-        {
-            var value = codeMember.GetObject(output!);
-            if (value is not null)
-                statusCode = (int)ParseHttpValue(Schemas.Integer, value.ToString()!)!;
-        }
-        foreach (var (member, headerName) in binding.ResponseHeaderMembers)
-            AddHeader(headers, headerName, member, output!);
-        if (binding.ResponsePrefixHeadersMember is { } respPhMember)
-            AddPrefixedHeaders(headers, respPhMember.Prefix, respPhMember.Member, output!);
-
         SmithyHttpBody responseBody = SmithyHttpBody.Empty;
-        if (binding.OutputPayloadWriter is { } writePayload)
+        if (bound.PayloadWriter is { } writePayload)
         {
-            var body = writePayload(output!);
+            var body = writePayload(output);
             responseBody = ToHttpBody(body);
             if (body.ContentType is not null)
+            {
                 contentHeaders["Content-Type"] = [body.ContentType];
+            }
         }
-        else if (binding.OutputBodyCodec is { } codec)
+        else if (bound.BodyCodec is { } codec)
         {
-            responseBody = ToHttpBody(codec.Serialize(output!));
+            responseBody = ToHttpBody(codec.Serialize(output));
             contentHeaders["Content-Type"] = [binding.BodyContentType];
         }
 
@@ -237,41 +264,62 @@ public static class RestProtocol
     {
         ArgumentNullException.ThrowIfNull(binding);
         ArgumentNullException.ThrowIfNull(response);
+        return ReadResponse(binding.Output, response, prepareBody: null);
+    }
 
-        var builder = binding.OutputSchema.CreateTypedBuilder();
-
-        if (binding.ResponseCodeMember is { } codeMember)
-            codeMember.SetObject(
-                builder,
-                ParseHttpValue(
-                    codeMember.Target,
-                    ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)
-                )
-            );
-        foreach (var (member, headerName) in binding.ResponseHeaderMembers)
+    private static void WriteHeaders<T, TBuilder>(
+        RestStructBinding<T, TBuilder> bound,
+        T value,
+        Dictionary<string, IReadOnlyList<string>> headers
+    )
+        where TBuilder : notnull
+    {
+        foreach (var header in bound.HeaderWriters)
         {
-            if (
-                TryGetFirstHeader(response.Headers, headerName, out var header)
-                || TryGetFirstHeader(response.ContentHeaders, headerName, out header)
-            )
+            if (header.Format(value) is { } text)
             {
-                member.SetObject(
-                    builder,
-                    ParseHttpBindingValue(member.Target, member.MemberTraits, header)
-                );
+                headers[header.Name] = [text];
             }
         }
-        if (binding.ResponsePrefixHeadersMember is { } respPhMember)
-            respPhMember.Member.SetObject(
-                builder,
-                ReadPrefixedHeaders(respPhMember.Member, response.Headers, respPhMember.Prefix)
-            );
-        if (binding.OutputPayloadReader is { } readPayload)
-            readPayload(BodyBytesOrNull(response.Body), BodyStreamOrNull(response.Body), builder);
-        else if (binding.OutputBodyCodec is { } codec && response.Content.Length > 0)
-            codec.ReadInto(response.Content, builder);
 
-        return binding.OutputSchema.Build(builder);
+        bound.PrefixHeaderWriter?.Write(headers, value);
+    }
+
+    private static T ReadResponse<T, TBuilder>(
+        RestStructBinding<T, TBuilder> bound,
+        SmithyHttpClientResponse response,
+        Func<byte[], byte[]>? prepareBody
+    )
+        where TBuilder : notnull
+    {
+        var builder = bound.Schema.CreateTypedBuilder();
+        bound.StatusCodeReader?.Read(builder, (int)response.StatusCode);
+        foreach (var header in bound.HeaderReaders)
+        {
+            if (
+                TryGetFirstHeader(response.Headers, header.Name, out var value)
+                || TryGetFirstHeader(response.ContentHeaders, header.Name, out value)
+            )
+            {
+                header.Read(builder, value);
+            }
+        }
+
+        bound.PrefixHeaderReader?.Read(builder, response.Headers);
+
+        if (bound.PayloadReader is { } readPayload)
+        {
+            readPayload(BodyBytesOrNull(response.Body), BodyStreamOrNull(response.Body), builder);
+        }
+        else if (bound.BodyCodec is { } codec && response.Content.Length > 0)
+        {
+            codec.ReadInto(
+                prepareBody is null ? response.Content : prepareBody(response.Content),
+                builder
+            );
+        }
+
+        return bound.Schema.Build(builder);
     }
 
     internal static HttpOperationError[] CompileErrorDeserializers(
@@ -319,99 +367,25 @@ public static class RestProtocol
         where TError : Exception
         where TBuilder : notnull
     {
-        IMemberSchema<TError>? responseCodeMember = null;
-        var headerMembers = new List<HeaderMemberBinding>();
-        var prefixHeaderMembers = new List<PrefixHeaderMemberBinding>();
-        RestPayloadReader? payloadReader = null;
-        var bodyMembers = new List<IMemberSchema<TError>>();
-
-        foreach (var member in Schemas.GetMembers(schema))
+        var bound = RestStructBinding<TError, TBuilder>.Compile(
+            schema,
+            HttpBindingSide.Response,
+            codecFactory,
+            rawStringPayloads,
+            emptyStructOnNullPayload: false
+        );
+        if (bound.PayloadMember is null && bound.BodyMemberNames.Count > 0)
         {
-            if (member.MemberTraits.ContainsKey(RestTraits.HttpResponseCode))
-            {
-                responseCodeMember = member;
-            }
-            else if (member.MemberTraits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
-            {
-                headerMembers.Add(new HeaderMemberBinding(member, headerTrait.Value.AsString()));
-            }
-            else if (
-                member.MemberTraits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait)
-            )
-            {
-                prefixHeaderMembers.Add(
-                    new PrefixHeaderMemberBinding(member, prefixTrait.Value.AsString())
-                );
-            }
-            else if (member.MemberTraits.ContainsKey(RestTraits.HttpPayload))
-            {
-                payloadReader = BuildPayloadReader(member, codecFactory, rawStringPayloads);
-            }
-            else
-            {
-                bodyMembers.Add(member);
-            }
+            bound.BodyCodec = bound.CompileBodyCodec(
+                codecFactory,
+                new CodecFactoryOptions { MaterializeTopLevelDefaults = true }
+            );
         }
-
-        var bodyCodec =
-            bodyMembers.Count > 0
-                ? codecFactory.FromProjection(
-                    Schemas.Project(schema, bodyMembers),
-                    new CodecFactoryOptions { MaterializeTopLevelDefaults = true }
-                )
-                : null;
 
         return new HttpOperationError(
             error.Id,
             error.HttpStatusCode,
-            response =>
-            {
-                var builder = schema.CreateTypedBuilder();
-                if (responseCodeMember is not null)
-                {
-                    responseCodeMember.SetObject(
-                        builder,
-                        ParseHttpValue(
-                            responseCodeMember.Target,
-                            ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)
-                        )
-                    );
-                }
-
-                foreach (var (member, headerName) in headerMembers)
-                {
-                    if (
-                        TryGetFirstHeader(response.Headers, headerName, out var header)
-                        || TryGetFirstHeader(response.ContentHeaders, headerName, out header)
-                    )
-                    {
-                        member.SetObject(
-                            builder,
-                            ParseHttpBindingValue(member.Target, member.MemberTraits, header)
-                        );
-                    }
-                }
-
-                foreach (var (member, prefix) in prefixHeaderMembers)
-                {
-                    member.SetObject(
-                        builder,
-                        ReadPrefixedHeaders(member, response.Headers, prefix)
-                    );
-                }
-
-                payloadReader?.Invoke(
-                    BodyBytesOrNull(response.Body),
-                    BodyStreamOrNull(response.Body),
-                    builder
-                );
-                if (bodyCodec is not null && response.Content.Length > 0)
-                {
-                    bodyCodec.ReadInto(codecFactory.PrepareErrorBody(response.Content), builder);
-                }
-
-                return schema.Build(builder);
-            }
+            response => ReadResponse(bound, response, codecFactory.PrepareErrorBody)
         );
     }
 
@@ -493,57 +467,25 @@ public static class RestProtocol
     )
         where TBuilder : notnull
     {
-        var headerMembers = new List<(string Name, IMemberSchema<TError> Member)>();
-        var prefixHeaderMembers = new List<(string Prefix, IMemberSchema<TError> Member)>();
-        var bodyMembers = new List<IMemberSchema<TError>>();
-        IMemberSchema<TError>? payloadMember = null;
-
-        foreach (var member in Schemas.GetMembers(schema))
-        {
-            if (member.MemberTraits.ContainsKey(RestTraits.HttpResponseCode))
-            {
-                continue;
-            }
-
-            if (member.MemberTraits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
-            {
-                headerMembers.Add((headerTrait.Value.AsString(), member));
-            }
-            else if (
-                member.MemberTraits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait)
-            )
-            {
-                prefixHeaderMembers.Add((prefixTrait.Value.AsString(), member));
-            }
-            else if (member.MemberTraits.ContainsKey(RestTraits.HttpPayload))
-            {
-                payloadMember = member;
-            }
-            else
-            {
-                bodyMembers.Add(member);
-            }
-        }
-
-        var headerBindings = headerMembers.ToArray();
-        var prefixHeaderBindings = prefixHeaderMembers.ToArray();
+        var bound = RestStructBinding<TError, TBuilder>.Compile(
+            schema,
+            HttpBindingSide.Response,
+            codecFactory,
+            rawStringPayloads,
+            emptyStructOnNullPayload: false
+        );
 
         // The body writer is where the bulk of the per-response cost was: without this the projected
         // schema was rebuilt and a whole codec recompiled for every error served.
         Func<TError, RestBody> writeBody;
-        if (payloadMember is not null)
+        if (bound.PayloadWriter is { } writePayload)
         {
-            writeBody = BuildPayloadWriter(
-                payloadMember,
-                codecFactory,
-                rawStringPayloads,
-                emptyStructOnNull: false
-            );
+            writeBody = writePayload;
         }
         else
         {
-            var codec = codecFactory.FromProjection(
-                Schemas.Project(schema, bodyMembers),
+            var codec = bound.CompileBodyCodec(
+                codecFactory,
                 new CodecFactoryOptions { MaterializeTopLevelDefaults = true }
             );
             var contentType = codecFactory.ContentType;
@@ -558,15 +500,7 @@ public static class RestProtocol
             {
                 [errorTypeHeader] = [LocalName(errorShapeId)],
             };
-            foreach (var (name, member) in headerBindings)
-            {
-                AddHeader(headers, name, member, value);
-            }
-
-            foreach (var (prefix, member) in prefixHeaderBindings)
-            {
-                AddPrefixedHeaders(headers, prefix, member, value);
-            }
+            WriteHeaders(bound, value, headers);
 
             var contentHeaders = new Dictionary<string, IReadOnlyList<string>>(
                 StringComparer.OrdinalIgnoreCase
@@ -665,10 +599,10 @@ public static class RestProtocol
     private static Stream? BodyStreamOrNull(SmithyHttpBody body) =>
         body is SmithyHttpBody.Streaming stream ? stream.Content : null;
 
-    private static async IAsyncEnumerable<ReadOnlyMemory<byte>> FrameEventsAsync<TEvent>(
+    internal static async IAsyncEnumerable<ReadOnlyMemory<byte>> FrameEventsAsync<TEvent>(
         IAsyncEnumerable<TEvent> events,
         ICodec<TEvent> codec,
-        IUnionSchema eventSchema,
+        Func<TEvent, string> eventTypeOf,
         string payloadContentType,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
@@ -677,9 +611,8 @@ public static class RestProtocol
             var value in events.WithCancellation(cancellationToken).ConfigureAwait(false)
         )
         {
-            var eventType = eventSchema.GetCaseObject(value!).Name;
             yield return CreateEventStreamMessage(
-                    eventType,
+                    eventTypeOf(value),
                     codec.Serialize(value),
                     payloadContentType
                 )
@@ -687,7 +620,7 @@ public static class RestProtocol
         }
     }
 
-    private static async IAsyncEnumerable<TEvent> ReadEventsAsync<TEvent>(
+    internal static async IAsyncEnumerable<TEvent> ReadEventsAsync<TEvent>(
         Stream stream,
         ICodec<TEvent> codec,
         string payloadContentType,
@@ -838,7 +771,7 @@ public static class RestProtocol
             return mediaType;
         }
 
-        return UnwrapNullable(target).Kind switch
+        return HttpBindingPlans.UnwrapNullable(target).Kind switch
         {
             _ when target.Resolved is IEventStreamSchema => EventStreamContentType,
             ShapeKind.Blob => codecFactory.BlobContentType,
@@ -849,796 +782,13 @@ public static class RestProtocol
         };
     }
 
-    /// <summary>
-    /// Builds — once, at binding construction — a delegate that serializes an <c>@httpPayload</c>
-    /// member to its wire body. The blob/text/codec decision and the compiled body codec are baked
-    /// in, so nothing is recompiled per request. <paramref name="emptyStructOnNull"/> separates the
-    /// request side (a null struct payload still emits <c>{}</c>) from the response side (emits
-    /// nothing).
-    /// </summary>
-    internal static Func<TContainer, RestBody> BuildPayloadWriter<TContainer>(
-        IMemberSchema<TContainer> member,
-        IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads,
-        bool emptyStructOnNull
-    )
-    {
-        var builder = new PayloadWriterBuilder<TContainer>(
-            codecFactory,
-            rawStringPayloads,
-            emptyStructOnNull
-        );
-        member.Accept(builder);
-        return builder.Result!;
-    }
-
-    /// <summary>Builds — once — a delegate that reads an <c>@httpPayload</c> member from the body.</summary>
-    internal static RestPayloadReader BuildPayloadReader<TContainer>(
-        IMemberSchema<TContainer> member,
-        IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads
-    )
-    {
-        var builder = new PayloadReaderBuilder<TContainer>(codecFactory, rawStringPayloads);
-        member.Accept(builder);
-        return builder.Result!;
-    }
-
-    private sealed class PayloadWriterBuilder<TContainer>(
-        IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads,
-        bool emptyStructOnNull
-    ) : IMemberVisitor<TContainer>
-    {
-        public Func<TContainer, RestBody>? Result { get; private set; }
-
-        public void Visit<TValue>(IMemberSchema<TContainer, TValue> member)
-        {
-            var target = member.TargetSchema;
-            var traits = member.MemberTraits;
-            var mediaType = GetMediaType(target, traits);
-            var kind = UnwrapNullable(target).Kind;
-
-            if (target.Resolved is IEventStreamSchema eventStream)
-            {
-                Result = BuildEventStreamPayloadWriter(
-                    member,
-                    (dynamic)eventStream.EventSchema,
-                    codecFactory
-                );
-                return;
-            }
-
-            if (kind == ShapeKind.Blob && traits.ContainsKey(RestTraits.Streaming))
-            {
-                var contentType = mediaType ?? codecFactory.BlobContentType;
-                var requiresLength = traits.ContainsKey(RestTraits.RequiresLength);
-                Result = container =>
-                {
-                    if (member.GetValue(container) is not { } value)
-                    {
-                        return RestBody.None;
-                    }
-
-                    var stream = (Stream)(object)value;
-                    if (!requiresLength)
-                    {
-                        return new RestBody([], contentType, stream);
-                    }
-
-                    if (!stream.CanSeek)
-                    {
-                        throw new InvalidOperationException(
-                            "Streaming blob payloads with @requiresLength require a seekable stream."
-                        );
-                    }
-
-                    return new RestBody([], contentType, stream, stream.Length - stream.Position);
-                };
-                return;
-            }
-
-            if (kind == ShapeKind.Blob)
-            {
-                var contentType = mediaType ?? codecFactory.BlobContentType;
-                Result = container =>
-                    member.GetValue(container) is { } value
-                        ? new RestBody((byte[])(object)value, contentType)
-                        : RestBody.None;
-                return;
-            }
-
-            if (
-                (kind == ShapeKind.String || kind == ShapeKind.Enum)
-                && (
-                    mediaType is not null
-                    || !UseBodyCodecForPayload(target, traits, rawStringPayloads)
-                )
-            )
-            {
-                var contentType = mediaType ?? "text/plain";
-                Result = container =>
-                {
-                    var value = member.GetValue(container);
-                    if (value is null)
-                        return RestBody.None;
-                    var text =
-                        kind == ShapeKind.Enum
-                            ? ((IStringEnumValue)(object)value).Value
-                            : (string)(object)value;
-                    return new RestBody(Encoding.UTF8.GetBytes(text), contentType);
-                };
-                return;
-            }
-
-            // Codec path: structures, unions, documents, and string/enum that go through the body
-            // codec (alloy simpleRestJson, or members carrying an explicit @default). The codec is
-            // compiled once here; the empty-struct value for a null request payload is built lazily
-            // (only if a null actually arrives) so binding construction never materializes a struct
-            // with required members.
-            var codec = codecFactory.FromMember(member);
-            var jsonContentType = codecFactory.ContentType;
-            var writeEmptyStructOnNull = emptyStructOnNull;
-
-            Result = container =>
-            {
-                var value = member.GetValue(container);
-                if (value is null)
-                {
-                    return
-                        writeEmptyStructOnNull
-                        && UnwrapNullable(target).Resolved is IStructSchema<TValue> emptyStruct
-                        ? new RestBody(codec.Serialize(emptyStruct.BuildEmpty()), jsonContentType)
-                        : RestBody.None;
-                }
-                if (IsDefaultValue(target, traits, value))
-                    return RestBody.None;
-                return new RestBody(codec.Serialize(value), jsonContentType);
-            };
-        }
-    }
-
-    private sealed class PayloadReaderBuilder<TContainer>(
-        IRestBodyCodecFactory codecFactory,
-        bool rawStringPayloads
-    ) : IMemberVisitor<TContainer>
-    {
-        public RestPayloadReader? Result { get; private set; }
-
-        public void Visit<TValue>(IMemberSchema<TContainer, TValue> member)
-        {
-            var target = member.TargetSchema;
-            var traits = member.MemberTraits;
-            var unwrapped = UnwrapNullable(target);
-
-            if (target.Resolved is IEventStreamSchema eventStream)
-            {
-                Result = BuildEventStreamPayloadReader(
-                    member,
-                    (dynamic)eventStream.EventSchema,
-                    codecFactory
-                );
-                return;
-            }
-
-            if (unwrapped.Kind == ShapeKind.Blob && traits.ContainsKey(RestTraits.Streaming))
-            {
-                Result = (content, streamingContent, builder) =>
-                {
-                    if (streamingContent is not null)
-                    {
-                        member.SetObject(builder, streamingContent);
-                    }
-                    else if (content is null or { Length: 0 })
-                    {
-                        if (traits.ContainsKey(DefaultTrait))
-                        {
-                            member.SetObject(builder, Stream.Null);
-                        }
-                    }
-                    else
-                    {
-                        member.SetObject(builder, new MemoryStream(content, writable: false));
-                    }
-                };
-                return;
-            }
-
-            if (unwrapped.Kind == ShapeKind.Blob)
-            {
-                Result = (content, streamingContent, builder) =>
-                {
-                    if (content is null or { Length: 0 })
-                        ApplyDefault(member, target, traits, builder);
-                    else
-                        member.SetObject(builder, content);
-                };
-                return;
-            }
-
-            if (!UseBodyCodecForPayload(target, traits, rawStringPayloads))
-            {
-                Result = (content, streamingContent, builder) =>
-                {
-                    if (content is null or { Length: 0 })
-                    {
-                        ApplyDefault(member, target, traits, builder);
-                        return;
-                    }
-                    var text = Encoding.UTF8.GetString(content);
-                    member.SetObject(
-                        builder,
-                        unwrapped.Kind == ShapeKind.Enum
-                            ? ((IStringEnumSchema)unwrapped).CreateObject(text)
-                            : text
-                    );
-                };
-                return;
-            }
-
-            var codec = codecFactory.FromMember(member);
-            Result = (content, streamingContent, builder) =>
-            {
-                if (content is null or { Length: 0 })
-                    ApplyDefault(member, target, traits, builder);
-                else
-                    member.SetObject(builder, codec.Deserialize(content));
-            };
-        }
-
-        private static void ApplyDefault(
-            IStructMemberSchema member,
-            Schema target,
-            IReadOnlyDictionary<ShapeId, Trait> traits,
-            object builder
-        )
-        {
-            if (TryCreateDefaultValue(target, traits, out var defaultValue))
-                member.SetObject(builder, defaultValue);
-        }
-    }
-
-    private static Func<TContainer, RestBody> BuildEventStreamPayloadWriter<
-        TContainer,
-        TValue,
-        TEvent
-    >(
-        IMemberSchema<TContainer, TValue> member,
-        Schema<TEvent> eventSchema,
-        IRestBodyCodecFactory codecFactory
-    )
-    {
-        var codec = codecFactory.FromSchema(eventSchema);
-        var union =
-            eventSchema.Resolved as IUnionSchema
-            ?? throw new InvalidOperationException(
-                "REST event stream payloads must target a union schema."
-            );
-
-        return container =>
-        {
-            var value = member.GetValue(container);
-            if (value is null)
-            {
-                return RestBody.None;
-            }
-
-            return new RestBody(
-                [],
-                EventStreamContentType,
-                EventStreamingContent: FrameEventsAsync(
-                    (IAsyncEnumerable<TEvent>)(object)value,
-                    codec,
-                    union,
-                    codecFactory.ContentType
-                )
-            );
-        };
-    }
-
-    private static RestPayloadReader BuildEventStreamPayloadReader<TContainer, TValue, TEvent>(
-        IMemberSchema<TContainer, TValue> member,
-        Schema<TEvent> eventSchema,
-        IRestBodyCodecFactory codecFactory
-    )
-    {
-        var codec = codecFactory.FromSchema(eventSchema);
-        var payloadContentType = codecFactory.ContentType;
-        return (content, streamingContent, builder) =>
-        {
-            var stream =
-                streamingContent
-                ?? (
-                    content is { Length: > 0 }
-                        ? new MemoryStream(content, writable: false)
-                        : Stream.Null
-                );
-            member.SetObject(
-                builder,
-                (TValue)(object)ReadEventsAsync(stream, codec, payloadContentType)
-            );
-        };
-    }
-
-    private static string BuildRequestUri<TInput>(
-        string uriTemplate,
-        IReadOnlyList<IStructMemberSchema> labelMembers,
-        TInput input
-    )
-    {
-        var requestUri = uriTemplate;
-        foreach (var member in labelMembers)
-        {
-            var value = member.GetObject(input!);
-            if (value is null)
-                throw new InvalidOperationException(
-                    $"HTTP label member '{member.Name}' cannot be null."
-                );
-
-            requestUri = requestUri
-                .Replace(
-                    "{" + member.Name + "+}",
-                    EscapeGreedyLabel(member.Target, member.MemberTraits, value),
-                    StringComparison.Ordinal
-                )
-                .Replace(
-                    "{" + member.Name + "}",
-                    Uri.EscapeDataString(
-                        FormatHttpValue(member.Target, member.MemberTraits, value)
-                    ),
-                    StringComparison.Ordinal
-                );
-        }
-
-        return requestUri;
-    }
-
-    private static void AddHeader<TInput>(
-        Dictionary<string, IReadOnlyList<string>> headers,
-        string name,
-        IStructMemberSchema member,
-        TInput input
-    )
-    {
-        var value = member.GetObject(input!);
-        if (value is null)
-        {
-            return;
-        }
-
-        headers[name] = [FormatHttpHeaderValue(member, value)];
-    }
-
-    private static void AddRequestHeader<TInput>(
-        SmithyHttpRequest request,
-        string name,
-        IStructMemberSchema member,
-        TInput input
-    )
-    {
-        var value = member.GetObject(input!);
-        if (value is null)
-        {
-            return;
-        }
-
-        var formatted = FormatHttpHeaderValue(member, value);
-        if (string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase))
-        {
-            request.ContentType = formatted;
-            return;
-        }
-
-        if (string.Equals(name, "Content-Encoding", StringComparison.OrdinalIgnoreCase))
-        {
-            request.ContentHeaders[name] = [formatted];
-            return;
-        }
-
-        request.Headers[name] = [formatted];
-    }
-
-    private static void AddPrefixedHeaders<TInput>(
-        IDictionary<string, IReadOnlyList<string>> headers,
-        string prefix,
-        IStructMemberSchema member,
-        TInput input
-    )
-    {
-        var value = member.GetObject(input!);
-        if (value is null)
-        {
-            return;
-        }
-
-        var mapSchema = RequireMap(member);
-        foreach (var entry in mapSchema.GetEntriesObject(value))
-        {
-            if (entry.Value is null)
-            {
-                continue;
-            }
-
-            var headerName = $"{prefix}{entry.Key}";
-            if (!headers.ContainsKey(headerName))
-            {
-                headers[headerName] = [FormatHttpValue(mapSchema.Value, entry.Value)];
-            }
-        }
-    }
-
-    private static object ReadPrefixedHeaders(
-        IStructMemberSchema member,
-        IEnumerable<KeyValuePair<string, IReadOnlyList<string>>> headers,
-        string prefix
-    )
-    {
-        var mapSchema = RequireMap(member);
-        var builder = mapSchema.CreateBuilder();
-        foreach (var header in headers)
-        {
-            if (
-                !header.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                || (prefix.Length == 0 && IsTransportManagedHeader(header.Key))
-                || header.Value.Count == 0
-            )
-            {
-                continue;
-            }
-
-            mapSchema.AddObject(
-                builder,
-                header.Key[prefix.Length..],
-                ParseHttpValue(mapSchema.Value, header.Value[0])
-            );
-        }
-
-        return mapSchema.BuildObject(builder);
-    }
-
-    private static object ReadQueryParams(
-        IStructMemberSchema member,
-        Dictionary<string, IReadOnlyList<string>> query
-    )
-    {
-        var mapSchema = RequireMap(member);
-        var builder = mapSchema.CreateBuilder();
-        foreach (var entry in query)
-        {
-            if (entry.Value.Count == 0)
-            {
-                continue;
-            }
-
-            mapSchema.AddObject(
-                builder,
-                entry.Key,
-                ParseHttpBindingValues(mapSchema.Value, entry.Value)
-            );
-        }
-
-        return mapSchema.BuildObject(builder);
-    }
-
-    private static bool IsTransportManagedHeader(string name) =>
-        name.Equals("Host", StringComparison.OrdinalIgnoreCase)
-        || name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase);
-
-    private static string AppendQuery<TInput>(
-        string requestUri,
-        string name,
-        IStructMemberSchema member,
-        TInput input
-    )
-    {
-        var value = member.GetObject(input!);
-        if (value is null)
-        {
-            return requestUri;
-        }
-
-        var builder = new StringBuilder(requestUri);
-        AppendQueryValue(builder, name, member.Target, member.MemberTraits, value);
-        return builder.ToString();
-    }
-
-    private static string AppendQueryParams<TInput>(
-        string requestUri,
-        IStructMemberSchema member,
-        TInput input,
-        HashSet<string> excludedNames
-    )
-    {
-        var value = member.GetObject(input!);
-        if (value is null)
-        {
-            return requestUri;
-        }
-
-        var builder = new StringBuilder(requestUri);
-        var mapSchema = RequireMap(member);
-        foreach (var entry in mapSchema.GetEntriesObject(value))
-        {
-            if (entry.Value is null || excludedNames.Contains(entry.Key))
-            {
-                continue;
-            }
-
-            AppendQueryValue(builder, entry.Key, mapSchema.Value, entry.Value);
-        }
-
-        return builder.ToString();
-    }
-
-    private static IMapSchema RequireMap(IStructMemberSchema member) =>
-        member.Target.Resolved is IMapSchema mapSchema
-            ? mapSchema
-            : throw new InvalidOperationException(
-                $"HTTP binding member '{member.Name}' must target a map schema."
-            );
-
-    private static void AppendQueryValue(
-        StringBuilder builder,
-        string name,
-        Schema schema,
-        object value
-    ) => AppendQueryValue(builder, name, schema, traits: null, value);
-
-    private static void AppendQueryValue(
-        StringBuilder builder,
-        string name,
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    )
-    {
-        if (schema.Resolved is IListSchema listSchema)
-        {
-            foreach (var element in listSchema.GetElementsObject(value))
-            {
-                if (element is not null)
-                {
-                    AppendPrimitiveQueryValue(builder, name, listSchema.Element, traits, element);
-                }
-            }
-
-            return;
-        }
-
-        AppendPrimitiveQueryValue(builder, name, schema, traits, value);
-    }
-
-    private static void AppendPrimitiveQueryValue(
-        StringBuilder builder,
-        string name,
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    )
-    {
-        builder.Append(builder.ToString().Contains('?', StringComparison.Ordinal) ? '&' : '?');
-        builder.Append(Uri.EscapeDataString(name));
-        builder.Append('=');
-        builder.Append(Uri.EscapeDataString(FormatHttpValue(schema, traits, value)));
-    }
-
-    private static string FormatHttpHeaderValue(IStructMemberSchema member, object value)
-    {
-        if (member.Target.Resolved is IListSchema listSchema)
-        {
-            return string.Join(
-                ", ",
-                listSchema
-                    .GetElementsObject(value)
-                    .Where(element => element is not null)
-                    .Select(element =>
-                        FormatHttpHeaderListValue(listSchema.Element, member.MemberTraits, element!)
-                    )
-            );
-        }
-
-        return FormatHttpValue(member.Target, member.MemberTraits, value);
-    }
-
-    private static string FormatHttpValue(Schema schema, object value)
-    {
-        return FormatHttpValue(schema, traits: null, value);
-    }
-
-    private static string FormatHttpValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    )
-    {
-        schema = UnwrapNullable(schema);
-        return schema.Kind switch
-        {
-            ShapeKind.Boolean => ((bool)value).ToString().ToLowerInvariant(),
-            ShapeKind.Byte => ((sbyte)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Short => ((short)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Integer => ((int)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Long => ((long)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Float => FormatFloat((float)value),
-            ShapeKind.Double => FormatDouble((double)value),
-            ShapeKind.BigInteger => ((BigInteger)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.BigDecimal => ((decimal)value).ToString(CultureInfo.InvariantCulture),
-            ShapeKind.String => HasTrait(schema, traits, RestTraits.MediaType)
-                ? Convert.ToBase64String(Encoding.UTF8.GetBytes((string)value))
-                : (string)value,
-            ShapeKind.Enum => ((IStringEnumValue)value).Value ?? string.Empty,
-            ShapeKind.IntEnum => ((IIntEnumSchema)schema)
-                .GetIntegerValueObject(value)
-                .ToString(CultureInfo.InvariantCulture),
-            ShapeKind.Blob => Convert.ToBase64String((byte[])value),
-            ShapeKind.Timestamp => FormatTimestamp(schema, traits, (DateTimeOffset)value),
-            _ => throw new NotSupportedException(
-                $"RestJson HTTP binding codec does not support schema kind '{schema.Kind}'."
-            ),
-        };
-    }
-
-    private static string FormatHttpHeaderListValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    )
-    {
-        schema = UnwrapNullable(schema);
-        var formatted = FormatHttpValue(schema, traits, value);
-        if (schema.Kind is not (ShapeKind.String or ShapeKind.Enum))
-        {
-            return formatted;
-        }
-
-        return NeedsQuotedHeaderValue(formatted) ? QuoteHeaderValue(formatted) : formatted;
-    }
-
-    private static object? ParseHttpBindingValue(Schema schema, string value)
-    {
-        return ParseHttpBindingValue(schema, traits: null, value);
-    }
-
-    private static object? ParseHttpBindingValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        if (schema.Resolved is IListSchema listSchema)
-        {
-            var element = UnwrapNullable(listSchema.Element);
-            return ParseHttpBindingValues(
-                schema,
-                traits,
-                SplitHeaderList(value, element.Kind).ToArray()
-            );
-        }
-
-        return ParseHttpValue(schema, traits, value);
-    }
-
-    private static object? ParseHttpBindingValues(Schema schema, IReadOnlyList<string> values) =>
-        ParseHttpBindingValues(schema, traits: null, values);
-
-    private static object? ParseHttpBindingValues(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        IReadOnlyList<string> values
-    )
-    {
-        if (schema.Resolved is not IListSchema listSchema)
-        {
-            return values.Count > 0 ? ParseHttpValue(schema, traits, values[0]) : null;
-        }
-
-        var builder = listSchema.CreateBuilder();
-        foreach (var value in values)
-        {
-            listSchema.AddObject(
-                builder,
-                ParseHttpValue(UnwrapNullable(listSchema.Element), traits, value)
-            );
-        }
-
-        return listSchema.BuildObject(builder);
-    }
-
-    private static object? ParseHttpValue(Schema schema, string value)
-    {
-        return ParseHttpValue(schema, traits: null, value);
-    }
-
-    private static object? ParseHttpValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        schema = UnwrapNullable(schema);
-        try
-        {
-            return ParseHttpValueCore(schema, traits, value);
-        }
-        catch (Exception exception)
-            when (exception is FormatException or OverflowException or ArgumentException)
-        {
-            // A label, query parameter, or header the model types but the caller did not: on a
-            // server the caller's mistake, answered with a structured 400 rather than a fault.
-            throw MalformedRequestException.Serialization(
-                $"Value '{value}' is not a valid {schema.Kind.ToString().ToLowerInvariant()}."
-            );
-        }
-    }
-
-    private static object? ParseHttpValueCore(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        return schema.Kind switch
-        {
-            // Only the two literals the model means. bool.Parse also accepts "True" and " TRUE ",
-            // which would let a caller coerce a string into a boolean the model never declared.
-            ShapeKind.Boolean => value switch
-            {
-                "true" => true,
-                "false" => false,
-                _ => throw new FormatException($"'{value}' is not a boolean."),
-            },
-            ShapeKind.Byte => sbyte.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Short => short.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Integer => int.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Long => long.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.Float => ParseFloat(value),
-            ShapeKind.Double => ParseDouble(value),
-            ShapeKind.BigInteger => BigInteger.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.BigDecimal => decimal.Parse(value, CultureInfo.InvariantCulture),
-            ShapeKind.String => HasTrait(schema, traits, RestTraits.MediaType)
-                ? Encoding.UTF8.GetString(Convert.FromBase64String(value))
-                : value,
-            ShapeKind.Enum => ((IStringEnumSchema)schema).CreateObject(value),
-            ShapeKind.IntEnum => ((IIntEnumSchema)schema).CreateObject(
-                int.Parse(value, CultureInfo.InvariantCulture)
-            ),
-            ShapeKind.Blob => Convert.FromBase64String(value),
-            ShapeKind.Timestamp => ParseTimestamp(schema, traits, value),
-            _ => throw new NotSupportedException(
-                $"RestJson HTTP binding codec does not support schema kind '{schema.Kind}'."
-            ),
-        };
-    }
-
-    private static Schema UnwrapNullable(Schema schema)
-    {
-        var resolved = schema.Resolved;
-        return resolved is INullableSchema nullable ? nullable.Target.Resolved : resolved;
-    }
-
-    private static bool IsDefaultValue(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait> traits,
-        object value
-    )
-    {
-        if (!TryCreateDefaultValue(schema, traits, out var defaultValue))
-        {
-            return false;
-        }
-
-        return value is byte[] bytes && defaultValue is byte[] defaultBytes
-            ? bytes.SequenceEqual(defaultBytes)
-            : EqualityComparer<object>.Default.Equals(value, defaultValue);
-    }
-
-    private static bool UseBodyCodecForPayload(
+    internal static bool UseBodyCodecForPayload(
         Schema schema,
         IReadOnlyDictionary<ShapeId, Trait> traits,
         bool rawStringPayloads
     )
     {
-        var kind = UnwrapNullable(schema).Kind;
+        var kind = HttpBindingPlans.UnwrapNullable(schema).Kind;
         if (kind is not (ShapeKind.String or ShapeKind.Enum))
         {
             return true;
@@ -1650,183 +800,15 @@ public static class RestProtocol
         return traits.ContainsKey(DefaultTrait) || !rawStringPayloads;
     }
 
-    private static bool TryCreateDefaultValue(
+    internal static string? GetMediaType(
         Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait> traits,
-        out object? value
-    )
-    {
-        if (!traits.TryGetValue(DefaultTrait, out var trait))
-        {
-            value = null;
-            return false;
-        }
-
-        value = CreateDefaultValue(UnwrapNullable(schema), trait.Value);
-        return true;
-    }
-
-    private static object? CreateDefaultValue(Schema schema, Document value)
-    {
-        return schema.Kind switch
-        {
-            ShapeKind.Boolean => value.AsBoolean(),
-            ShapeKind.Byte => (sbyte)value.AsNumber(),
-            ShapeKind.Short => (short)value.AsNumber(),
-            ShapeKind.Integer => (int)value.AsNumber(),
-            ShapeKind.Long => (long)value.AsNumber(),
-            ShapeKind.Float => (float)value.AsNumber(),
-            ShapeKind.Double => (double)value.AsNumber(),
-            ShapeKind.BigInteger => new BigInteger(value.AsNumber()),
-            ShapeKind.BigDecimal => value.AsNumber(),
-            ShapeKind.String => value.AsString(),
-            ShapeKind.Enum => ((IStringEnumSchema)schema).CreateObject(value.AsString()),
-            ShapeKind.IntEnum => ((IIntEnumSchema)schema).CreateObject((int)value.AsNumber()),
-            ShapeKind.Blob => Convert.FromBase64String(value.AsString()),
-            _ => null,
-        };
-    }
-
-    private static string EscapeGreedyLabel(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        object value
-    )
-    {
-        return string.Join(
-            "/",
-            FormatHttpValue(schema, traits, value).Split('/').Select(Uri.EscapeDataString)
-        );
-    }
-
-    private static string FormatFloat(float value)
-    {
-        if (float.IsNaN(value))
-        {
-            return "NaN";
-        }
-
-        if (float.IsPositiveInfinity(value))
-        {
-            return "Infinity";
-        }
-
-        if (float.IsNegativeInfinity(value))
-        {
-            return "-Infinity";
-        }
-
-        return value.ToString(CultureInfo.InvariantCulture);
-    }
-
-    private static string FormatDouble(double value)
-    {
-        if (double.IsNaN(value))
-        {
-            return "NaN";
-        }
-
-        if (double.IsPositiveInfinity(value))
-        {
-            return "Infinity";
-        }
-
-        if (double.IsNegativeInfinity(value))
-        {
-            return "-Infinity";
-        }
-
-        return value.ToString(CultureInfo.InvariantCulture);
-    }
-
-    private static float ParseFloat(string value) =>
-        value switch
-        {
-            "NaN" => float.NaN,
-            "Infinity" => float.PositiveInfinity,
-            "-Infinity" => float.NegativeInfinity,
-            _ => float.Parse(value, CultureInfo.InvariantCulture),
-        };
-
-    private static double ParseDouble(string value) =>
-        value switch
-        {
-            "NaN" => double.NaN,
-            "Infinity" => double.PositiveInfinity,
-            "-Infinity" => double.NegativeInfinity,
-            _ => double.Parse(value, CultureInfo.InvariantCulture),
-        };
-
-    private static string FormatRfc3339(DateTimeOffset value)
-    {
-        var utc = value.ToUniversalTime();
-        return utc.Ticks % TimeSpan.TicksPerSecond == 0
-            ? utc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture)
-            : utc.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'", CultureInfo.InvariantCulture);
-    }
-
-    private static string FormatTimestamp(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        DateTimeOffset value
-    )
-    {
-        return GetTimestampFormat(schema, traits) switch
-        {
-            "epoch-seconds" => FormatEpochSeconds(value),
-            "http-date" => value
-                .ToUniversalTime()
-                .ToString("ddd, dd MMM yyyy HH':'mm':'ss 'GMT'", CultureInfo.InvariantCulture),
-            "date-time" => FormatRfc3339(value),
-            var format => throw new NotSupportedException(
-                $"Timestamp format '{format}' is not supported."
-            ),
-        };
-    }
-
-    private static DateTimeOffset ParseTimestamp(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        string value
-    )
-    {
-        return GetTimestampFormat(schema, traits) switch
-        {
-            "epoch-seconds" => ParseEpochSeconds(value),
-            "http-date" => DateTimeOffset.ParseExact(value, "r", CultureInfo.InvariantCulture),
-            // A label, query parameter, or header is only ever read from a request, so there is no
-            // looser peer to accommodate here the way there is in a response body.
-            "date-time" => Rfc3339.Parse(value, WireReadMode.Strict),
-            var format => throw new NotSupportedException(
-                $"Timestamp format '{format}' is not supported."
-            ),
-        };
-    }
-
-    private static string GetTimestampFormat(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits
-    )
-    {
-        if (TryGetTrait(schema, traits, RestTraits.TimestampFormat, out var trait))
-        {
-            return trait.Value.AsString();
-        }
-
-        if (HasTrait(schema, traits, RestTraits.HttpHeader))
-        {
-            return "http-date";
-        }
-
-        return "date-time";
-    }
-
-    private static string? GetMediaType(Schema schema, IReadOnlyDictionary<ShapeId, Trait> traits)
-    {
-        return TryGetTrait(schema, traits, RestTraits.MediaType, out var trait)
-            ? trait.Value.AsString()
-            : null;
-    }
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    ) =>
+        (
+            traits.TryGetValue(RestTraits.MediaType, out var trait)
+                ? trait
+                : schema.GetTrait(RestTraits.MediaType)
+        )?.Value.AsString();
 
     /// <summary>
     /// Whether an <c>@httpPayload</c> member carries bytes the protocol assigns no meaning to: a blob
@@ -1840,154 +822,7 @@ public static class RestProtocol
     ) =>
         GetMediaType(target, traits) is null
         && target.Resolved is not IEventStreamSchema
-        && UnwrapNullable(target).Kind == ShapeKind.Blob;
-
-    private static DateTimeOffset ParseEpochSeconds(string value)
-    {
-        var seconds = decimal.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
-        var wholeSeconds = decimal.Truncate(seconds);
-        var fractionalSeconds = seconds - wholeSeconds;
-        return DateTimeOffset
-            .FromUnixTimeSeconds((long)wholeSeconds)
-            .AddTicks((long)(fractionalSeconds * TimeSpan.TicksPerSecond));
-    }
-
-    private static string FormatEpochSeconds(DateTimeOffset value)
-    {
-        var unixSeconds = value.ToUnixTimeSeconds();
-        var fractionalTicks = value.ToUniversalTime().Ticks % TimeSpan.TicksPerSecond;
-        if (fractionalTicks == 0)
-        {
-            return unixSeconds.ToString(CultureInfo.InvariantCulture);
-        }
-
-        var fractional = ((decimal)fractionalTicks / TimeSpan.TicksPerSecond).ToString(
-            "0.################",
-            CultureInfo.InvariantCulture
-        );
-        return $"{unixSeconds}{fractional[1..]}";
-    }
-
-    private static bool HasTrait(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        ShapeId id
-    ) => TryGetTrait(schema, traits, id, out _);
-
-    private static bool TryGetTrait(
-        Schema schema,
-        IReadOnlyDictionary<ShapeId, Trait>? traits,
-        ShapeId id,
-        out Trait trait
-    )
-    {
-        if (traits?.TryGetValue(id, out trait) == true)
-        {
-            return true;
-        }
-
-        if (schema.Traits.TryGetValue(id, out trait))
-        {
-            return true;
-        }
-
-        trait = default;
-        return false;
-    }
-
-    private static IEnumerable<string> SplitHeaderList(string value, ShapeKind elementKind)
-    {
-        if (
-            elementKind == ShapeKind.Timestamp
-            && value.Contains("GMT,", StringComparison.OrdinalIgnoreCase)
-        )
-        {
-            var segments = value.Split("GMT,", StringSplitOptions.None);
-            for (var i = 0; i < segments.Length; i++)
-            {
-                var segment = segments[i].Trim();
-                if (segment.Length == 0)
-                {
-                    continue;
-                }
-
-                yield return i < segments.Length - 1 ? segment + " GMT" : segment;
-            }
-
-            yield break;
-        }
-
-        if (
-            elementKind is ShapeKind.String or ShapeKind.Enum
-            && value.Contains('"', StringComparison.Ordinal)
-        )
-        {
-            foreach (var part in ParseQuotedHeaderList(value))
-            {
-                yield return part;
-            }
-
-            yield break;
-        }
-
-        foreach (var part in value.Split(','))
-        {
-            yield return part.Trim();
-        }
-    }
-
-    private static IEnumerable<string> ParseQuotedHeaderList(string value)
-    {
-        var builder = new StringBuilder();
-        var inQuotes = false;
-        var escaping = false;
-        foreach (var ch in value)
-        {
-            if (escaping)
-            {
-                builder.Append(ch);
-                escaping = false;
-                continue;
-            }
-
-            if (ch == '\\' && inQuotes)
-            {
-                escaping = true;
-                continue;
-            }
-
-            if (ch == '"')
-            {
-                inQuotes = !inQuotes;
-                continue;
-            }
-
-            if (ch == ',' && !inQuotes)
-            {
-                yield return builder.ToString().Trim();
-                builder.Clear();
-                continue;
-            }
-
-            builder.Append(ch);
-        }
-
-        if (builder.Length > 0 || (value.Length > 0 && value[^1] == ','))
-        {
-            yield return builder.ToString().Trim();
-        }
-    }
-
-    private static bool NeedsQuotedHeaderValue(string value) =>
-        value.Length == 0
-        || value.Any(ch => ch == ',' || ch == '"' || ch == '\\' || char.IsWhiteSpace(ch));
-
-    private static string QuoteHeaderValue(string value) =>
-        "\""
-        + value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("\"", "\\\"", StringComparison.Ordinal)
-        + "\"";
+        && HttpBindingPlans.UnwrapNullable(target).Kind == ShapeKind.Blob;
 
     private static Dictionary<string, string> ExtractLabels(string pattern, string requestUri)
     {

--- a/packages/NSmithy.Protocols.Rest/RestProtocol.cs
+++ b/packages/NSmithy.Protocols.Rest/RestProtocol.cs
@@ -65,8 +65,6 @@ public static class RestProtocol
         TInputBuilder,
         TOutputBuilder
     >(RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding, TInput input)
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
         var bound = binding.Input;
@@ -139,8 +137,6 @@ public static class RestProtocol
         RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
         SmithyHttpRequest request
     )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
         ArgumentNullException.ThrowIfNull(request);
@@ -221,8 +217,6 @@ public static class RestProtocol
         TInputBuilder,
         TOutputBuilder
     >(RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding, TOutput output)
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
         var bound = binding.Output;
@@ -259,8 +253,6 @@ public static class RestProtocol
         RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
         SmithyHttpClientResponse response
     )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         ArgumentNullException.ThrowIfNull(binding);
         ArgumentNullException.ThrowIfNull(response);
@@ -272,7 +264,6 @@ public static class RestProtocol
         T value,
         Dictionary<string, IReadOnlyList<string>> headers
     )
-        where TBuilder : notnull
     {
         foreach (var header in bound.HeaderWriters)
         {
@@ -290,7 +281,6 @@ public static class RestProtocol
         SmithyHttpClientResponse response,
         Func<byte[], byte[]>? prepareBody
     )
-        where TBuilder : notnull
     {
         var builder = bound.Schema.CreateTypedBuilder();
         bound.StatusCodeReader?.Read(builder, (int)response.StatusCode);
@@ -330,15 +320,18 @@ public static class RestProtocol
     {
         ArgumentNullException.ThrowIfNull(errors);
         ArgumentNullException.ThrowIfNull(codecFactory);
-        return errors
-            .Select(error =>
-                (HttpOperationError)CompileErrorDeserializer(
-                    (dynamic)error,
-                    codecFactory,
-                    rawStringPayloads
-                )
-            )
-            .ToArray();
+        var compiler = new ErrorDeserializerCompiler(codecFactory, rawStringPayloads);
+        return errors.Select(error => error.Accept(compiler)).ToArray();
+    }
+
+    private sealed class ErrorDeserializerCompiler(
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads
+    ) : IOperationErrorSchemaVisitor<HttpOperationError>
+    {
+        public HttpOperationError Visit<TError>(OperationErrorSchema<TError> error)
+            where TError : Exception =>
+            CompileErrorDeserializer(error, codecFactory, rawStringPayloads);
     }
 
     private static HttpOperationError CompileErrorDeserializer<TError>(
@@ -355,7 +348,20 @@ public static class RestProtocol
             );
         }
 
-        return CompileErrorDeserializer(error, (dynamic)schema, codecFactory, rawStringPayloads);
+        return schema.Accept(
+            new ErrorStructDeserializerCompiler<TError>(error, codecFactory, rawStringPayloads)
+        );
+    }
+
+    private sealed class ErrorStructDeserializerCompiler<TError>(
+        OperationErrorSchema<TError> error,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads
+    ) : IStructSchemaVisitor<TError, HttpOperationError>
+        where TError : Exception
+    {
+        public HttpOperationError Visit<TBuilder>(IStructSchema<TError, TBuilder> schema) =>
+            CompileErrorDeserializer(error, schema, codecFactory, rawStringPayloads);
     }
 
     private static HttpOperationError CompileErrorDeserializer<TError, TBuilder>(
@@ -365,7 +371,6 @@ public static class RestProtocol
         bool rawStringPayloads
     )
         where TError : Exception
-        where TBuilder : notnull
     {
         var bound = RestStructBinding<TError, TBuilder>.Compile(
             schema,
@@ -451,12 +456,20 @@ public static class RestProtocol
             );
         }
 
-        return CompileStructuredError(
-            (dynamic)schema,
-            codecFactory,
-            rawStringPayloads,
-            errorTypeHeader
+        return schema.Accept(
+            new StructuredErrorCompiler<TError>(codecFactory, rawStringPayloads, errorTypeHeader)
         );
+    }
+
+    private sealed class StructuredErrorCompiler<TError>(
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads,
+        string errorTypeHeader
+    ) : IStructSchemaVisitor<TError, RestErrorSerializer<TError>>
+    {
+        public RestErrorSerializer<TError> Visit<TBuilder>(
+            IStructSchema<TError, TBuilder> schema
+        ) => CompileStructuredError(schema, codecFactory, rawStringPayloads, errorTypeHeader);
     }
 
     private static RestErrorSerializer<TError> CompileStructuredError<TError, TBuilder>(
@@ -465,7 +478,6 @@ public static class RestProtocol
         bool rawStringPayloads,
         string errorTypeHeader
     )
-        where TBuilder : notnull
     {
         var bound = RestStructBinding<TError, TBuilder>.Compile(
             schema,
@@ -910,8 +922,6 @@ public static class RestProtocol
         RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
         SmithyHttpRequest request
     )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         var declared = TryGetFirstHeader(request.Headers, "Content-Type", out var header)
             ? header
@@ -968,8 +978,6 @@ public static class RestProtocol
         RestOperationBinding<TInput, TOutput, TInputBuilder, TOutputBuilder> binding,
         SmithyHttpRequest request
     )
-        where TInputBuilder : notnull
-        where TOutputBuilder : notnull
     {
         if (
             binding.OutputIsUnit

--- a/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
@@ -177,8 +177,8 @@ internal sealed class RestStructBinding<T, TBuilder>
             if (side == HttpBindingSide.Request && traits.ContainsKey(RestTraits.HttpQueryParams))
             {
                 var plan = MapPlan(member, prefix: string.Empty);
-                QueryParamsWriter = (IHttpQueryParamsWriter<T>)plan;
-                QueryParamsReader = (IHttpQueryParamsReader<TBuilder>)plan;
+                QueryParamsWriter = plan;
+                QueryParamsReader = plan;
                 return;
             }
 
@@ -203,8 +203,8 @@ internal sealed class RestStructBinding<T, TBuilder>
             if (traits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait))
             {
                 var plan = MapPlan(member, prefixTrait.Value.AsString());
-                PrefixHeaderWriter = (IHttpPrefixHeaderWriter<T>)plan;
-                PrefixHeaderReader = (IHttpPrefixHeaderReader<TBuilder>)plan;
+                PrefixHeaderWriter = plan;
+                PrefixHeaderReader = plan;
                 return;
             }
 
@@ -228,7 +228,7 @@ internal sealed class RestStructBinding<T, TBuilder>
             IMemberSchema<T, TBuilder, TValue> member
         ) => HttpBindingCompiler.Compile(member.TargetSchema, member.MemberTraits);
 
-        private static object MapPlan<TValue>(
+        private static IMapBindingPlan<T, TBuilder> MapPlan<TValue>(
             IMemberSchema<T, TBuilder, TValue> member,
             string prefix
         ) =>

--- a/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
@@ -23,7 +23,6 @@ internal delegate void RestPayloadReader<in TBuilder>(
 /// and outputs and error shapes alike.
 /// </summary>
 internal sealed class RestStructBinding<T, TBuilder>
-    where TBuilder : notnull
 {
     private static readonly ShapeId DefaultTrait = new("smithy.api", "default");
 
@@ -226,13 +225,13 @@ internal sealed class RestStructBinding<T, TBuilder>
 
         private static IHttpValueCodec<TValue> Codec<TValue>(
             IMemberSchema<T, TBuilder, TValue> member
-        ) => HttpBindingCompiler.Compile(member.TargetSchema, member.MemberTraits);
+        ) => HttpBindingCompiler.Compile(member.TypedTarget, member.MemberTraits);
 
         private static IMapBindingPlan<T, TBuilder> MapPlan<TValue>(
             IMemberSchema<T, TBuilder, TValue> member,
             string prefix
         ) =>
-            member.TargetSchema.Resolved.Accept(
+            member.TypedTarget.Resolved.Accept(
                 new MapBindingPlanCompiler<T, TBuilder, TValue>(member, prefix)
             );
     }
@@ -251,7 +250,7 @@ internal sealed class RestStructBinding<T, TBuilder>
         bool emptyStructOnNull
     )
     {
-        var target = member.TargetSchema;
+        var target = member.TypedTarget;
         var traits = member.MemberTraits;
         var mediaType = RestProtocol.GetMediaType(target, traits);
         var kind = HttpBindingPlans.UnwrapNullable(target).Kind;
@@ -381,7 +380,7 @@ internal sealed class RestStructBinding<T, TBuilder>
         bool rawStringPayloads
     )
     {
-        var target = member.TargetSchema;
+        var target = member.TypedTarget;
         var traits = member.MemberTraits;
         var unwrapped = HttpBindingPlans.UnwrapNullable(target);
 
@@ -468,7 +467,7 @@ internal sealed class RestStructBinding<T, TBuilder>
         IMemberSchema<T, TBuilder, TValue> member
     ) =>
         DefaultValues.TryCompile(
-            member.TargetSchema,
+            member.TypedTarget,
             member.MemberTraits,
             honorClientOptional: false,
             out var create
@@ -480,7 +479,7 @@ internal sealed class RestStructBinding<T, TBuilder>
     private sealed class EventStreamPayloadCompiler<TValue>(
         IMemberSchema<T, TBuilder, TValue> member,
         IRestBodyCodecFactory codecFactory
-    ) : SchemaVisitor<(Func<T, RestBody> Writer, RestPayloadReader<TBuilder> Reader)>
+    ) : PartialSchemaVisitor<(Func<T, RestBody> Writer, RestPayloadReader<TBuilder> Reader)>
     {
         public override (
             Func<T, RestBody> Writer,

--- a/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
+++ b/packages/NSmithy.Protocols.Rest/RestStructBinding.cs
@@ -1,0 +1,533 @@
+using System.Text;
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Protocols.Rest;
+
+/// <summary>Which HTTP message a structure is bound to; the same trait set reads differently on each.</summary>
+internal enum HttpBindingSide
+{
+    Request,
+    Response,
+}
+
+internal delegate void RestPayloadReader<in TBuilder>(
+    byte[]? content,
+    Stream? streamingContent,
+    TBuilder builder
+);
+
+/// <summary>
+/// One structure's HTTP bindings, compiled once: every member bound to the URI, headers, status code
+/// or payload has a plan, and the members left over are the body projection. Serves operation inputs
+/// and outputs and error shapes alike.
+/// </summary>
+internal sealed class RestStructBinding<T, TBuilder>
+    where TBuilder : notnull
+{
+    private static readonly ShapeId DefaultTrait = new("smithy.api", "default");
+
+    public required IStructSchema<T, TBuilder> Schema { get; init; }
+
+    public required IHttpLabelWriter<T>[] LabelWriters { get; init; }
+
+    public required IHttpLabelReader<TBuilder>[] LabelReaders { get; init; }
+
+    public required IHttpQueryWriter<T>[] QueryWriters { get; init; }
+
+    public required IHttpQueryReader<TBuilder>[] QueryReaders { get; init; }
+
+    public IHttpQueryParamsWriter<T>? QueryParamsWriter { get; init; }
+
+    public IHttpQueryParamsReader<TBuilder>? QueryParamsReader { get; init; }
+
+    public required HashSet<string> BoundQueryNames { get; init; }
+
+    public required IHttpHeaderWriter<T>[] HeaderWriters { get; init; }
+
+    public required IHttpHeaderReader<TBuilder>[] HeaderReaders { get; init; }
+
+    public IHttpPrefixHeaderWriter<T>? PrefixHeaderWriter { get; init; }
+
+    public IHttpPrefixHeaderReader<TBuilder>? PrefixHeaderReader { get; init; }
+
+    public IHttpStatusCodeWriter<T>? StatusCodeWriter { get; init; }
+
+    public IHttpStatusCodeReader<TBuilder>? StatusCodeReader { get; init; }
+
+    public Func<T, RestBody>? PayloadWriter { get; init; }
+
+    public RestPayloadReader<TBuilder>? PayloadReader { get; init; }
+
+    /// <summary>The <c>@httpPayload</c> member, whose target decides the message's media type.</summary>
+    public IMemberSchema? PayloadMember { get; init; }
+
+    public required int MemberCount { get; init; }
+
+    /// <summary>The members no binding claimed: what the body carries.</summary>
+    public required IReadOnlySet<string> BodyMemberNames { get; init; }
+
+    /// <summary>Codec for the body projection; null when the message has no structured body.</summary>
+    public IProjectionCodec<T, TBuilder>? BodyCodec { get; set; }
+
+    public IProjectionCodec<T, TBuilder> CompileBodyCodec(
+        IRestBodyCodecFactory codecFactory,
+        CodecFactoryOptions options
+    ) => codecFactory.FromProjection(Schemas.Project(Schema, BodyMemberNames), options);
+
+    /// <param name="uriTemplate">The operation's <c>@http(uri)</c>, which decides greedy labels.</param>
+    internal static RestStructBinding<T, TBuilder> Compile(
+        IStructSchema<T, TBuilder> schema,
+        HttpBindingSide side,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads,
+        bool emptyStructOnNullPayload,
+        string uriTemplate = ""
+    )
+    {
+        var classifier = new Classifier(
+            side,
+            uriTemplate,
+            codecFactory,
+            rawStringPayloads,
+            emptyStructOnNullPayload
+        );
+        schema.VisitMembers(classifier);
+        return new RestStructBinding<T, TBuilder>
+        {
+            Schema = schema,
+            LabelWriters = [.. classifier.LabelWriters],
+            LabelReaders = [.. classifier.LabelReaders],
+            QueryWriters = [.. classifier.QueryWriters],
+            QueryReaders = [.. classifier.QueryReaders],
+            QueryParamsWriter = classifier.QueryParamsWriter,
+            QueryParamsReader = classifier.QueryParamsReader,
+            BoundQueryNames = classifier.BoundQueryNames,
+            HeaderWriters = [.. classifier.HeaderWriters],
+            HeaderReaders = [.. classifier.HeaderReaders],
+            PrefixHeaderWriter = classifier.PrefixHeaderWriter,
+            PrefixHeaderReader = classifier.PrefixHeaderReader,
+            StatusCodeWriter = classifier.StatusCodeWriter,
+            StatusCodeReader = classifier.StatusCodeReader,
+            PayloadWriter = classifier.PayloadWriter,
+            PayloadReader = classifier.PayloadReader,
+            PayloadMember = classifier.PayloadMember,
+            MemberCount = classifier.MemberCount,
+            BodyMemberNames = classifier.BodyMemberNames,
+        };
+    }
+
+    private sealed class Classifier(
+        HttpBindingSide side,
+        string uriTemplate,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads,
+        bool emptyStructOnNullPayload
+    ) : IMemberVisitor<T, TBuilder>
+    {
+        public List<IHttpLabelWriter<T>> LabelWriters { get; } = [];
+        public List<IHttpLabelReader<TBuilder>> LabelReaders { get; } = [];
+        public List<IHttpQueryWriter<T>> QueryWriters { get; } = [];
+        public List<IHttpQueryReader<TBuilder>> QueryReaders { get; } = [];
+        public IHttpQueryParamsWriter<T>? QueryParamsWriter { get; private set; }
+        public IHttpQueryParamsReader<TBuilder>? QueryParamsReader { get; private set; }
+        public HashSet<string> BoundQueryNames { get; } = new(StringComparer.Ordinal);
+        public List<IHttpHeaderWriter<T>> HeaderWriters { get; } = [];
+        public List<IHttpHeaderReader<TBuilder>> HeaderReaders { get; } = [];
+        public IHttpPrefixHeaderWriter<T>? PrefixHeaderWriter { get; private set; }
+        public IHttpPrefixHeaderReader<TBuilder>? PrefixHeaderReader { get; private set; }
+        public IHttpStatusCodeWriter<T>? StatusCodeWriter { get; private set; }
+        public IHttpStatusCodeReader<TBuilder>? StatusCodeReader { get; private set; }
+        public Func<T, RestBody>? PayloadWriter { get; private set; }
+        public RestPayloadReader<TBuilder>? PayloadReader { get; private set; }
+        public IMemberSchema? PayloadMember { get; private set; }
+        public int MemberCount { get; private set; }
+        public HashSet<string> BodyMemberNames { get; } = new(StringComparer.Ordinal);
+
+        public void Visit<TValue>(IMemberSchema<T, TBuilder, TValue> member)
+        {
+            MemberCount++;
+            var traits = member.MemberTraits;
+
+            if (side == HttpBindingSide.Request && traits.ContainsKey(RestTraits.HttpLabel))
+            {
+                var plan = new LabelPlan<T, TBuilder, TValue>(
+                    member,
+                    Codec(member),
+                    greedy: uriTemplate.Contains("{" + member.Name + "+}", StringComparison.Ordinal)
+                );
+                LabelWriters.Add(plan);
+                LabelReaders.Add(plan);
+                return;
+            }
+
+            if (
+                side == HttpBindingSide.Request
+                && traits.TryGetValue(RestTraits.HttpQuery, out var queryTrait)
+            )
+            {
+                var name = queryTrait.Value.AsString();
+                var plan = new QueryPlan<T, TBuilder, TValue>(member, Codec(member), name);
+                QueryWriters.Add(plan);
+                QueryReaders.Add(plan);
+                BoundQueryNames.Add(name);
+                return;
+            }
+
+            if (side == HttpBindingSide.Request && traits.ContainsKey(RestTraits.HttpQueryParams))
+            {
+                var plan = MapPlan(member, prefix: string.Empty);
+                QueryParamsWriter = (IHttpQueryParamsWriter<T>)plan;
+                QueryParamsReader = (IHttpQueryParamsReader<TBuilder>)plan;
+                return;
+            }
+
+            if (side == HttpBindingSide.Response && traits.ContainsKey(RestTraits.HttpResponseCode))
+            {
+                (StatusCodeWriter, StatusCodeReader) = StatusCodePlan<T, TBuilder>.Compile(member);
+                return;
+            }
+
+            if (traits.TryGetValue(RestTraits.HttpHeader, out var headerTrait))
+            {
+                var plan = new HeaderPlan<T, TBuilder, TValue>(
+                    member,
+                    Codec(member),
+                    headerTrait.Value.AsString()
+                );
+                HeaderWriters.Add(plan);
+                HeaderReaders.Add(plan);
+                return;
+            }
+
+            if (traits.TryGetValue(RestTraits.HttpPrefixHeaders, out var prefixTrait))
+            {
+                var plan = MapPlan(member, prefixTrait.Value.AsString());
+                PrefixHeaderWriter = (IHttpPrefixHeaderWriter<T>)plan;
+                PrefixHeaderReader = (IHttpPrefixHeaderReader<TBuilder>)plan;
+                return;
+            }
+
+            if (traits.ContainsKey(RestTraits.HttpPayload))
+            {
+                PayloadMember = member;
+                PayloadWriter = CompilePayloadWriter(
+                    member,
+                    codecFactory,
+                    rawStringPayloads,
+                    emptyStructOnNullPayload
+                );
+                PayloadReader = CompilePayloadReader(member, codecFactory, rawStringPayloads);
+                return;
+            }
+
+            BodyMemberNames.Add(member.Name);
+        }
+
+        private static IHttpValueCodec<TValue> Codec<TValue>(
+            IMemberSchema<T, TBuilder, TValue> member
+        ) => HttpBindingCompiler.Compile(member.TargetSchema, member.MemberTraits);
+
+        private static object MapPlan<TValue>(
+            IMemberSchema<T, TBuilder, TValue> member,
+            string prefix
+        ) =>
+            member.TargetSchema.Resolved.Accept(
+                new MapBindingPlanCompiler<T, TBuilder, TValue>(member, prefix)
+            );
+    }
+
+    /// <summary>
+    /// Builds — once, at binding construction — a delegate that serializes an <c>@httpPayload</c>
+    /// member to its wire body. The blob/text/codec decision and the compiled body codec are baked
+    /// in, so nothing is recompiled per request. <paramref name="emptyStructOnNull"/> separates the
+    /// request side (a null struct payload still emits <c>{}</c>) from the response side (emits
+    /// nothing).
+    /// </summary>
+    private static Func<T, RestBody> CompilePayloadWriter<TValue>(
+        IMemberSchema<T, TBuilder, TValue> member,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads,
+        bool emptyStructOnNull
+    )
+    {
+        var target = member.TargetSchema;
+        var traits = member.MemberTraits;
+        var mediaType = RestProtocol.GetMediaType(target, traits);
+        var kind = HttpBindingPlans.UnwrapNullable(target).Kind;
+
+        if (target.Resolved is IEventStreamSchema)
+        {
+            return target
+                .Resolved.Accept(new EventStreamPayloadCompiler<TValue>(member, codecFactory))
+                .Writer;
+        }
+
+        if (kind == ShapeKind.Blob && traits.ContainsKey(RestTraits.Streaming))
+        {
+            var contentType = mediaType ?? codecFactory.BlobContentType;
+            var requiresLength = traits.ContainsKey(RestTraits.RequiresLength);
+            return container =>
+            {
+                if (member.GetValue(container) is not { } value)
+                {
+                    return RestBody.None;
+                }
+
+                var stream = (Stream)(object)value;
+                if (!requiresLength)
+                {
+                    return new RestBody([], contentType, stream);
+                }
+
+                if (!stream.CanSeek)
+                {
+                    throw new InvalidOperationException(
+                        "Streaming blob payloads with @requiresLength require a seekable stream."
+                    );
+                }
+
+                return new RestBody([], contentType, stream, stream.Length - stream.Position);
+            };
+        }
+
+        if (kind == ShapeKind.Blob)
+        {
+            var contentType = mediaType ?? codecFactory.BlobContentType;
+            return container =>
+                member.GetValue(container) is { } value
+                    ? new RestBody((byte[])(object)value, contentType)
+                    : RestBody.None;
+        }
+
+        if (
+            (kind == ShapeKind.String || kind == ShapeKind.Enum)
+            && (
+                mediaType is not null
+                || !RestProtocol.UseBodyCodecForPayload(target, traits, rawStringPayloads)
+            )
+        )
+        {
+            var contentType = mediaType ?? "text/plain";
+            return container =>
+            {
+                var value = member.GetValue(container);
+                if (value is null)
+                {
+                    return RestBody.None;
+                }
+
+                var text =
+                    kind == ShapeKind.Enum
+                        ? ((IStringEnumValue)(object)value).Value
+                        : (string)(object)value;
+                return new RestBody(Encoding.UTF8.GetBytes(text), contentType);
+            };
+        }
+
+        // Codec path: structures, unions, documents, and string/enum that go through the body
+        // codec (alloy simpleRestJson, or members carrying an explicit @default). The codec is
+        // compiled once here; the empty-struct value for a null request payload is built lazily
+        // (only if a null actually arrives) so binding construction never materializes a struct
+        // with required members.
+        var codec = codecFactory.FromMember(member);
+        var bodyContentType = codecFactory.ContentType;
+        var emptyStruct = emptyStructOnNull
+            ? HttpBindingPlans.UnwrapNullable(target) as IStructSchema<TValue>
+            : null;
+        var isDefault = CompileDefaultCheck(target, traits);
+
+        return container =>
+        {
+            var value = member.GetValue(container);
+            if (value is null)
+            {
+                return emptyStruct is not null
+                    ? new RestBody(codec.Serialize(emptyStruct.BuildEmpty()), bodyContentType)
+                    : RestBody.None;
+            }
+
+            return isDefault(value)
+                ? RestBody.None
+                : new RestBody(codec.Serialize(value), bodyContentType);
+        };
+    }
+
+    // A payload equal to its modelled default is not written, as a body codec would not write it.
+    private static Func<TValue, bool> CompileDefaultCheck<TValue>(
+        Schema<TValue> target,
+        IReadOnlyDictionary<ShapeId, Trait> traits
+    )
+    {
+        if (!DefaultValues.TryCompile(target, traits, honorClientOptional: false, out var create))
+        {
+            return static _ => false;
+        }
+
+        var defaultValue = create();
+        if (defaultValue is byte[] defaultBytes)
+        {
+            return value => value is byte[] bytes && bytes.AsSpan().SequenceEqual(defaultBytes);
+        }
+
+        var comparer = EqualityComparer<TValue>.Default;
+        return value => comparer.Equals(value, defaultValue);
+    }
+
+    /// <summary>Builds — once — a delegate that reads an <c>@httpPayload</c> member from the body.</summary>
+    private static RestPayloadReader<TBuilder> CompilePayloadReader<TValue>(
+        IMemberSchema<T, TBuilder, TValue> member,
+        IRestBodyCodecFactory codecFactory,
+        bool rawStringPayloads
+    )
+    {
+        var target = member.TargetSchema;
+        var traits = member.MemberTraits;
+        var unwrapped = HttpBindingPlans.UnwrapNullable(target);
+
+        if (target.Resolved is IEventStreamSchema)
+        {
+            return target
+                .Resolved.Accept(new EventStreamPayloadCompiler<TValue>(member, codecFactory))
+                .Reader;
+        }
+
+        if (unwrapped.Kind == ShapeKind.Blob && traits.ContainsKey(RestTraits.Streaming))
+        {
+            var defaultsToEmpty = traits.ContainsKey(DefaultTrait);
+            return (content, streamingContent, builder) =>
+            {
+                if (streamingContent is not null)
+                {
+                    member.SetValue(builder, (TValue)(object)streamingContent);
+                }
+                else if (content is null or { Length: 0 })
+                {
+                    if (defaultsToEmpty)
+                    {
+                        member.SetValue(builder, (TValue)(object)Stream.Null);
+                    }
+                }
+                else
+                {
+                    member.SetValue(
+                        builder,
+                        (TValue)(object)new MemoryStream(content, writable: false)
+                    );
+                }
+            };
+        }
+
+        var applyDefault = CompileDefault(member);
+
+        if (unwrapped.Kind == ShapeKind.Blob)
+        {
+            return (content, streamingContent, builder) =>
+            {
+                if (content is null or { Length: 0 })
+                {
+                    applyDefault(builder);
+                }
+                else
+                {
+                    member.SetValue(builder, (TValue)(object)content);
+                }
+            };
+        }
+
+        if (!RestProtocol.UseBodyCodecForPayload(target, traits, rawStringPayloads))
+        {
+            var text = HttpBindingCompiler.Compile(target, memberTraits: null);
+            return (content, streamingContent, builder) =>
+            {
+                if (content is null or { Length: 0 })
+                {
+                    applyDefault(builder);
+                    return;
+                }
+
+                member.SetValue(builder, text.Parse(Encoding.UTF8.GetString(content)));
+            };
+        }
+
+        var codec = codecFactory.FromMember(member);
+        return (content, streamingContent, builder) =>
+        {
+            if (content is null or { Length: 0 })
+            {
+                applyDefault(builder);
+            }
+            else
+            {
+                member.SetValue(builder, codec.Deserialize(content));
+            }
+        };
+    }
+
+    private static Action<TBuilder> CompileDefault<TValue>(
+        IMemberSchema<T, TBuilder, TValue> member
+    ) =>
+        DefaultValues.TryCompile(
+            member.TargetSchema,
+            member.MemberTraits,
+            honorClientOptional: false,
+            out var create
+        )
+            ? builder => member.SetValue(builder, create())
+            : static _ => { };
+
+    /// <summary>An event stream payload frames each event by the name of the union case it holds.</summary>
+    private sealed class EventStreamPayloadCompiler<TValue>(
+        IMemberSchema<T, TBuilder, TValue> member,
+        IRestBodyCodecFactory codecFactory
+    ) : SchemaVisitor<(Func<T, RestBody> Writer, RestPayloadReader<TBuilder> Reader)>
+    {
+        public override (
+            Func<T, RestBody> Writer,
+            RestPayloadReader<TBuilder> Reader
+        ) VisitEventStream<TEvent>(EventStreamSchema<TEvent> schema)
+        {
+            var typed = (IMemberSchema<T, TBuilder, IAsyncEnumerable<TEvent>>)(object)member;
+            var eventSchema = schema.TypedEventSchema;
+            var codec = codecFactory.FromSchema(eventSchema);
+            var eventTypeOf = Schemas.CompileCaseName(
+                eventSchema.Resolved as IUnionSchema<TEvent>
+                    ?? throw new InvalidOperationException(
+                        "REST event stream payloads must target a union schema."
+                    )
+            );
+            var payloadContentType = codecFactory.ContentType;
+
+            Func<T, RestBody> writer = container =>
+                typed.GetValue(container) is { } events
+                    ? new RestBody(
+                        [],
+                        RestProtocol.EventStreamContentType,
+                        EventStreamingContent: RestProtocol.FrameEventsAsync(
+                            events,
+                            codec,
+                            eventTypeOf,
+                            payloadContentType
+                        )
+                    )
+                    : RestBody.None;
+
+            RestPayloadReader<TBuilder> reader = (content, streamingContent, builder) =>
+            {
+                var stream =
+                    streamingContent
+                    ?? (
+                        content is { Length: > 0 }
+                            ? new MemoryStream(content, writable: false)
+                            : Stream.Null
+                    );
+                typed.SetValue(
+                    builder,
+                    RestProtocol.ReadEventsAsync(stream, codec, payloadContentType)
+                );
+            };
+
+            return (writer, reader);
+        }
+    }
+}

--- a/packages/NSmithy.Protocols.RestJson/JsonRestBodyCodecFactory.cs
+++ b/packages/NSmithy.Protocols.RestJson/JsonRestBodyCodecFactory.cs
@@ -30,7 +30,7 @@ internal sealed class JsonRestBodyCodecFactory(WireReadMode readMode) : IRestBod
         codecFactory.FromSchema(schema, options);
 
     public ICodec<T> FromMember<T>(
-        ITargetedMemberSchema<T> member,
+        ITypedTargetMemberSchema<T> member,
         CodecFactoryOptions? options = null
     ) => codecFactory.FromMember(member, options);
 

--- a/packages/NSmithy.Protocols.RestXml/RestXmlProtocol.cs
+++ b/packages/NSmithy.Protocols.RestXml/RestXmlProtocol.cs
@@ -82,7 +82,7 @@ public sealed class RestXmlProtocol : IProtocol
             codecFactory.FromSchema(schema, options);
 
         public ICodec<T> FromMember<T>(
-            ITargetedMemberSchema<T> member,
+            ITypedTargetMemberSchema<T> member,
             CodecFactoryOptions? options = null
         ) => codecFactory.FromMember(member, options);
 

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -144,7 +144,7 @@ public sealed class RpcV2CborProtocol : IProtocol
         where TInputBuilder : notnull
     {
         var codec = CodecFactory.FromSchema(eventSchema);
-        var union = RequireUnion(eventSchema);
+        var eventTypeOf = CompileEventType(eventSchema);
         var binding = EventStreamShapeBinding<TInput, TInputEvent, TInputBuilder>.Create(
             inputSchema,
             materializeTopLevelDefaults: false
@@ -158,7 +158,7 @@ public sealed class RpcV2CborProtocol : IProtocol
                         input,
                         binding,
                         codec,
-                        union,
+                        eventTypeOf,
                         InitialRequestEventType,
                         cancellationToken
                     )
@@ -229,7 +229,7 @@ public sealed class RpcV2CborProtocol : IProtocol
         where TOutputBuilder : notnull
     {
         var codec = CodecFactory.FromSchema(eventSchema);
-        var union = RequireUnion(eventSchema);
+        var eventTypeOf = CompileEventType(eventSchema);
         var binding = EventStreamShapeBinding<TOutput, TOutputEvent, TOutputBuilder>.Create(
             outputSchema,
             materializeTopLevelDefaults: true
@@ -243,7 +243,7 @@ public sealed class RpcV2CborProtocol : IProtocol
                         output,
                         binding,
                         codec,
-                        union,
+                        eventTypeOf,
                         InitialResponseEventType,
                         cancellationToken
                     )
@@ -265,10 +265,12 @@ public sealed class RpcV2CborProtocol : IProtocol
         );
     }
 
-    private static IUnionSchema RequireUnion<TEvent>(Schema<TEvent> eventSchema) =>
-        eventSchema.Resolved as IUnionSchema
-        ?? throw new InvalidOperationException(
-            "rpcv2Cbor event streams must target a union schema."
+    private static Func<TEvent, string> CompileEventType<TEvent>(Schema<TEvent> eventSchema) =>
+        Schemas.CompileCaseName(
+            eventSchema.Resolved as IUnionSchema<TEvent>
+                ?? throw new InvalidOperationException(
+                    "rpcv2Cbor event streams must target a union schema."
+                )
         );
 
     private sealed class OperationProtocol<TInput, TOutput>(
@@ -537,7 +539,7 @@ public sealed class RpcV2CborProtocol : IProtocol
     private static async IAsyncEnumerable<ReadOnlyMemory<byte>> FrameEventsAsync<T>(
         IAsyncEnumerable<T> events,
         ICodec<T> codec,
-        IUnionSchema eventSchema,
+        Func<T, string> eventTypeOf,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
@@ -545,8 +547,8 @@ public sealed class RpcV2CborProtocol : IProtocol
             var value in events.WithCancellation(cancellationToken).ConfigureAwait(false)
         )
         {
-            var eventType = eventSchema.GetCaseObject(value!).Name;
-            yield return CreateEventStreamMessage(eventType, codec.Serialize(value)).Encode();
+            yield return CreateEventStreamMessage(eventTypeOf(value), codec.Serialize(value))
+                .Encode();
         }
     }
 
@@ -579,19 +581,24 @@ public sealed class RpcV2CborProtocol : IProtocol
             bool materializeTopLevelDefaults
         )
         {
-            var streamMember = FindStreamMember(structure);
-            var initialMembers = CollectInitialMembers(structure, streamMember);
+            var visitor = new EventStreamMemberVisitor<TShape, TBuilder, TEvent>();
+            structure.VisitMembers(visitor);
+            var streamMember =
+                visitor.Member
+                ?? throw new InvalidOperationException(
+                    "rpcv2Cbor initial event streams require one event stream member."
+                );
             return new EventStreamShapeBinding<TShape, TEvent, TBuilder>(
                 structure,
                 streamMember,
                 CodecFactory.FromProjection(
-                    Schemas.Project(structure, initialMembers),
+                    Schemas.Project(structure, member => !ReferenceEquals(member, streamMember)),
                     new CodecFactoryOptions
                     {
                         MaterializeTopLevelDefaults = materializeTopLevelDefaults,
                     }
                 ),
-                initialMembers.Length > 0
+                visitor.MemberCount > 1
             );
         }
 
@@ -612,27 +619,6 @@ public sealed class RpcV2CborProtocol : IProtocol
             StreamMember.SetValue(builder, events);
             return Structure.Build(builder);
         }
-
-        private static IMemberSchema<TShape, TBuilder, IAsyncEnumerable<TEvent>> FindStreamMember(
-            IStructSchema<TShape, TBuilder> structure
-        )
-        {
-            var visitor = new EventStreamMemberVisitor<TShape, TBuilder, TEvent>();
-            structure.VisitMembers(visitor);
-            return visitor.Member
-                ?? throw new InvalidOperationException(
-                    "rpcv2Cbor initial event streams require one event stream member."
-                );
-        }
-
-        private static IMemberSchema<TShape>[] CollectInitialMembers(
-            IStructSchema<TShape, TBuilder> structure,
-            IMemberSchema<TShape> streamMember
-        ) =>
-            Schemas
-                .GetMembers(structure)
-                .Where(member => !ReferenceEquals(member, streamMember))
-                .ToArray();
     }
 
     private sealed class EventStreamMemberVisitor<TShape, TBuilder, TEvent>
@@ -644,8 +630,11 @@ public sealed class RpcV2CborProtocol : IProtocol
             private set;
         }
 
+        public int MemberCount { get; private set; }
+
         public void Visit<TValue>(IMemberSchema<TShape, TBuilder, TValue> member)
         {
+            MemberCount++;
             if (member.Target is not EventStreamSchema<TEvent>)
             {
                 return;
@@ -670,7 +659,7 @@ public sealed class RpcV2CborProtocol : IProtocol
         TShape shape,
         EventStreamShapeBinding<TShape, TEvent, TBuilder> binding,
         ICodec<TEvent> eventCodec,
-        IUnionSchema eventSchema,
+        Func<TEvent, string> eventTypeOf,
         string initialEventType,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
@@ -689,7 +678,7 @@ public sealed class RpcV2CborProtocol : IProtocol
             var chunk in FrameEventsAsync(
                     binding.GetEvents(shape),
                     eventCodec,
-                    eventSchema,
+                    eventTypeOf,
                     cancellationToken
                 )
                 .ConfigureAwait(false)
@@ -955,13 +944,13 @@ public sealed class RpcV2CborProtocol : IProtocol
     private static bool IsUnit<T>(Schema schema) =>
         typeof(T) == typeof(SmithyUnit) || Schemas.IsSyntheticUnit(schema);
 
-    private static Schema? FindEventStreamEventSchema(Schema schema) =>
-        schema.Resolved is IStructSchema structure
-            ? FindEventStreamEventSchemaCore((dynamic)structure)
-            : null;
-
-    private static Schema? FindEventStreamEventSchemaCore<T>(IStructSchema<T> structure)
+    private static Schema? FindEventStreamEventSchema<T>(Schema<T> schema)
     {
+        if (schema.Resolved is not IStructSchema<T> structure)
+        {
+            return null;
+        }
+
         var visitor = new EventStreamSchemaVisitor<T>();
         structure.VisitMembers(visitor);
         return visitor.EventSchema;

--- a/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
+++ b/packages/NSmithy.Protocols.RpcV2Cbor/RpcV2CborProtocol.cs
@@ -57,10 +57,10 @@ public sealed class RpcV2CborProtocol : IProtocol
             var outputEvent = FindEventStreamEventSchema(operation.Output);
             RequestStrategy<TInput> request = inputEvent is null
                 ? UnaryRequestStrategy(operation.Input)
-                : StreamingRequestStrategy(RequireStruct(operation.Input), (dynamic)inputEvent);
+                : CompileStreamingRequestStrategy(operation.Input, inputEvent);
             ResponseStrategy<TOutput> response = outputEvent is null
                 ? UnaryResponseStrategy(operation.Output)
-                : StreamingResponseStrategy(RequireStruct(operation.Output), (dynamic)outputEvent);
+                : CompileStreamingResponseStrategy(operation.Output, outputEvent);
 
             return new OperationProtocol<TInput, TOutput>(
                 service,
@@ -71,16 +71,70 @@ public sealed class RpcV2CborProtocol : IProtocol
                 inputValidator
             );
         }
+    }
 
-        /// <summary>
-        /// An event-stream shape is always a structure: the stream is one member of it, alongside
-        /// whatever the initial message carries. The builder type comes back erased, so the
-        /// strategy that captures it is reached through dynamic dispatch.
-        /// </summary>
-        private static dynamic RequireStruct<T>(Schema<T> schema) =>
-            schema.Resolved as IStructSchema<T>
+    private static RequestStrategy<TInput> CompileStreamingRequestStrategy<TInput>(
+        Schema<TInput> inputSchema,
+        Schema eventSchema
+    ) =>
+        (
+            inputSchema.Resolved as IStructSchema<TInput>
             ?? throw new InvalidOperationException(
-                $"rpcv2Cbor event stream shape '{schema.Id}' must use a structure shape."
+                $"rpcv2Cbor event stream shape '{inputSchema.Id}' must use a structure shape."
+            )
+        ).Accept(new StreamingRequestStructCompiler<TInput>(eventSchema));
+
+    private sealed class StreamingRequestStructCompiler<TInput>(Schema eventSchema)
+        : IStructSchemaVisitor<TInput, RequestStrategy<TInput>>
+    {
+        public RequestStrategy<TInput> Visit<TBuilder>(
+            IStructSchema<TInput, TBuilder> inputSchema
+        ) => eventSchema.Accept(new StreamingRequestEventCompiler<TInput, TBuilder>(inputSchema));
+    }
+
+    private sealed class StreamingRequestEventCompiler<TInput, TBuilder>(
+        IStructSchema<TInput, TBuilder> inputSchema
+    ) : PartialSchemaVisitor<RequestStrategy<TInput>>
+    {
+        public override RequestStrategy<TInput> VisitUnion<TEvent>(IUnionSchema<TEvent> schema) =>
+            StreamingRequestStrategy(inputSchema, (Schema<TEvent>)schema);
+
+        protected override RequestStrategy<TInput> VisitDefault(Schema schema) =>
+            throw new InvalidOperationException(
+                $"rpcv2Cbor event streams must target a union schema; found '{schema.Id}'."
+            );
+    }
+
+    private static ResponseStrategy<TOutput> CompileStreamingResponseStrategy<TOutput>(
+        Schema<TOutput> outputSchema,
+        Schema eventSchema
+    ) =>
+        (
+            outputSchema.Resolved as IStructSchema<TOutput>
+            ?? throw new InvalidOperationException(
+                $"rpcv2Cbor event stream shape '{outputSchema.Id}' must use a structure shape."
+            )
+        ).Accept(new StreamingResponseStructCompiler<TOutput>(eventSchema));
+
+    private sealed class StreamingResponseStructCompiler<TOutput>(Schema eventSchema)
+        : IStructSchemaVisitor<TOutput, ResponseStrategy<TOutput>>
+    {
+        public ResponseStrategy<TOutput> Visit<TBuilder>(
+            IStructSchema<TOutput, TBuilder> outputSchema
+        ) =>
+            eventSchema.Accept(new StreamingResponseEventCompiler<TOutput, TBuilder>(outputSchema));
+    }
+
+    private sealed class StreamingResponseEventCompiler<TOutput, TBuilder>(
+        IStructSchema<TOutput, TBuilder> outputSchema
+    ) : PartialSchemaVisitor<ResponseStrategy<TOutput>>
+    {
+        public override ResponseStrategy<TOutput> VisitUnion<TEvent>(IUnionSchema<TEvent> schema) =>
+            StreamingResponseStrategy(outputSchema, (Schema<TEvent>)schema);
+
+        protected override ResponseStrategy<TOutput> VisitDefault(Schema schema) =>
+            throw new InvalidOperationException(
+                $"rpcv2Cbor event streams must target a union schema; found '{schema.Id}'."
             );
     }
 
@@ -141,7 +195,6 @@ public sealed class RpcV2CborProtocol : IProtocol
         TInputEvent,
         TInputBuilder
     >(IStructSchema<TInput, TInputBuilder> inputSchema, Schema<TInputEvent> eventSchema)
-        where TInputBuilder : notnull
     {
         var codec = CodecFactory.FromSchema(eventSchema);
         var eventTypeOf = CompileEventType(eventSchema);
@@ -226,7 +279,6 @@ public sealed class RpcV2CborProtocol : IProtocol
         TOutputEvent,
         TOutputBuilder
     >(IStructSchema<TOutput, TOutputBuilder> outputSchema, Schema<TOutputEvent> eventSchema)
-        where TOutputBuilder : notnull
     {
         var codec = CodecFactory.FromSchema(eventSchema);
         var eventTypeOf = CompileEventType(eventSchema);
@@ -287,7 +339,7 @@ public sealed class RpcV2CborProtocol : IProtocol
 
         private readonly ModeledErrorSerializer serverErrors = ModeledErrorSerializer.Compile(
             operation.Errors,
-            error => CompileServerError((dynamic)error)
+            error => error.Accept(ServerErrorCompiler.Instance)
         );
 
         public IReadOnlyList<HttpOperationError> HttpErrors { get; } =
@@ -474,9 +526,28 @@ public sealed class RpcV2CborProtocol : IProtocol
         );
     }
 
+    private sealed class ServerErrorCompiler
+        : IOperationErrorSchemaVisitor<(Type, Func<Exception, SmithyHttpServerResponse>)>
+    {
+        public static ServerErrorCompiler Instance { get; } = new();
+
+        public (Type, Func<Exception, SmithyHttpServerResponse>) Visit<TError>(
+            OperationErrorSchema<TError> schema
+        )
+            where TError : Exception => CompileServerError(schema);
+    }
+
     private static HttpOperationError[] CompileErrors(
         IReadOnlyList<IOperationErrorSchema> errors
-    ) => errors.Select(error => (HttpOperationError)CompileError((dynamic)error)).ToArray();
+    ) => errors.Select(error => error.Accept(ErrorCompiler.Instance)).ToArray();
+
+    private sealed class ErrorCompiler : IOperationErrorSchemaVisitor<HttpOperationError>
+    {
+        public static ErrorCompiler Instance { get; } = new();
+
+        public HttpOperationError Visit<TError>(OperationErrorSchema<TError> schema)
+            where TError : Exception => CompileError(schema);
+    }
 
     private static HttpOperationError CompileError<TError>(OperationErrorSchema<TError> error)
         where TError : Exception
@@ -553,7 +624,6 @@ public sealed class RpcV2CborProtocol : IProtocol
     }
 
     private sealed class EventStreamShapeBinding<TShape, TEvent, TBuilder>
-        where TBuilder : notnull
     {
         private EventStreamShapeBinding(
             IStructSchema<TShape, TBuilder> structure,
@@ -663,7 +733,6 @@ public sealed class RpcV2CborProtocol : IProtocol
         string initialEventType,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
-        where TBuilder : notnull
     {
         if (binding.HasInitialMembers)
         {
@@ -712,7 +781,6 @@ public sealed class RpcV2CborProtocol : IProtocol
         string initialEventType,
         CancellationToken cancellationToken
     )
-        where TBuilder : notnull
     {
         var enumerator = EventStreamMessageReader
             .ReadAllAsync(body, cancellationToken)

--- a/tests/AotSmoke/NSmithy.AotSmoke.csproj
+++ b/tests/AotSmoke/NSmithy.AotSmoke.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../packages/NSmithy.Protocols.RestJson/NSmithy.Protocols.RestJson.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AotSmoke/Program.cs
+++ b/tests/AotSmoke/Program.cs
@@ -1,0 +1,81 @@
+using NSmithy.Core;
+using NSmithy.Core.Serde;
+using NSmithy.Protocols.Rest;
+using NSmithy.Protocols.RestJson;
+
+var inputSchema = Schemas
+    .Structure<AotInput, AotInputBuilder>(new ShapeId("example", "AotInput"))
+    .Required(
+        "userId",
+        static input => input.UserId,
+        static (builder, value) => builder.UserId = value,
+        Schemas.String,
+        traits: [RestTraits.HttpLabelTrait]
+    )
+    .Optional(
+        "requestToken",
+        static input => input.RequestToken!,
+        static (builder, value) => builder.RequestToken = value,
+        Schemas.String,
+        traits: [RestTraits.HttpHeaderTrait("X-Request-Token")]
+    )
+    .Required(
+        "pageSize",
+        static input => input.PageSize,
+        static (builder, value) => builder.PageSize = value,
+        Schemas.Integer,
+        traits: [RestTraits.HttpQueryTrait("pageSize")]
+    )
+    .Required(
+        "displayName",
+        static input => input.DisplayName,
+        static (builder, value) => builder.DisplayName = value,
+        Schemas.String
+    )
+    .Build(
+        static () => new AotInputBuilder(),
+        static builder => new AotInput(
+            builder.UserId!,
+            builder.RequestToken,
+            builder.PageSize,
+            builder.DisplayName!
+        )
+    );
+var operation = Schemas.Operation(
+    new ShapeId("example", "UpdateUser"),
+    inputSchema,
+    Schemas.Unit,
+    traits: [RestTraits.HttpTrait("PUT", "/users/{userId}")]
+);
+var service = new RestJson1Protocol().ForService(
+    Schemas.Service(new ShapeId("example", "Service"))
+);
+var clientProtocol = service.ForClientOperation(operation);
+var serverProtocol = service.ForServerOperation(operation);
+var expected = new AotInput("ada lovelace", "token-123", 25, "Ada");
+
+var request = clientProtocol.SerializeRequest(expected);
+var actual = await serverProtocol.DeserializeRequestAsync(request);
+
+if (actual != expected)
+{
+    throw new InvalidOperationException($"REST/JSON NativeAOT round trip failed: {actual}");
+}
+
+internal sealed record AotInput(
+    string UserId,
+    string? RequestToken,
+    int PageSize,
+    string DisplayName
+);
+
+internal sealed class AotInputBuilder
+{
+    public string? UserId { get; set; }
+
+    public string? RequestToken { get; set; }
+
+    public int PageSize { get; set; }
+
+    public string? DisplayName { get; set; }
+}

--- a/tests/NSmithy.Tests/Codecs/CodecFactoryTests.cs
+++ b/tests/NSmithy.Tests/Codecs/CodecFactoryTests.cs
@@ -48,7 +48,7 @@ public sealed class CodecFactoryTests
         Assert.Equal(value, codec.DeserializeText(xml));
     }
 
-    private static ITargetedMemberSchema<DateTimeOffset> TimestampMember()
+    private static ITypedTargetMemberSchema<DateTimeOffset> TimestampMember()
     {
         var schema = Schemas
             .Structure<TimestampPayload, TimestampPayloadBuilder>(
@@ -68,7 +68,7 @@ public sealed class CodecFactoryTests
                 static () => new TimestampPayloadBuilder(),
                 static builder => new TimestampPayload(builder.Value)
             );
-        return Assert.IsAssignableFrom<ITargetedMemberSchema<DateTimeOffset>>(
+        return Assert.IsAssignableFrom<ITypedTargetMemberSchema<DateTimeOffset>>(
             schema.GetMember("value")
         );
     }

--- a/tests/NSmithy.Tests/Codecs/Json/JsonCodecTests.cs
+++ b/tests/NSmithy.Tests/Codecs/Json/JsonCodecTests.cs
@@ -448,7 +448,7 @@ public sealed class JsonCodecTests
     {
         var schema = DefaultedSchema();
         var codec = JsonCodecFactory.Default.FromProjection(
-            Schemas.Project<Defaulted, DefaultedBuilder>(schema, Schemas.GetMembers(schema))
+            Schemas.Project<Defaulted, DefaultedBuilder>(schema, _ => true)
         );
 
         var builder = new DefaultedBuilder();

--- a/tests/NSmithy.Tests/Core/SchemaTests.cs
+++ b/tests/NSmithy.Tests/Core/SchemaTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NSmithy.Codecs.Json;
 using NSmithy.Core;
 using NSmithy.Core.Serde;
@@ -686,5 +687,130 @@ public sealed class SchemaTests
         Assert.Same(error, operation.Errors[0]);
         Assert.Same(errorSchema, ((OperationErrorSchema<TestException>)operation.Errors[0]).Schema);
         Assert.Equal(400, operation.Errors[0].HttpStatusCode);
+    }
+
+    [Fact]
+    public void StructProjectionSnapshotsSelectedMembers()
+    {
+        var schema = Schemas
+            .Structure<VisitorInput, VisitorInputBuilder>(new ShapeId("example", "VisitorInput"))
+            .Required(
+                "name",
+                static value => value.Name,
+                static (builder, value) => builder.Name = value,
+                Schemas.String
+            )
+            .Required(
+                "age",
+                static value => value.Age,
+                static (builder, value) => builder.Age = value,
+                Schemas.Integer
+            )
+            .Build(
+                static () => new VisitorInputBuilder(),
+                static builder => new VisitorInput(builder.Name!, builder.Age)
+            );
+        var selected = new HashSet<string>(StringComparer.Ordinal) { "name" };
+        var projection = Schemas.Project(schema, selected);
+
+        selected.Clear();
+        selected.Add("age");
+
+        Assert.NotNull(projection.GetMember("name"));
+        Assert.Null(projection.GetMember("age"));
+        Assert.Equal(
+            "{\"name\":\"Ada\"}",
+            Encoding.UTF8.GetString(
+                JsonCodecFactory
+                    .Default.FromProjection(projection)
+                    .Serialize(new VisitorInput("Ada", 36))
+            )
+        );
+    }
+
+    [Fact]
+    public void SchemaVisitorsRecoverHiddenBuilderAndErrorTypes()
+    {
+        var structure = Schemas
+            .Structure<VisitorInput, VisitorInputBuilder>(new ShapeId("example", "VisitorInput"))
+            .Build(
+                static () => new VisitorInputBuilder(),
+                static builder => new VisitorInput(builder.Name!, builder.Age)
+            );
+        var error = Schemas.OperationError(
+            new ShapeId("example", "BadRequest"),
+            Schemas
+                .Structure<TestException, TestExceptionBuilder>(
+                    new ShapeId("example", "BadRequest")
+                )
+                .Build(
+                    static () => new TestExceptionBuilder(),
+                    static builder => new TestException(builder.Message)
+                ),
+            400
+        );
+
+        Assert.Equal(typeof(VisitorInputBuilder), GetBuilderType(structure));
+        Assert.Equal(typeof(TestException), GetErrorType(error));
+    }
+
+    [Fact]
+    public void CompiledCollectionDefaultsDoNotAlias()
+    {
+        var defaultId = ShapeId.Parse("smithy.api#default");
+        var schema = Schemas.List(new ShapeId("example", "Names"), Schemas.String);
+        IReadOnlyDictionary<ShapeId, Trait> traits = new Dictionary<ShapeId, Trait>
+        {
+            [defaultId] = new(defaultId, Document.From([Document.From("Ada")])),
+        };
+
+        Assert.True(
+            DefaultValues.TryCompile(schema, traits, honorClientOptional: false, out var create)
+        );
+
+        var first = create();
+        var second = create();
+        Assert.NotSame(first, second);
+        Assert.Equal(["Ada"], first);
+        Assert.Equal(["Ada"], second);
+    }
+
+    [Fact]
+    public void NullableSchemaDistinguishesTypedAndUntypedTargets()
+    {
+        var nullable = Assert.IsType<NullableSchema<int>>(Schemas.Nullable(Schemas.Integer));
+
+        Assert.Same(Schemas.Integer, nullable.TypedTarget);
+        Assert.Same(Schemas.Integer, nullable.Target);
+    }
+
+    private sealed class BuilderTypeVisitor : IStructSchemaVisitor<VisitorInput, Type>
+    {
+        public Type Visit<TBuilder>(IStructSchema<VisitorInput, TBuilder> schema) =>
+            typeof(TBuilder);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "The erased interface is the behavior under test."
+    )]
+    private static Type GetBuilderType(IStructSchema<VisitorInput> schema) =>
+        schema.Accept(new BuilderTypeVisitor());
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "The erased interface is the behavior under test."
+    )]
+    private static Type GetErrorType(IOperationErrorSchema schema) =>
+        schema.Accept(ErrorTypeVisitor.Instance);
+
+    private sealed class ErrorTypeVisitor : IOperationErrorSchemaVisitor<Type>
+    {
+        public static ErrorTypeVisitor Instance { get; } = new();
+
+        public Type Visit<TError>(OperationErrorSchema<TError> schema)
+            where TError : Exception => typeof(TError);
     }
 }

--- a/website/src/content/docs/reference/known-limitations.md
+++ b/website/src/content/docs/reference/known-limitations.md
@@ -98,9 +98,10 @@ they use the codegen-emitted typed accessors on the schema, with **no runtime
 reflection** — and each compiles a per-shape reader and writer once from the
 schema, caching structural decisions such as dispatch and boxing.
 
-The codecs are not yet validated or optimized for:
+CI publishes and runs a NativeAOT smoke covering a REST/JSON operation with label, header, query,
+and document-body bindings. The codecs are not yet comprehensively validated or optimized for:
 
-- NativeAOT
+- NativeAOT across every codec and protocol combination
 - source-generated serializer metadata
 - every Smithy edge case across future protocol families
 


### PR DESCRIPTION
## Summary

Removes the untyped/object tier from the schema model and makes schema compilation fully typed from end to end.

- Removes `GetObject`/`SetObject`, object-based collection and enum/union accessors, `Schemas.GetMembers`, runtime `ShapeKind` switches used by that tier, and executable `dynamic` dispatch from the runtime packages.
- Adds typed generic dispatch for erased structure builder types and modeled error types, preserving AOT-friendly compilation without reflection or the runtime binder.
- Compiles REST labels, headers, query parameters, prefix headers, response codes, bodies, modeled errors, and AWS Query form bodies once per operation into typed plans.
- Resolves modeled defaults once into typed factories shared by JSON, CBOR, XML, and REST payload handling; mutable collection defaults produce independent instances.
- Makes structure projections immutable snapshots of their selected members.
- Clarifies the public schema vocabulary: `CollectionSchema`, `PartialSchemaVisitor`, `ITypedTargetMemberSchema<TValue>.TypedTarget`, `IBuilderMemberSchema`, and `NullableSchema<T>.Target`/`TypedTarget`.
- Simplifies focused Proto message visitors by deriving from `PartialSchemaVisitor` while retaining exhaustive visitors for the full codec algebra.
- Adds a NativeAOT smoke project that exercises a REST/JSON operation with label, header, query, and document-body bindings, and wires it into CI.

Behavior is unchanged across the conformance suites, except that unsupported HTTP binding kinds and non-integer `@httpResponseCode` members now fail when the operation protocol is constructed instead of on the first request.
