### PR TITLE
feat: add Smithy MCP prompt support

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/TraitIds.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/TraitIds.java
@@ -24,6 +24,7 @@ public final class TraitIds {
   public static final ShapeId GRPC = ShapeId.from("alloy.proto#grpc");
   public static final ShapeId PROTO_INDEX = ShapeId.from("alloy.proto#protoIndex");
   public static final ShapeId XML_NAME = ShapeId.from("smithy.api#xmlName");
+  public static final ShapeId PROMPTS = ShapeId.from("smithy.ai#prompts");
 
   private TraitIds() {}
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -2,7 +2,8 @@
  * Server-side code generator. Emits:
  *   - one `I{Operation}Handler` per operation (streaming surface derived from the model)
  *   - aggregate `I{Service}ServiceHandler`
- *   - a protocol-neutral executable operation catalog for the aggregate handler
+ *   - a DI-registered service definition that binds each independently registered operation
+ *     handler into a protocol-neutral executable catalog
  *   - `{Service}ServiceServerExtensions` with AddXxxHandler<THandler>(IServiceCollection)
  *   - `{Service}ServiceProtocols` flags and `Map{Service}Service(..., protocols)` that bind
  *     selected protocol routes to the shared handler
@@ -17,6 +18,7 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
+import io.github.thomaslaich.nsmithy.csharp.codegen.TraitIds;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport.Kind;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
@@ -29,10 +31,15 @@ import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -71,6 +78,7 @@ public final class ServerGenerator implements Runnable {
             .collect(Collectors.toList());
 
     List<Kind> serverKinds = serverKinds();
+    List<PromptDefinition> prompts = promptDefinitions(ops);
     if (serverKinds.contains(Kind.GRPC)) {
       ops.forEach(op -> ShapeSupport.requireGrpcEventStreamWrapperIsFlattenable(model, op));
     }
@@ -79,6 +87,7 @@ public final class ServerGenerator implements Runnable {
     writer.addImport(RuntimeTypes.NSMITHY_CORE);
     writer.addImport(RuntimeTypes.NSMITHY_SERVER);
     writer.addImport(RuntimeTypes.MS_EXT_DI);
+    writer.addImport(RuntimeTypes.MS_EXT_DI_EXTENSIONS);
     if (emitsAspNetCore) {
       writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
       writer.addImport(RuntimeTypes.NSMITHY_HTTP);
@@ -122,10 +131,123 @@ public final class ServerGenerator implements Runnable {
       writer.write("");
     }
 
+    writeServiceDefinition(ops, prompts, contract);
+    writer.write("");
     writeServerExtensions(ops, contract, aggInterface, serverKinds);
   }
 
   // ---------------- DI registration ----------------
+
+  private void writeServiceDefinition(
+      List<OperationShape> ops, List<PromptDefinition> prompts, String contract) {
+    writer.write("public sealed class $LDefinition : IServiceDefinition", contract);
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write(
+              "public ServiceSchema Schema => $L;",
+              SchemaGenerator.serviceSchemaAccessor(context, service));
+          writer.write("");
+          writePromptDefinitions(prompts);
+          writer.write("");
+          writer.write(
+              "public ServiceOperationCatalog CreateOperationCatalog(IServiceProvider services)");
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write("return CreateOperationCatalog(");
+                writer.indent();
+                for (int i = 0; i < ops.size(); i++) {
+                  OperationShape op = ops.get(i);
+                  writer.write(
+                      "services.GetRequiredService<$L>()$L",
+                      opHandlerName(op),
+                      i + 1 == ops.size() ? "" : ",");
+                }
+                writer.dedent();
+                writer.write(");");
+              });
+          writer.write("");
+          writeOperationCatalogFactory(ops);
+
+          if (ops.stream().anyMatch(op -> !isStreaming(op))) {
+            writer.write("");
+            writeOperationJsonSchemas(ops);
+          }
+        });
+  }
+
+  private void writePromptDefinitions(List<PromptDefinition> prompts) {
+    writer.write("public IReadOnlyList<ServicePromptDefinition> Prompts { get; } =");
+    writer.write("[");
+    writer.indent();
+    for (PromptDefinition prompt : prompts) {
+      writer.write("new ServicePromptDefinition(");
+      writer.indent();
+      writer.write("$L,", CSharpNaming.formatString(prompt.name()));
+      writer.write("$L,", CSharpNaming.formatString(prompt.description()));
+      writer.write("$L,", CSharpNaming.formatString(prompt.template()));
+      writer.write(
+          "$L,",
+          prompt.preferWhen() == null ? "null" : CSharpNaming.formatString(prompt.preferWhen()));
+      writer.write("[");
+      writer.indent();
+      for (PromptArgumentDefinition argument : prompt.arguments()) {
+        writer.write(
+            "new ServicePromptArgumentDefinition($L, $L, $L),",
+            CSharpNaming.formatString(argument.name()),
+            argument.description() == null
+                ? "null"
+                : CSharpNaming.formatString(argument.description()),
+            argument.required() ? "true" : "false");
+      }
+      writer.dedent();
+      writer.write("]");
+      writer.dedent();
+      writer.write("),");
+    }
+    writer.dedent();
+    writer.write("];");
+  }
+
+  private void writeOperationCatalogFactory(List<OperationShape> ops) {
+    String parameters =
+        ops.stream()
+            .map(op -> opHandlerName(op) + " " + operationHandlerVariable(op))
+            .collect(Collectors.joining(", "));
+    writer.write("private static ServiceOperationCatalog CreateOperationCatalog($L)", parameters);
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("return new ServiceOperationCatalog(");
+          writer.indent();
+          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(context, service));
+          writer.write("[");
+          writer.indent();
+          for (OperationShape op : ops) {
+            if (isStreaming(op)) {
+              writer.write(
+                  "ServiceOperation.Create($L, $L),",
+                  SchemaGenerator.operationSchemaAccessor(context, op),
+                  unaryAdapter(op, operationHandlerVariable(op)));
+            } else {
+              writer.write(
+                  "ServiceOperation.Create($L, $L, $L.Value),",
+                  SchemaGenerator.operationSchemaAccessor(context, op),
+                  unaryAdapter(op, operationHandlerVariable(op)),
+                  operationJsonSchemasClass(op));
+            }
+          }
+          writer.dedent();
+          writer.write("]");
+          writer.dedent();
+          writer.write(");");
+        });
+  }
 
   private void writeServerExtensions(
       List<OperationShape> ops, String contract, String aggInterface, List<Kind> serverKinds) {
@@ -135,6 +257,21 @@ public final class ServerGenerator implements Runnable {
         "{",
         "}",
         () -> {
+          writer.write(
+              "public static IServiceCollection Add$L(this IServiceCollection services)", contract);
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write(
+                    "services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceDefinition,"
+                        + " $LDefinition>());",
+                    contract);
+                writer.write("return services;");
+              });
+
+          writer.write("");
           writer.write(
               "public static IServiceCollection Add$LHandler<THandler>(this IServiceCollection"
                   + " services)",
@@ -146,6 +283,7 @@ public final class ServerGenerator implements Runnable {
               () -> {
                 writer.write("System.ArgumentNullException.ThrowIfNull(services);");
                 writer.write("");
+                writer.write("services.Add$L();", contract);
                 writer.write("services.AddSingleton<THandler>();");
                 writer.write(
                     "services.AddSingleton<$L>(serviceProvider =>"
@@ -159,13 +297,6 @@ public final class ServerGenerator implements Runnable {
                 }
                 writer.write("return services;");
               });
-
-          writer.write("");
-          writeOperationJsonSchemas(ops);
-          if (ops.stream().anyMatch(op -> !isStreaming(op))) {
-            writer.write("");
-          }
-          writeOperationCatalog(ops, contract, aggInterface);
 
           if (serverKinds.isEmpty()) {
             return;
@@ -182,44 +313,6 @@ public final class ServerGenerator implements Runnable {
             writer.write("");
             writeProtocolMapHelper(kind, ops, contract, protocolEnum);
           }
-        });
-  }
-
-  private void writeOperationCatalog(
-      List<OperationShape> ops, String contract, String aggregateInterface) {
-    writer.write(
-        "public static ServiceOperationCatalog Create$LOperationCatalog(this $L handler)",
-        contract,
-        aggregateInterface);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("System.ArgumentNullException.ThrowIfNull(handler);");
-          writer.write("");
-          writer.write("return new ServiceOperationCatalog(");
-          writer.indent();
-          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(context, service));
-          writer.write("[");
-          writer.indent();
-          for (OperationShape op : ops) {
-            if (isStreaming(op)) {
-              writer.write(
-                  "ServiceOperation.Create($L, $L),",
-                  SchemaGenerator.operationSchemaAccessor(context, op),
-                  unaryAdapter(op));
-            } else {
-              writer.write(
-                  "ServiceOperation.Create($L, $L, $L.Value),",
-                  SchemaGenerator.operationSchemaAccessor(context, op),
-                  unaryAdapter(op),
-                  operationJsonSchemasClass(op));
-            }
-          }
-          writer.dedent();
-          writer.write("]");
-          writer.dedent();
-          writer.write(");");
         });
   }
 
@@ -472,9 +565,13 @@ public final class ServerGenerator implements Runnable {
   // output (the handler returns Task, but the runtime expects Task<SmithyUnit>).
 
   private String unaryAdapter(OperationShape op) {
+    return unaryAdapter(op, "handler");
+  }
+
+  private String unaryAdapter(OperationShape op, String handlerVariable) {
     boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
     boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
-    String method = handlerMethod(op);
+    String method = handlerMethod(op, handlerVariable);
     if (hasInput && hasOutput) {
       return method;
     }
@@ -490,8 +587,63 @@ public final class ServerGenerator implements Runnable {
             + ".ConfigureAwait(false); return SmithyUnit.Value; }";
   }
 
-  private String handlerMethod(OperationShape op) {
-    return "handler." + CSharpNaming.typeName(op.getId().getName()) + "Async";
+  private String handlerMethod(OperationShape op, String handlerVariable) {
+    return handlerVariable + "." + CSharpNaming.typeName(op.getId().getName()) + "Async";
+  }
+
+  // ---------------- prompts ----------------
+
+  private List<PromptDefinition> promptDefinitions(List<OperationShape> ops) {
+    var prompts = new java.util.ArrayList<PromptDefinition>();
+    addPromptDefinitions(service, prompts);
+    for (OperationShape op : ops) {
+      addPromptDefinitions(op, prompts);
+    }
+    return List.copyOf(prompts);
+  }
+
+  private void addPromptDefinitions(Shape owner, List<PromptDefinition> prompts) {
+    owner
+        .findTrait(TraitIds.PROMPTS)
+        .ifPresent(
+            trait -> {
+              var entries =
+                  trait.toNode().expectObjectNode().getStringMap().entrySet().stream()
+                      .sorted(Map.Entry.comparingByKey())
+                      .toList();
+              for (var entry : entries) {
+                ObjectNode definition = entry.getValue().expectObjectNode();
+                String description = definition.expectStringMember("description").getValue();
+                String template = definition.expectStringMember("template").getValue();
+                String preferWhen =
+                    definition.getStringMember("preferWhen").map(n -> n.getValue()).orElse(null);
+                List<PromptArgumentDefinition> arguments =
+                    definition
+                        .getStringMember("arguments")
+                        .map(node -> promptArguments(node.getValue()))
+                        .orElse(List.of());
+                prompts.add(
+                    new PromptDefinition(
+                        entry.getKey(), description, template, preferWhen, arguments));
+              }
+            });
+  }
+
+  private List<PromptArgumentDefinition> promptArguments(String shapeId) {
+    StructureShape structure =
+        context.model().expectShape(ShapeId.from(shapeId), StructureShape.class);
+    return structure.getAllMembers().values().stream()
+        .sorted(Comparator.comparing(member -> member.getMemberName()))
+        .map(
+            member ->
+                new PromptArgumentDefinition(
+                    member.getMemberName(),
+                    member
+                        .getTrait(DocumentationTrait.class)
+                        .map(trait -> trait.getValue())
+                        .orElse(null),
+                    member.hasTrait(RequiredTrait.class)))
+        .toList();
   }
 
   // ---------------- routing helpers ----------------
@@ -569,6 +721,10 @@ public final class ServerGenerator implements Runnable {
     return "I" + CSharpNaming.typeName(op.getId().getName()) + "Handler";
   }
 
+  private String operationHandlerVariable(OperationShape op) {
+    return CSharpNaming.parameterName(op.getId().getName() + "Handler");
+  }
+
   private String serverOperationSignature(SymbolProvider sp, OperationShape op) {
     Model model = context.model();
     boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
@@ -619,4 +775,13 @@ public final class ServerGenerator implements Runnable {
   private boolean isOutputStreaming(Model model, OperationShape op) {
     return ShapeSupport.isEventStreamShape(model, op.getOutputShape());
   }
+
+  private record PromptDefinition(
+      String name,
+      String description,
+      String template,
+      String preferWhen,
+      List<PromptArgumentDefinition> arguments) {}
+
+  private record PromptArgumentDefinition(String name, String description, boolean required) {}
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -273,6 +273,48 @@ final class ServerGeneratorTest {
       }
       """;
 
+  private static final String PROMPTS_MODEL =
+      """
+      $version: "2"
+
+      namespace example.prompts
+
+      use smithy.ai#prompts
+
+      @prompts({
+          service_brief: {
+              description: "Summarize two locations"
+              template: "Compare {{first}} with {{second}}."
+              arguments: ComparisonArguments
+              preferWhen: "Use this for comparisons"
+          }
+      })
+      service PromptService {
+          version: "1"
+          operations: [Compare]
+      }
+
+      @prompts({
+          operation_brief: {
+              description: "Use the comparison operation"
+              template: "Call Compare for {{first}} and {{second}}."
+              arguments: ComparisonArguments
+          }
+      })
+      operation Compare {
+          input: ComparisonArguments
+          output := {}
+      }
+
+      structure ComparisonArguments {
+          /// First location.
+          @required
+          first: String
+
+          second: String
+      }
+      """;
+
   @Test
   void streamingGrpcServerUsesAsyncEnumerableHandlersAndStreamingWriter() throws Exception {
     String generated = renderServer();
@@ -405,10 +447,17 @@ final class ServerGeneratorTest {
 
     assertTrue(generated.contains("using NSmithy.Server;"), generated);
     assertTrue(
-        generated.contains(
-            "public static ServiceOperationCatalog CreateCatalogServiceOperationCatalog("
-                + "this ICatalogServiceHandler handler)"),
+        generated.contains("public sealed class CatalogServiceDefinition : IServiceDefinition"),
         generated);
+    assertTrue(
+        generated.contains(
+            "public static IServiceCollection AddCatalogService(this IServiceCollection"
+                + " services)"),
+        generated);
+    assertTrue(generated.contains("services.AddCatalogService();"), generated);
+    assertTrue(generated.contains("services.GetRequiredService<INotifyHandler>()"), generated);
+    assertTrue(generated.contains("services.GetRequiredService<IPingHandler>()"), generated);
+    assertFalse(generated.contains("CreateCatalogServiceOperationCatalog"), generated);
     assertTrue(generated.contains("CatalogServiceSchema.Schema,"), generated);
     assertTrue(generated.contains("private static class NotifyJsonSchemas"), generated);
     assertTrue(generated.contains("private static class PingJsonSchemas"), generated);
@@ -418,14 +467,35 @@ final class ServerGeneratorTest {
     assertTrue(
         generated.contains(
             "ServiceOperation.Create(Example.Example.Catalog.NotifySchema.Schema, async (input, ct)"
-                + " => { await handler.NotifyAsync(input, ct).ConfigureAwait(false); return"
+                + " => { await notifyHandler.NotifyAsync(input, ct).ConfigureAwait(false); return"
                 + " SmithyUnit.Value; }, NotifyJsonSchemas.Value),"),
         generated);
     assertTrue(
         generated.contains(
             "ServiceOperation.Create(Example.Example.Catalog.PingSchema.Schema, "
-                + "(_, ct) => handler.PingAsync(ct), PingJsonSchemas.Value),"),
+                + "(_, ct) => pingHandler.PingAsync(ct), PingJsonSchemas.Value),"),
         generated);
+  }
+
+  @Test
+  void serverGeneratesServiceAndOperationPromptDefinitions() throws Exception {
+    String generated =
+        renderServer("", PROMPTS_MODEL, "example.prompts#PromptService", "Example.Prompts");
+
+    assertTrue(
+        generated.contains("public IReadOnlyList<ServicePromptDefinition> Prompts"), generated);
+    assertTrue(generated.contains("\"service_brief\""), generated);
+    assertTrue(generated.contains("\"Summarize two locations\""), generated);
+    assertTrue(generated.contains("\"Compare {{first}} with {{second}}.\""), generated);
+    assertTrue(generated.contains("\"Use this for comparisons\""), generated);
+    assertTrue(
+        generated.contains(
+            "new ServicePromptArgumentDefinition(\"first\", \"First location.\", true)"),
+        generated);
+    assertTrue(
+        generated.contains("new ServicePromptArgumentDefinition(\"second\", null, false)"),
+        generated);
+    assertTrue(generated.contains("\"operation_brief\""), generated);
   }
 
   private String renderServer() throws Exception {
@@ -447,7 +517,8 @@ final class ServerGeneratorTest {
         assembler.addUnparsedModel("protocol-traits-" + i + ".smithy", protocolTraitModels[i]);
       }
     }
-    Model model = assembler.addUnparsedModel("model.smithy", modelText).assemble().unwrap();
+    Model model =
+        assembler.addUnparsedModel("model.smithy", modelText).discoverModels().assemble().unwrap();
     CSharpSettings settings =
         CSharpSettings.fromNode(
             ObjectNode.builder()

--- a/designs/codegen-architecture.md
+++ b/designs/codegen-architecture.md
@@ -164,8 +164,8 @@ Generated code depends on .NET packages published to NuGet:
 - `NSmithy.Client` — `SmithyClientRuntime`, `IClientInterceptor`
 - `NSmithy.Server` / `NSmithy.Server.AspNetCore` — host-neutral operation
   catalogs and server framework
-- `NSmithy.Server.Mcp` — transport-neutral MCP tools backed by generated
-  operation catalogs
+- `NSmithy.Server.Mcp` — MCP tools and prompts projected from generated service
+  definitions
 - `NSmithy.Codecs.Json/Xml/Cbor` — schema-bound body codec implementations
 - `NSmithy.Protocols.Rest` — shared REST HTTP binding projection
 - `NSmithy.Protocols.*` — protocol adapters such as restJson1, restXml,
@@ -197,8 +197,9 @@ Service files contain:
 - `<Service>.Client.g.cs` — typed async methods for each operation; binds
   protocol and transport at construction time.
 - `<Service>.Server.g.cs` — server-side handler interface, a
-  `ServiceOperationCatalog` factory that binds operation schemas to the typed
-  handler, generated JSON Schema 2020-12 companions for unary operation tool
+  DI-registered `IServiceDefinition` that binds operation schemas to their
+  per-operation handlers, prompt definitions generated from
+  `smithy.ai#prompts`, JSON Schema 2020-12 companions for unary operation tool
   projections, and the ASP.NET Core adapter.
 
 Generated client and server methods bind the service schema, operation schemas,
@@ -207,12 +208,15 @@ the runtime protocol pipeline. The protocol adapter projects each operation into
 transport fields and delegates body payloads to a schema-bound codec such as
 `JsonCodecFactory`.
 
-The generated operation catalog stops at typed handler invocation and
-transport-neutral metadata. It has no HTTP, ASP.NET Core, MCP, or stdio
-behavior; those hosts enumerate the catalog, construct input using its runtime
-schemas, and choose their own wire mapping. JSON Schema metadata lives on the
-server operation binding rather than the shared operation schema, so client-only
-generation does not carry tool metadata.
+The generated service definition is transport-neutral. It resolves each
+operation handler independently and builds an operation catalog that stops at
+typed invocation and runtime metadata. It also exposes prompt definitions, but
+does not interpret or execute their templates. Transport adapters project these
+parts into their own capability model: the MCP adapter creates tools from the
+catalog and renders prompts, while ASP.NET Core continues to bind routes
+directly. JSON Schema metadata lives on the server operation binding rather than
+the shared operation schema, so client-only generation does not carry tool
+metadata.
 
 ## Tradeoffs
 

--- a/designs/serialization.md
+++ b/designs/serialization.md
@@ -177,6 +177,12 @@ timestamps, base64 blobs, unions, and constraints), not any particular HTTP or
 binary wire protocol. MCP tools consume this metadata without coupling the
 shared operation schema or client-only output to MCP concerns.
 
+Prompt metadata follows a separate path. Server generation converts
+`smithy.ai#prompts` traits into transport-neutral `ServicePromptDefinition`
+values on the generated `IServiceDefinition`; it does not add prompt semantics
+to `ServiceSchema` or `OperationSchema`. An MCP adapter renders those definitions
+into MCP prompts, while other hosts can ignore them.
+
 Traits stay on schemas and members. Core schemas carry any Smithy trait, but
 consumers decide which traits they interpret. REST protocols interpret
 `@httpLabel`, `@httpHeader`, `@httpPayload`, and `@timestampFormat`; a gRPC

--- a/examples/restjson1/README.md
+++ b/examples/restjson1/README.md
@@ -4,7 +4,7 @@ A Weather service built with `aws.protocols#restJson1`. The model is adapted fro
 the [Smithy quickstart](https://smithy.io/2.0/quickstart.html) and demonstrates
 resources, pagination, errors, retries (`@retryable`), HTTP binding traits, and
 end-to-end OpenTelemetry observability using the AWS REST JSON protocol. The
-same generated operations and handwritten handler are also exposed as MCP tools.
+same generated operations and Smithy prompt templates are also exposed over MCP.
 
 - `contracts`: the Smithy model, packaged as a contracts project.
 - `server`: generated ASP.NET Core endpoints and an MCP stdio server backed by a handwritten `IWeatherServiceHandler` implementation that supports real server-side pagination.
@@ -56,7 +56,7 @@ curl -i http://localhost:5000/cities/SEA/forecast
 curl -i http://localhost:5000/cities/SEA/flaky-forecast   # 503s two of every three calls
 ```
 
-## MCP tools
+## MCP tools and prompts
 
 Run the same Weather service as an MCP stdio server by passing `--mcp`:
 
@@ -85,9 +85,40 @@ path with an absolute path):
 }
 ```
 
+For [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp), add the
+built server from the repository root:
+
+```bash
+claude mcp add weather -- dotnet /absolute/path/to/smithy-dotnet/examples/restjson1/server/bin/Debug/net10.0/NSmithy.Examples.RestJson1.Server.dll --mcp
+```
+
+Or let Claude Code launch the project through `dotnet run`. Keep `--no-build`:
+build output on stdout would corrupt the MCP stdio stream.
+
+```bash
+claude mcp add weather -- dotnet run --no-build --project /absolute/path/to/smithy-dotnet/examples/restjson1/server/NSmithy.Examples.RestJson1.Server.csproj -- --mcp
+```
+
+Check the registration with `claude mcp get weather`. Inside Claude Code, `/mcp`
+shows the connection, and the generated prompts are available as
+`/mcp__weather__city_weather_brief SEA` and
+`/mcp__weather__forecast_answer SEA`.
+
 The generated `GetCurrentTime`, `GetCity`, `ListCities`, `GetForecast`, and
 `GetFlakyForecast` operations appear as tools. Their descriptions, input and
 output schemas, validation, and read-only hints all come from the Smithy model.
+The model also contributes two prompts:
+
+- `city_weather_brief` guides the model to call both `GetCity` and `GetForecast`
+  before producing a combined summary.
+- `forecast_answer` guides the model to call `GetForecast` and explain its
+  numeric chance of rain in plain language.
+
+Both prompts accept a required `cityId` argument. A prompt template does not
+call a handler itself; the MCP client expands it into instructions for the model,
+which then chooses and invokes the named tools. The server exposes the tools and
+prompts together through `.WithSmithyService(WeatherSchema.Schema)`.
+
 The ASP.NET Core and MCP hosts share the same `WeatherHandler`; only the
 transport adapter changes.
 

--- a/examples/restjson1/contracts/model/weather.smithy
+++ b/examples/restjson1/contracts/model/weather.smithy
@@ -3,11 +3,20 @@ $version: "2"
 namespace example.weather
 
 use aws.protocols#restJson1
+use smithy.ai#prompts
 
 /// Provides weather forecasts.
 ///
 /// The service exposes city resources, each with a forecast sub-resource that
 /// gives the current chance of rain. Cities are listed with pagination support.
+@prompts({
+    city_weather_brief: {
+        description: "Create a weather brief for a city"
+        template: "Use GetCity and GetForecast for city ID {{cityId}}, then summarize the city's location and chance of rain."
+        arguments: CityWeatherBriefArguments
+        preferWhen: "The user asks for a combined city and weather overview"
+    }
+})
 @restJson1
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
@@ -91,6 +100,14 @@ operation ListCities {
 
 /// Returns the weather forecast for a city.
 @readonly
+@prompts({
+    forecast_answer: {
+        description: "Answer a forecast question for one city"
+        template: "Use GetForecast with city ID {{cityId}} and explain the chance of rain in plain language."
+        arguments: ForecastPromptArguments
+        preferWhen: "The user asks specifically about rain or the forecast for a known city ID"
+    }
+})
 @http(method: "GET", uri: "/cities/{cityId}/forecast")
 operation GetForecast {
     input := for Forecast {
@@ -111,6 +128,18 @@ structure CityCoordinates {
 
     @required
     longitude: Float
+}
+
+structure CityWeatherBriefArguments for City {
+    /// City ID accepted by the Weather service, such as `SEA` or `ZRH`.
+    @required
+    $cityId
+}
+
+structure ForecastPromptArguments for Forecast {
+    /// City ID whose rain forecast should be explained.
+    @required
+    $cityId
 }
 
 list CitySummaries {

--- a/examples/restjson1/contracts/smithy-build.json
+++ b/examples/restjson1/contracts/smithy-build.json
@@ -3,7 +3,8 @@
   "sources": ["model"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-aws-traits:1.73.0"
+      "software.amazon.smithy:smithy-aws-traits:1.73.0",
+      "software.amazon.smithy.java:smithy-ai-traits:1.6.0"
     ]
   }
 }

--- a/examples/restjson1/server/Program.cs
+++ b/examples/restjson1/server/Program.cs
@@ -42,9 +42,7 @@ static async Task RunMcpServerAsync(string[] args)
     builder
         .Services.AddMcpServer()
         .WithStdioServerTransport()
-        .WithSmithyTools<IWeatherServiceHandler>(handler =>
-            handler.CreateWeatherServiceOperationCatalog()
-        );
+        .WithSmithyService(WeatherSchema.Schema);
 
     await builder.Build().RunAsync();
 }

--- a/packages/NSmithy.Server.Mcp/SmithyMcpPrompts.cs
+++ b/packages/NSmithy.Server.Mcp/SmithyMcpPrompts.cs
@@ -1,0 +1,186 @@
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using NSmithy.Server;
+
+namespace NSmithy.Server.Mcp;
+
+/// <summary>Creates MCP prompts from generated Smithy prompt definitions.</summary>
+public static class SmithyMcpPrompts
+{
+    public static IReadOnlyList<McpServerPrompt> Create(
+        IEnumerable<ServicePromptDefinition> definitions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        List<McpServerPrompt> prompts = [];
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var definition in definitions)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+            if (!names.Add(definition.Name))
+            {
+                throw new InvalidOperationException(
+                    $"More than one Smithy prompt maps to MCP prompt name '{definition.Name}' "
+                        + "when compared without regard to case."
+                );
+            }
+
+            prompts.Add(new SmithyMcpPrompt(definition));
+        }
+
+        return new ReadOnlyCollection<McpServerPrompt>(prompts);
+    }
+}
+
+internal sealed class SmithyMcpPrompt : McpServerPrompt
+{
+    private const string PreferWhenPrefix = "\n\nTool preference: ";
+
+    private readonly ServicePromptDefinition definition;
+    private readonly Dictionary<string, ServicePromptArgumentDefinition> argumentsByName;
+
+    public SmithyMcpPrompt(ServicePromptDefinition definition)
+    {
+        this.definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        argumentsByName = definition.Arguments.ToDictionary(
+            argument => argument.Name,
+            StringComparer.Ordinal
+        );
+        ProtocolPrompt = new Prompt
+        {
+            Name = definition.Name,
+            Description = definition.Description,
+            Arguments =
+            [
+                .. definition.Arguments.Select(argument => new PromptArgument
+                {
+                    Name = argument.Name,
+                    Description = argument.Description,
+                    Required = argument.IsRequired,
+                }),
+            ],
+        };
+    }
+
+    public override Prompt ProtocolPrompt { get; }
+
+    public override IReadOnlyList<object> Metadata { get; } = [];
+
+    public override ValueTask<GetPromptResult> GetAsync(
+        RequestContext<GetPromptRequestParams> request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var supplied = request.Params.Arguments;
+        if (supplied is not null)
+        {
+            foreach (var argument in supplied)
+            {
+                if (!argumentsByName.ContainsKey(argument.Key))
+                {
+                    throw InvalidParams(
+                        $"Prompt '{definition.Name}' does not declare argument '{argument.Key}'."
+                    );
+                }
+
+                if (argument.Value.ValueKind != JsonValueKind.String)
+                {
+                    throw InvalidParams(
+                        $"Argument '{argument.Key}' for prompt '{definition.Name}' must be a string."
+                    );
+                }
+            }
+        }
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var argument in definition.Arguments)
+        {
+            if (supplied is not null && supplied.TryGetValue(argument.Name, out var value))
+            {
+                values.Add(argument.Name, value.GetString()!);
+            }
+            else if (argument.IsRequired)
+            {
+                throw InvalidParams(
+                    $"Prompt '{definition.Name}' requires argument '{argument.Name}'."
+                );
+            }
+            else
+            {
+                values.Add(argument.Name, string.Empty);
+            }
+        }
+
+        var template = definition.Template;
+        if (!string.IsNullOrEmpty(definition.PreferWhen))
+        {
+            template += PreferWhenPrefix + definition.PreferWhen;
+        }
+
+        return ValueTask.FromResult(
+            new GetPromptResult
+            {
+                Description = definition.Description,
+                Messages =
+                [
+                    new PromptMessage
+                    {
+                        Role = Role.User,
+                        Content = new TextContentBlock { Text = Render(template, values) },
+                    },
+                ],
+            }
+        );
+    }
+
+    private static string Render(string template, Dictionary<string, string> arguments)
+    {
+        var result = new StringBuilder(template.Length);
+        var position = 0;
+        while (position < template.Length)
+        {
+            var opening = template.IndexOf("{{", position, StringComparison.Ordinal);
+            if (opening < 0)
+            {
+                result.Append(template, position, template.Length - position);
+                break;
+            }
+
+            result.Append(template, position, opening - position);
+            var closing = template.IndexOf("}}", opening + 2, StringComparison.Ordinal);
+            if (closing < 0)
+            {
+                result.Append(template, opening, template.Length - opening);
+                break;
+            }
+
+            var name = template.Substring(opening + 2, closing - opening - 2);
+            if (IsPlaceholderName(name))
+            {
+                result.Append(arguments.TryGetValue(name, out var value) ? value : string.Empty);
+            }
+            else
+            {
+                result.Append(template, opening, closing + 2 - opening);
+            }
+
+            position = closing + 2;
+        }
+
+        return result.ToString();
+    }
+
+    private static bool IsPlaceholderName(string name) =>
+        name.Length > 0
+        && name.All(character => char.IsAsciiLetterOrDigit(character) || character == '_');
+
+    private static McpProtocolException InvalidParams(string message) =>
+        new(message, McpErrorCode.InvalidParams);
+}

--- a/packages/NSmithy.Server.Mcp/SmithyMcpServerBuilderExtensions.cs
+++ b/packages/NSmithy.Server.Mcp/SmithyMcpServerBuilderExtensions.cs
@@ -1,13 +1,47 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
+using NSmithy.Core.Serde;
 using NSmithy.Server;
 
 namespace NSmithy.Server.Mcp;
 
-/// <summary>Registers generated Smithy service operations with an MCP server.</summary>
+/// <summary>Registers generated Smithy service tools and prompts with an MCP server.</summary>
 public static class SmithyMcpServerBuilderExtensions
 {
+    /// <summary>
+    /// Adds the tools and prompts for the generated service identified by
+    /// <paramref name="schema"/>. The generated service definition and operation handlers are
+    /// resolved from dependency injection when MCP server options are materialized.
+    /// </summary>
+    public static IMcpServerBuilder WithSmithyService(
+        this IMcpServerBuilder builder,
+        ServiceSchema schema
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(schema);
+        return builder.WithSmithyDefinition(services =>
+        {
+            var matches = services
+                .GetServices<IServiceDefinition>()
+                .Where(definition => definition.Schema.Id == schema.Id)
+                .ToArray();
+            return matches.Length switch
+            {
+                1 => matches[0],
+                0 => throw new InvalidOperationException(
+                    $"Generated service definition '{schema.Id}' is not registered. Call the "
+                        + "generated Add{Service} method, or Add{Service}Handler for an aggregate "
+                        + "handler, before WithSmithyService."
+                ),
+                _ => throw new InvalidOperationException(
+                    $"Generated service definition '{schema.Id}' is registered more than once."
+                ),
+            };
+        });
+    }
+
     /// <summary>Adds the unary operations in <paramref name="catalog"/> as MCP tools.</summary>
     public static IMcpServerBuilder WithSmithyTools(
         this IMcpServerBuilder builder,
@@ -19,45 +53,51 @@ public static class SmithyMcpServerBuilderExtensions
         return builder.WithTools(SmithyMcpTools.Create(catalog));
     }
 
-    /// <summary>
-    /// Adds Smithy operations resolved from dependency injection as MCP tools. The catalog is
-    /// created when MCP server options are materialized, after application services are available.
-    /// </summary>
-    public static IMcpServerBuilder WithSmithyTools(
+    /// <summary>Adds generated Smithy prompt definitions to an MCP server.</summary>
+    public static IMcpServerBuilder WithSmithyPrompts(
         this IMcpServerBuilder builder,
-        Func<IServiceProvider, ServiceOperationCatalog> catalogFactory
+        IEnumerable<ServicePromptDefinition> definitions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(catalogFactory);
+        ArgumentNullException.ThrowIfNull(definitions);
+        return builder.WithPrompts(SmithyMcpPrompts.Create(definitions));
+    }
+
+    private static IMcpServerBuilder WithSmithyDefinition(
+        this IMcpServerBuilder builder,
+        Func<IServiceProvider, IServiceDefinition> definitionFactory
+    )
+    {
         builder.Services.AddSingleton<IConfigureOptions<McpServerOptions>>(
             services => new ConfigureOptions<McpServerOptions>(options =>
             {
                 var tools = options.ToolCollection ?? [];
-                foreach (var tool in SmithyMcpTools.Create(catalogFactory(services)))
+                var prompts = options.PromptCollection ?? [];
+                var definition = definitionFactory(services);
+                foreach (
+                    var tool in SmithyMcpTools.Create(definition.CreateOperationCatalog(services))
+                )
                 {
                     tools.Add(tool);
+                }
+
+                foreach (var prompt in SmithyMcpPrompts.Create(definition.Prompts))
+                {
+                    prompts.Add(prompt);
                 }
 
                 if (!tools.IsEmpty)
                 {
                     options.ToolCollection = tools;
                 }
+
+                if (!prompts.IsEmpty)
+                {
+                    options.PromptCollection = prompts;
+                }
             })
         );
         return builder;
-    }
-
-    /// <summary>Adds Smithy operations from a handler resolved through dependency injection.</summary>
-    public static IMcpServerBuilder WithSmithyTools<THandler>(
-        this IMcpServerBuilder builder,
-        Func<THandler, ServiceOperationCatalog> catalogFactory
-    )
-        where THandler : class
-    {
-        ArgumentNullException.ThrowIfNull(catalogFactory);
-        return builder.WithSmithyTools(services =>
-            catalogFactory(services.GetRequiredService<THandler>())
-        );
     }
 }

--- a/packages/NSmithy.Server/ServiceDefinition.cs
+++ b/packages/NSmithy.Server/ServiceDefinition.cs
@@ -1,0 +1,17 @@
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Server;
+
+/// <summary>
+/// A generated Smithy service surface registered with dependency injection. Host adapters use the
+/// definition to discover static service metadata and bind each operation to its independently
+/// registered handler.
+/// </summary>
+public interface IServiceDefinition
+{
+    ServiceSchema Schema { get; }
+
+    IReadOnlyList<ServicePromptDefinition> Prompts { get; }
+
+    ServiceOperationCatalog CreateOperationCatalog(IServiceProvider services);
+}

--- a/packages/NSmithy.Server/ServicePromptDefinition.cs
+++ b/packages/NSmithy.Server/ServicePromptDefinition.cs
@@ -1,0 +1,71 @@
+using System.Collections.ObjectModel;
+
+namespace NSmithy.Server;
+
+/// <summary>Transport-neutral metadata for one argument accepted by a Smithy prompt.</summary>
+public sealed class ServicePromptArgumentDefinition
+{
+    public ServicePromptArgumentDefinition(string name, string? description, bool isRequired)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+        Description = description;
+        IsRequired = isRequired;
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public bool IsRequired { get; }
+}
+
+/// <summary>
+/// A prompt template declared on a Smithy service or one of its operations. The definition is
+/// transport-neutral; adapters decide how to expose and render it.
+/// </summary>
+public sealed class ServicePromptDefinition
+{
+    public ServicePromptDefinition(
+        string name,
+        string description,
+        string template,
+        string? preferWhen = null,
+        IEnumerable<ServicePromptArgumentDefinition>? arguments = null
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(template);
+
+        var copiedArguments = arguments?.ToArray() ?? [];
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var argument in copiedArguments)
+        {
+            ArgumentNullException.ThrowIfNull(argument);
+            if (!names.Add(argument.Name))
+            {
+                throw new ArgumentException(
+                    $"Prompt '{name}' contains more than one argument named '{argument.Name}'.",
+                    nameof(arguments)
+                );
+            }
+        }
+
+        Name = name;
+        Description = description;
+        Template = template;
+        PreferWhen = preferWhen;
+        Arguments = new ReadOnlyCollection<ServicePromptArgumentDefinition>(copiedArguments);
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public string Template { get; }
+
+    public string? PreferWhen { get; }
+
+    public IReadOnlyList<ServicePromptArgumentDefinition> Arguments { get; }
+}

--- a/tests/AotSmoke/Program.cs
+++ b/tests/AotSmoke/Program.cs
@@ -87,6 +87,22 @@ if (mcpTool.Name != "UpdateUser" || mcpTool.InputSchema.GetProperty("type").GetS
     throw new InvalidOperationException("MCP NativeAOT tool projection failed.");
 }
 
+var mcpPrompt = SmithyMcpPrompts
+    .Create([
+        new ServicePromptDefinition(
+            "update_user",
+            "Update one user",
+            "Use UpdateUser for {{userId}}.",
+            arguments: [new ServicePromptArgumentDefinition("userId", null, true)]
+        ),
+    ])
+    .Single()
+    .ProtocolPrompt;
+if (mcpPrompt.Name != "update_user" || mcpPrompt.Arguments?.Single().Name != "userId")
+{
+    throw new InvalidOperationException("MCP NativeAOT prompt projection failed.");
+}
+
 internal sealed record AotInput(
     string UserId,
     string? RequestToken,

--- a/tests/NSmithy.Tests/Server/Mcp/SmithyMcpPromptsTests.cs
+++ b/tests/NSmithy.Tests/Server/Mcp/SmithyMcpPromptsTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using NSmithy.Server;
+using NSmithy.Server.Mcp;
+
+namespace NSmithy.Tests.Server.Mcp;
+
+public sealed class SmithyMcpPromptsTests
+{
+    [Fact]
+    public async Task CreatesPromptMetadataAndRendersTemplate()
+    {
+        var prompt = Assert.Single(SmithyMcpPrompts.Create([WeatherBrief]));
+
+        Assert.Equal("weather_brief", prompt.ProtocolPrompt.Name);
+        Assert.Equal("Create a concise weather brief", prompt.ProtocolPrompt.Description);
+        var arguments = prompt.ProtocolPrompt.Arguments!;
+        Assert.Equal(2, arguments.Count);
+        Assert.Equal("location", arguments[0].Name);
+        Assert.Equal("City or coordinates.", arguments[0].Description);
+        Assert.True(arguments[0].Required);
+        Assert.Equal("style", arguments[1].Name);
+        Assert.False(arguments[1].Required);
+
+        var result = await InvokeAsync(
+            prompt,
+            new Dictionary<string, JsonElement>
+            {
+                ["location"] = JsonSerializer.SerializeToElement("Zurich"),
+                ["style"] = JsonSerializer.SerializeToElement("three sentences"),
+            }
+        );
+
+        Assert.Equal("Create a concise weather brief", result.Description);
+        var message = Assert.Single(result.Messages);
+        Assert.Equal(Role.User, message.Role);
+        Assert.Equal(
+            "Call GetForecast for Zurich and summarize it in three sentences."
+                + "\n\nTool preference: The user wants a short weather summary",
+            Assert.IsType<TextContentBlock>(message.Content).Text
+        );
+    }
+
+    [Fact]
+    public async Task ReplacesMissingOptionalArgumentsWithEmptyText()
+    {
+        var prompt = Assert.Single(SmithyMcpPrompts.Create([WeatherBrief]));
+
+        var result = await InvokeAsync(
+            prompt,
+            new Dictionary<string, JsonElement>
+            {
+                ["location"] = JsonSerializer.SerializeToElement("Zurich"),
+            }
+        );
+
+        Assert.StartsWith(
+            "Call GetForecast for Zurich and summarize it in .",
+            Assert.IsType<TextContentBlock>(Assert.Single(result.Messages).Content).Text,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public async Task RejectsMissingUnknownAndNonStringArguments()
+    {
+        var prompt = Assert.Single(SmithyMcpPrompts.Create([WeatherBrief]));
+
+        var missing = await Assert.ThrowsAsync<McpProtocolException>(async () =>
+            await InvokeAsync(prompt, null)
+        );
+        var unknown = await Assert.ThrowsAsync<McpProtocolException>(async () =>
+            await InvokeAsync(
+                prompt,
+                new Dictionary<string, JsonElement>
+                {
+                    ["location"] = JsonSerializer.SerializeToElement("Zurich"),
+                    ["extra"] = JsonSerializer.SerializeToElement("unused"),
+                }
+            )
+        );
+        var nonString = await Assert.ThrowsAsync<McpProtocolException>(async () =>
+            await InvokeAsync(
+                prompt,
+                new Dictionary<string, JsonElement>
+                {
+                    ["location"] = JsonSerializer.SerializeToElement(42),
+                }
+            )
+        );
+
+        Assert.Equal(McpErrorCode.InvalidParams, missing.ErrorCode);
+        Assert.Contains("requires argument 'location'", missing.Message, StringComparison.Ordinal);
+        Assert.Contains(
+            "does not declare argument 'extra'",
+            unknown.Message,
+            StringComparison.Ordinal
+        );
+        Assert.Contains("must be a string", nonString.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectsPromptNamesThatDifferOnlyByCase()
+    {
+        var duplicate = new ServicePromptDefinition("Weather_Brief", "Duplicate", "Duplicate");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            SmithyMcpPrompts.Create([WeatherBrief, duplicate])
+        );
+
+        Assert.Contains("without regard to case", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RegistersPromptsWithTheOfficialMcpBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer().WithSmithyPrompts([WeatherBrief]);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Single(provider.GetServices<McpServerPrompt>());
+    }
+
+    private static async Task<GetPromptResult> InvokeAsync(
+        McpServerPrompt prompt,
+        IDictionary<string, JsonElement>? arguments
+    )
+    {
+        await using var server = McpServer.Create(
+            new StreamServerTransport(new MemoryStream(), new MemoryStream()),
+            new McpServerOptions()
+        );
+        var context = new RequestContext<GetPromptRequestParams>(
+            server,
+            new JsonRpcRequest { Id = new RequestId(1), Method = RequestMethods.PromptsGet },
+            new GetPromptRequestParams { Name = prompt.ProtocolPrompt.Name, Arguments = arguments }
+        );
+        return await prompt.GetAsync(context);
+    }
+
+    private static readonly ServicePromptDefinition WeatherBrief = new(
+        "weather_brief",
+        "Create a concise weather brief",
+        "Call GetForecast for {{location}} and summarize it in {{style}}.",
+        "The user wants a short weather summary",
+        [
+            new ServicePromptArgumentDefinition("location", "City or coordinates.", true),
+            new ServicePromptArgumentDefinition("style", null, false),
+        ]
+    );
+}

--- a/tests/NSmithy.Tests/Server/Mcp/SmithyMcpToolsTests.cs
+++ b/tests/NSmithy.Tests/Server/Mcp/SmithyMcpToolsTests.cs
@@ -223,19 +223,18 @@ public sealed class SmithyMcpToolsTests
     }
 
     [Fact]
-    public void ResolvesCatalogFromDependencyInjection()
+    public void ResolvesGeneratedServiceDefinitionWithoutAnAggregateHandler()
     {
         var services = new ServiceCollection();
-        services.AddSingleton(Catalog(static (_, _) => Task.FromResult(new LookupOutput("sunny"))));
-        services
-            .AddMcpServer()
-            .WithSmithyTools(serviceProvider =>
-                serviceProvider.GetRequiredService<ServiceOperationCatalog>()
-            );
+        services.AddSingleton<LookupHandler>();
+        services.AddSingleton<IServiceDefinition, LookupServiceDefinition>();
+        services.AddMcpServer().WithSmithyService(ServiceSchema);
 
         using var provider = services.BuildServiceProvider();
         var options = provider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
         Assert.Single(options.ToolCollection!);
+        Assert.Single(options.PromptCollection!);
     }
 
     private static ServiceOperationCatalog Catalog(
@@ -374,5 +373,26 @@ public sealed class SmithyMcpToolsTests
     private sealed class LookupFailureBuilder
     {
         public string? Message { get; set; }
+    }
+
+    private sealed class LookupHandler
+    {
+        private readonly string suffix = string.Empty;
+
+        public Task<LookupOutput> InvokeAsync(
+            LookupInput input,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(new LookupOutput(input.Place + suffix));
+    }
+
+    private sealed class LookupServiceDefinition : IServiceDefinition
+    {
+        public ServiceSchema Schema => ServiceSchema;
+
+        public IReadOnlyList<ServicePromptDefinition> Prompts { get; } =
+        [new("weather_brief", "Create a weather brief", "Call LookupWeather.")];
+
+        public ServiceOperationCatalog CreateOperationCatalog(IServiceProvider services) =>
+            Catalog(services.GetRequiredService<LookupHandler>().InvokeAsync);
     }
 }

--- a/website/src/content/docs/servers/index.md
+++ b/website/src/content/docs/servers/index.md
@@ -51,6 +51,7 @@ convenience, not a requirement. If you'd rather split operations across classes
 `AddWeatherServiceHandler`:
 
 ```csharp
+builder.Services.AddWeatherService();
 builder.Services.AddSingleton<IGetCityHandler, GetCityHandler>();
 builder.Services.AddSingleton<IListCitiesHandler, ListCitiesHandler>();
 // …one registration per operation the mapped protocol serves
@@ -58,7 +59,8 @@ builder.Services.AddSingleton<IListCitiesHandler, ListCitiesHandler>();
 
 Each mapped route picks up its operation's handler independently. As long as
 every operation the protocol maps has a registration, the service is fully
-served.
+served. `AddWeatherService` registers generated service-level metadata used by
+adapters such as MCP; `AddWeatherServiceHandler` calls it automatically.
 
 ## Map the endpoints
 

--- a/website/src/content/docs/servers/mcp.md
+++ b/website/src/content/docs/servers/mcp.md
@@ -4,14 +4,13 @@ description: Expose generated Smithy services through Model Context Protocol wit
 ---
 
 `NSmithy.Server.Mcp` exposes generated services through the
-[Model Context Protocol](https://modelcontextprotocol.io/). It currently maps
-unary operations to MCP tools. Support for prompts modeled with
-`smithy.ai#prompts` is planned next.
+[Model Context Protocol](https://modelcontextprotocol.io/). It maps unary
+operations to MCP tools and `smithy.ai#prompts` traits to MCP prompts.
 
 | MCP capability | NSmithy support |
 | --- | --- |
 | Tools | Generated from unary operations |
-| Prompts | Planned from `smithy.ai#prompts` |
+| Prompts | Generated from `smithy.ai#prompts` on services and operations |
 | Resources | Not currently generated |
 
 The package integrates with the official
@@ -28,16 +27,10 @@ provided by that SDK.
 The package brings in the MCP server hosting APIs and the NSmithy JSON and
 server runtimes.
 
-## Tools
+## Register a Generated Service
 
-The tools adapter uses generated JSON Schema 2020-12 documents, JSON codecs,
-constraint validation, and typed handlers shared with the other NSmithy server
-surfaces.
-
-### Register Generated Operations
-
-Register the generated handler as usual, then give its generated operation
-catalog to `WithSmithyTools`:
+Register the generated handler as usual, then select the service by its generated
+schema. This exposes its tools and prompts together:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -50,23 +43,31 @@ builder.Services.AddWeatherServiceHandler<WeatherHandler>();
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()
-    .WithSmithyTools<IWeatherServiceHandler>(handler =>
-        handler.CreateWeatherServiceOperationCatalog()
-    );
+    .WithSmithyService(WeatherSchema.Schema);
 
 await builder.Build().RunAsync();
 ```
 
-The dependency-injection overload resolves the generated aggregate handler when
-the MCP server is configured. An existing catalog can also be registered
-directly:
+`AddWeatherServiceHandler` also registers the generated service definition.
+That definition resolves each operation through its per-operation handler
+interface, so MCP does not require an aggregate handler. For separately
+implemented operation handlers, register the service definition explicitly:
 
 ```csharp
-builder.Services
-    .AddMcpServer()
-    .WithStdioServerTransport()
-    .WithSmithyTools(handler.CreateWeatherServiceOperationCatalog());
+builder.Services.AddWeatherService();
+builder.Services.AddSingleton<IGetCityHandler, GetCityHandler>();
+builder.Services.AddSingleton<IGetForecastHandler, GetForecastHandler>();
+// Register the remaining operation handlers exposed by the service.
 ```
+
+`WithSmithyService` is explicit: registering a service or its handlers in DI
+does not expose it to MCP until its schema is selected.
+
+## Tools
+
+The tools adapter uses generated JSON Schema 2020-12 documents, JSON codecs,
+constraint validation, and typed handlers shared with the other NSmithy server
+surfaces.
 
 ### Operation Mapping
 
@@ -97,9 +98,65 @@ such as OpenAPI.
 Streaming operations are omitted because an MCP tool call has one JSON argument
 object and one result.
 
+An application that builds its own `ServiceOperationCatalog` can expose only
+that catalog with `WithSmithyTools(catalog)`. This is the low-level escape hatch;
+generated services normally use `WithSmithyService`.
+
+## Prompts
+
+Add `smithy.ai#prompts` to a service or operation:
+
+```smithy
+use smithy.ai#prompts
+
+@prompts({
+    city_weather_brief: {
+        description: "Create a weather brief for a city"
+        template: "Use GetCity and GetForecast for city ID {{cityId}}, then summarize the result."
+        arguments: CityWeatherBriefArguments
+        preferWhen: "The user asks for a combined city and weather overview"
+    }
+})
+service Weather {
+    version: "2006-03-01"
+    operations: [GetCity, GetForecast]
+}
+
+structure CityWeatherBriefArguments {
+    /// City ID accepted by the Weather service.
+    @required
+    cityId: String
+}
+```
+
+The generated MCP prompt has the name `city_weather_brief`, its modeled
+description, and a required string argument named `cityId`. Resolving it with
+`cityId = "SEA"` returns this user message:
+
+```text
+Use GetCity and GetForecast for city ID SEA, then summarize the result.
+
+Tool preference: The user asks for a combined city and weather overview
+```
+
+A template is text with `{{argumentName}}` placeholders. NSmithy substitutes
+the MCP prompt arguments and returns the rendered text to the client. It does
+not call either operation itself. The instructions establish the relationship:
+the model sees the rendered prompt and the available MCP tools, then decides
+whether and how to invoke `GetCity` and `GetForecast`. One prompt can therefore
+guide zero, one, or several tool calls.
+
+Prompt names must be unique within the generated service when compared without
+regard to case. Required and optional status plus argument documentation come
+from the referenced Smithy structure. Unknown arguments, non-string values, and
+missing required arguments produce MCP `InvalidParams` errors.
+
+Handwritten prompt definitions can be registered directly with
+`WithSmithyPrompts(definitions)`, independently of generated service tools.
+
 The [restJson1 Weather example](https://github.com/thomaslaich/smithy-dotnet/tree/main/examples/restjson1)
 runs the same generated service and handler as either an ASP.NET Core server or
-an MCP stdio server.
+an MCP stdio server, and includes both single-tool and multi-tool prompts.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- generate transport-neutral service definitions with prompt metadata and per-operation handler resolution
- expose generated tools and prompts through the explicit WithSmithyService API
- render and validate smithy.ai prompt arguments through the MCP C# SDK
- update the restJson1 example with single-tool and multi-tool prompts plus MCP client setup
- remove the superseded aggregate catalog factory and lambda registration overloads

## Verification

- just build
- just test
- just refresh-examples
- just check-format

Closes #121