### PR TITLE
refactor: centralize C# symbol imports and shorten type references

### DIFF
--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
@@ -78,12 +78,6 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
         .build();
   }
 
-  /** A *qualified* type expression for use in inline generic args: "ns.Name" or "Name". */
-  public static String qualified(Symbol s) {
-    String ns = s.getNamespace();
-    return (ns == null || ns.isEmpty()) ? s.getName() : ns + "." + s.getName();
-  }
-
   @Override
   public Symbol blobShape(BlobShape s) {
     return primitive("", "byte[]", false);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
@@ -135,7 +135,7 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
 
   @Override
   public Symbol timestampShape(TimestampShape s) {
-    return primitive("", "System.DateTimeOffset", true);
+    return primitive("System", "DateTimeOffset", true);
   }
 
   @Override

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/CSharpSymbolProvider.java
@@ -58,26 +58,6 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
     return CSharpNaming.propertyName(shape.getMemberName());
   }
 
-  private Symbol primitive(String namespace, String name, boolean isValueType) {
-    return Symbol.builder()
-        .name(name)
-        .namespace(namespace, ".")
-        .putProperty(SymbolProperties.IS_VALUE_TYPE, isValueType)
-        .build();
-  }
-
-  /** Generated user-defined shape: lives in the per-shape C# namespace, has its own .cs file. */
-  private Symbol generated(Shape shape, String typeName) {
-    String csNamespace = settings.csharpNamespace(shape.getId().getNamespace());
-    String file = csNamespace.replace('.', '/') + "/" + typeName + ".g.cs";
-    return Symbol.builder()
-        .name(typeName)
-        .namespace(csNamespace, ".")
-        .definitionFile(file)
-        .putProperty(SymbolProperties.IS_VALUE_TYPE, false)
-        .build();
-  }
-
   @Override
   public Symbol blobShape(BlobShape s) {
     return primitive("", "byte[]", false);
@@ -120,7 +100,9 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
 
   @Override
   public Symbol bigIntegerShape(BigIntegerShape s) {
-    return primitive("System.Numerics", "BigInteger", true);
+    return RuntimeTypes.BIG_INTEGER.toBuilder()
+        .putProperty(SymbolProperties.IS_VALUE_TYPE, true)
+        .build();
   }
 
   @Override
@@ -135,12 +117,16 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
 
   @Override
   public Symbol timestampShape(TimestampShape s) {
-    return primitive("System", "DateTimeOffset", true);
+    return RuntimeTypes.DATE_TIME_OFFSET.toBuilder()
+        .putProperty(SymbolProperties.IS_VALUE_TYPE, true)
+        .build();
   }
 
   @Override
   public Symbol documentShape(DocumentShape s) {
-    return primitive(RuntimeTypes.NSMITHY_CORE, "Document", false);
+    return RuntimeTypes.DOCUMENT.toBuilder()
+        .putProperty(SymbolProperties.IS_VALUE_TYPE, false)
+        .build();
   }
 
   @Override
@@ -159,12 +145,16 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
     // so union members and other references agree with Schemas.Unit
     // (Schema<SmithyUnit>).
     if (ShapeSupport.isUnit(s.getId())) {
-      return primitive(RuntimeTypes.NSMITHY_CORE, "SmithyUnit", true);
+      return RuntimeTypes.SMITHY_UNIT.toBuilder()
+          .putProperty(SymbolProperties.IS_VALUE_TYPE, true)
+          .build();
     }
     // The server runtime throws this one itself, so a model that declares it must bind to the
     // runtime's type — a generated copy would be a different type the runtime never throws.
     if (ShapeSupport.isValidationException(s.getId())) {
-      return primitive(RuntimeTypes.NSMITHY_CORE_VALIDATION, "ValidationException", false);
+      return RuntimeTypes.VALIDATION_EXCEPTION.toBuilder()
+          .putProperty(SymbolProperties.IS_VALUE_TYPE, false)
+          .build();
     }
     return generated(s, CSharpNaming.typeName(s.getId().getName()));
   }
@@ -204,5 +194,25 @@ public final class CSharpSymbolProvider implements SymbolProvider, ShapeVisitor<
   @Override
   public Symbol resourceShape(ResourceShape s) {
     return generated(s, CSharpNaming.typeName(s.getId().getName()));
+  }
+
+  private Symbol primitive(String namespace, String name, boolean isValueType) {
+    return Symbol.builder()
+        .name(name)
+        .namespace(namespace, ".")
+        .putProperty(SymbolProperties.IS_VALUE_TYPE, isValueType)
+        .build();
+  }
+
+  /** Generated user-defined shape: lives in the per-shape C# namespace, has its own .cs file. */
+  private Symbol generated(Shape shape, String typeName) {
+    String csNamespace = settings.csharpNamespace(shape.getId().getNamespace());
+    String file = csNamespace.replace('.', '/') + "/" + typeName + ".g.cs";
+    return Symbol.builder()
+        .name(typeName)
+        .namespace(csNamespace, ".")
+        .definitionFile(file)
+        .putProperty(SymbolProperties.IS_VALUE_TYPE, false)
+        .build();
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/DirectedCSharpCodegen.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/DirectedCSharpCodegen.java
@@ -54,7 +54,12 @@ final class DirectedCSharpCodegen
         .settings(directive.settings())
         .symbolProvider(directive.symbolProvider())
         .fileManifest(directive.fileManifest())
-        .writerDelegator(new CSharpDelegator(directive.fileManifest(), directive.symbolProvider()))
+        .writerDelegator(
+            new CSharpDelegator(
+                directive.fileManifest(),
+                directive.symbolProvider(),
+                directive.model(),
+                directive.settings()))
         .integrations(directive.integrations().stream().toList())
         .build();
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/RuntimeTypes.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/RuntimeTypes.java
@@ -1,49 +1,148 @@
-/*
- * Centralised C# runtime namespaces / type names that the generated code
- * references. Prevents typos from leaking into generators.
- */
+/* External C# types referenced by generated code. */
 package io.github.thomaslaich.nsmithy.csharp.codegen;
 
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
 public final class RuntimeTypes {
-  public static final String NSMITHY_CORE = "NSmithy.Core";
-  public static final String NSMITHY_CORE_ANNOTATIONS = "NSmithy.Core.Annotations";
-  public static final String NSMITHY_CORE_SERDE = "NSmithy.Core.Serde";
-  public static final String NSMITHY_CORE_VALIDATION = "NSmithy.Core.Validation";
-  public static final String NSMITHY_CLIENT = "NSmithy.Client";
-  public static final String NSMITHY_PROTOCOLS_AWSJSON = "NSmithy.Protocols.AwsJson";
-  public static final String NSMITHY_PROTOCOLS_AWSQUERY = "NSmithy.Protocols.AwsQuery";
-  public static final String NSMITHY_PROTOCOLS_RESTJSON = "NSmithy.Protocols.RestJson";
-  public static final String NSMITHY_PROTOCOLS_RESTXML = "NSmithy.Protocols.RestXml";
-  public static final String NSMITHY_PROTOCOLS_RPCV2CBOR = "NSmithy.Protocols.RpcV2Cbor";
-  public static final String NSMITHY_PROTOCOLS_GRPC = "NSmithy.Protocols.Grpc";
-  public static final String NSMITHY_HTTP = "NSmithy.Http";
-  public static final String NSMITHY_CODECS_JSON = "NSmithy.Codecs.Json";
-  public static final String NSMITHY_CODECS_XML = "NSmithy.Codecs.Xml";
-  public static final String NSMITHY_CODECS_CBOR = "NSmithy.Codecs.Cbor";
-  public static final String NSMITHY_CODECS_PROTO = "NSmithy.Codecs.Proto";
-  public static final String NSMITHY_SERVER = "NSmithy.Server";
-  public static final String NSMITHY_SERVER_ASPNETCORE = "NSmithy.Server.AspNetCore";
+  // System
+  public static final Symbol ACTION = type("System.Action");
+  public static final Symbol ARGUMENT_NULL_EXCEPTION = type("System.ArgumentNullException");
+  public static final Symbol ARGUMENT_OUT_OF_RANGE_EXCEPTION =
+      type("System.ArgumentOutOfRangeException");
+  public static final Symbol ARRAY = type("System.Array");
+  public static final Symbol BIG_INTEGER = type("System.Numerics.BigInteger");
+  public static final Symbol CANCELLATION_TOKEN = type("System.Threading.CancellationToken");
+  public static final Symbol CONVERT = type("System.Convert");
+  public static final Symbol CULTURE_INFO = type("System.Globalization.CultureInfo");
+  public static final Symbol DATE_TIME_OFFSET = type("System.DateTimeOffset");
+  public static final Symbol DICTIONARY = type("System.Collections.Generic.Dictionary");
+  public static final Symbol ENCODING = type("System.Text.Encoding");
+  public static final Symbol ENUMERABLE = type("System.Linq.Enumerable");
+  public static final Symbol ENUMERATOR_CANCELLATION_ATTRIBUTE =
+      type("System.Runtime.CompilerServices.EnumeratorCancellationAttribute");
+  public static final Symbol EXCEPTION = type("System.Exception");
+  public static final Symbol FLAGS_ATTRIBUTE = type("System.FlagsAttribute");
+  public static final Symbol FUNC = type("System.Func");
+  public static final Symbol GUID = type("System.Guid");
+  public static final Symbol HASH_SET = type("System.Collections.Generic.HashSet");
+  public static final Symbol HTTP_CLIENT = type("System.Net.Http.HttpClient");
+  public static final Symbol HTTP_VERSION = type("System.Net.HttpVersion");
+  public static final Symbol INVALID_OPERATION_EXCEPTION = type("System.InvalidOperationException");
+  public static final Symbol I_ASYNC_ENUMERABLE =
+      type("System.Collections.Generic.IAsyncEnumerable");
+  public static final Symbol I_DISPOSABLE = type("System.IDisposable");
+  public static final Symbol I_ENUMERABLE = type("System.Collections.Generic.IEnumerable");
+  public static final Symbol I_READ_ONLY_DICTIONARY =
+      type("System.Collections.Generic.IReadOnlyDictionary");
+  public static final Symbol I_READ_ONLY_LIST = type("System.Collections.Generic.IReadOnlyList");
+  public static final Symbol LIST = type("System.Collections.Generic.List");
+  public static final Symbol MEMORY_STREAM = type("System.IO.MemoryStream");
+  public static final Symbol NOT_SUPPORTED_EXCEPTION = type("System.NotSupportedException");
+  public static final Symbol READ_ONLY_DICTIONARY =
+      type("System.Collections.ObjectModel.ReadOnlyDictionary");
+  public static final Symbol STREAM = type("System.IO.Stream");
+  public static final Symbol STRING_COMPARER = type("System.StringComparer");
+  public static final Symbol TASK = type("System.Threading.Tasks.Task");
+  public static final Symbol URI = type("System.Uri");
 
+  // NSmithy models and serialization
+  public static final Symbol DOCUMENT = type("NSmithy.Core.Document");
+  public static final Symbol I_SMITHY_RETRYABLE_ERROR = type("NSmithy.Core.ISmithyRetryableError");
+  public static final Symbol I_STRING_ENUM_VALUE = type("NSmithy.Core.Serde.IStringEnumValue");
+  public static final Symbol I_STRUCT_MEMBER_WRITER =
+      type("NSmithy.Core.Serde.IStructMemberWriter");
+  public static final Symbol I_STRUCT_VALUE_SERIALIZER =
+      type("NSmithy.Core.Serde.IStructValueSerializer");
+  public static final Symbol MISSING_REQUIRED_MEMBER_EXCEPTION =
+      type("NSmithy.Core.Serde.MissingRequiredMemberException");
+  public static final Symbol OPERATION_SCHEMA = type("NSmithy.Core.Serde.OperationSchema");
+  public static final Symbol SCHEMA = type("NSmithy.Core.Serde.Schema");
+  public static final Symbol SCHEMAS = type("NSmithy.Core.Serde.Schemas");
+  public static final Symbol SERVICE_SCHEMA = type("NSmithy.Core.Serde.ServiceSchema");
+  public static final Symbol SHAPE_ID = type("NSmithy.Core.ShapeId");
+  public static final Symbol SMITHY_UNIT = type("NSmithy.Core.SmithyUnit");
+  public static final Symbol TRAIT = type("NSmithy.Core.Trait");
+  public static final Symbol VALIDATION_EXCEPTION =
+      type("NSmithy.Core.Validation.ValidationException");
+
+  // NSmithy clients and HTTP
+  public static final Symbol I_SERVER_OPERATION_PROTOCOL =
+      type("NSmithy.Http.IServerOperationProtocol");
+  public static final Symbol I_SERVICE_PROTOCOL = type("NSmithy.Http.IServiceProtocol");
+  public static final Symbol SMITHY_CLIENT_CONFIG = type("NSmithy.Client.SmithyClientConfig");
+  public static final Symbol SMITHY_CLIENT_RUNTIME = type("NSmithy.Client.SmithyClientRuntime");
+  public static final Symbol SMITHY_HOST_LABEL = type("NSmithy.Client.SmithyHostLabel");
+  public static final Symbol SMITHY_HOST_PREFIX = type("NSmithy.Client.SmithyHostPrefix");
+  public static final Symbol SMITHY_HTTP_CLIENT_ENVIRONMENT =
+      type("NSmithy.Client.SmithyHttpClientEnvironment");
+  public static final Symbol SMITHY_HTTP_VERSION_PREFERENCE =
+      type("NSmithy.Http.SmithyHttpVersionPreference");
+  public static final Symbol SMITHY_OPERATION_BINDING =
+      type("NSmithy.Client.SmithyOperationBinding");
+
+  // NSmithy servers
+  public static final Symbol I_SERVICE_DEFINITION = type("NSmithy.Server.IServiceDefinition");
+  public static final Symbol OPERATION_JSON_SCHEMAS = type("NSmithy.Server.OperationJsonSchemas");
+  public static final Symbol SERVICE_OPERATION = type("NSmithy.Server.ServiceOperation");
+  public static final Symbol SERVICE_OPERATION_CATALOG =
+      type("NSmithy.Server.ServiceOperationCatalog");
+  public static final Symbol SERVICE_PROMPT_ARGUMENT_DEFINITION =
+      type("NSmithy.Server.ServicePromptArgumentDefinition");
+  public static final Symbol SERVICE_PROMPT_DEFINITION =
+      type("NSmithy.Server.ServicePromptDefinition");
+  public static final Symbol SMITHY_ASP_NET_CORE_HOST =
+      type("NSmithy.Server.AspNetCore.SmithyAspNetCoreHost");
+  public static final Symbol SMITHY_SERVER_RUNTIME = type("NSmithy.Server.SmithyServerRuntime");
+
+  // NSmithy protocols and AWS support
+  public static final Symbol AWS_JSON10_PROTOCOL =
+      type("NSmithy.Protocols.AwsJson.AwsJson10Protocol");
+  public static final Symbol AWS_JSON11_PROTOCOL =
+      type("NSmithy.Protocols.AwsJson.AwsJson11Protocol");
+  public static final Symbol AWS_QUERY_PROTOCOL =
+      type("NSmithy.Protocols.AwsQuery.AwsQueryProtocol");
+  public static final Symbol EC2_QUERY_PROTOCOL =
+      type("NSmithy.Protocols.AwsQuery.Ec2QueryProtocol");
+  public static final Symbol GLACIER_INTERCEPTOR = type("NSmithy.Aws.GlacierInterceptor");
+  public static final Symbol GRPC_PROTOCOL = type("NSmithy.Protocols.Grpc.GrpcProtocol");
+  public static final Symbol REST_JSON1_PROTOCOL =
+      type("NSmithy.Protocols.RestJson.RestJson1Protocol");
+  public static final Symbol REST_XML_PROTOCOL = type("NSmithy.Protocols.RestXml.RestXmlProtocol");
+  public static final Symbol RPC_V2_CBOR_PROTOCOL =
+      type("NSmithy.Protocols.RpcV2Cbor.RpcV2CborProtocol");
+  public static final Symbol SIMPLE_REST_JSON_PROTOCOL =
+      type("NSmithy.Protocols.RestJson.SimpleRestJsonProtocol");
+
+  // ASP.NET Core and dependency injection
+  public static final Symbol FROM_SERVICES_ATTRIBUTE =
+      type("Microsoft.AspNetCore.Mvc.FromServicesAttribute");
+  public static final Symbol HTTP_CONTEXT = type("Microsoft.AspNetCore.Http.HttpContext");
+  public static final Symbol I_ENDPOINT_ROUTE_BUILDER =
+      type("Microsoft.AspNetCore.Routing.IEndpointRouteBuilder");
+  public static final Symbol I_HTTP_CLIENT_BUILDER =
+      type("Microsoft.Extensions.DependencyInjection.IHttpClientBuilder");
+  public static final Symbol I_SERVICE_COLLECTION =
+      type("Microsoft.Extensions.DependencyInjection.IServiceCollection");
+  public static final Symbol SERVICE_DESCRIPTOR =
+      type("Microsoft.Extensions.DependencyInjection.ServiceDescriptor");
+
+  // Namespace imports required for extension-method lookup.
   public static final String MS_EXT_DI = "Microsoft.Extensions.DependencyInjection";
   public static final String MS_EXT_DI_EXTENSIONS =
       "Microsoft.Extensions.DependencyInjection.Extensions";
   public static final String MS_ASPNETCORE_BUILDER = "Microsoft.AspNetCore.Builder";
-  public static final String MS_ASPNETCORE_HTTP = "Microsoft.AspNetCore.Http";
-  public static final String MS_ASPNETCORE_ROUTING = "Microsoft.AspNetCore.Routing";
 
-  public static final String GRPC_CORE = "Grpc.Core";
-  public static final String GOOGLE_PROTOBUF_WELLKNOWN = "Google.Protobuf.WellKnownTypes";
-
-  public static final String SYSTEM = "System";
-  public static final String SYSTEM_COLLECTIONS_GENERIC = "System.Collections.Generic";
-  public static final String SYSTEM_NET = "System.Net";
-  public static final String SYSTEM_NET_HTTP = "System.Net.Http";
-  public static final String SYSTEM_TEXT = "System.Text";
-  public static final String SYSTEM_THREADING = "System.Threading";
-  public static final String SYSTEM_THREADING_TASKS = "System.Threading.Tasks";
+  public static final String NSMITHY_SERVER_ASPNETCORE = "NSmithy.Server.AspNetCore";
 
   private RuntimeTypes() {}
+
+  private static Symbol type(String qualifiedName) {
+    int separator = qualifiedName.lastIndexOf('.');
+    return Symbol.builder()
+        .name(qualifiedName.substring(separator + 1))
+        .namespace(qualifiedName.substring(0, separator), ".")
+        .build();
+  }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/SymbolProperties.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/SymbolProperties.java
@@ -12,5 +12,8 @@ public final class SymbolProperties {
   /** Marks a symbol as a C# value type (struct/primitive). */
   public static final String IS_VALUE_TYPE = "isValueType";
 
+  /** Marks a type reference used as a C# attribute, permitting the short attribute spelling. */
+  public static final String IS_ATTRIBUTE = "isAttribute";
+
   private SymbolProperties() {}
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
@@ -36,6 +36,7 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
 
   public ClientDependencyInjectionGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }
@@ -55,6 +56,7 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
     String primaryProtocol = ProtocolSupport.protocolType(kinds.get(0));
     String modeledHttpVersionPreference =
         ClientGenerator.httpVersionPreferenceLiteral(
+            writer,
             ProtocolSupport.httpVersionPreference(
                 service,
                 kinds.get(0),
@@ -80,8 +82,10 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
               interfaceName);
           writer.write("public static IHttpClientBuilder Add$L(", clientName);
           writer.write("    this IServiceCollection services,");
-          writer.write("    System.Uri endpoint,");
-          writer.write("    System.Action<$LConfig>? configure = null) =>", clientName);
+          writer.write("    " + writer.frameworkType("System.Uri") + " endpoint,");
+          writer.write(
+              "    " + writer.frameworkType("System.Action") + "<$LConfig>? configure = null) =>",
+              clientName);
           writer.write(
               "    services.Add$L(client => client.BaseAddress = endpoint, configure);",
               clientName);
@@ -96,13 +100,22 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
               interfaceName);
           writer.write("public static IHttpClientBuilder Add$L(", clientName);
           writer.write("    this IServiceCollection services,");
-          writer.write("    System.Action<System.Net.Http.HttpClient>? configureClient = null,");
-          writer.write("    System.Action<$LConfig>? configure = null)", clientName);
+          writer.write(
+              "    "
+                  + writer.frameworkType("System.Action")
+                  + "<"
+                  + writer.frameworkType("System.Net.Http.HttpClient")
+                  + ">? configureClient = null,");
+          writer.write(
+              "    " + writer.frameworkType("System.Action") + "<$LConfig>? configure = null)",
+              clientName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(services);");
                 writer.write("var config = new $LConfig();", clientName);
                 writer.write("configure?.Invoke(config);");
                 writer.write("return services");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
@@ -36,7 +36,6 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
 
   public ClientDependencyInjectionGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
@@ -28,8 +28,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class ClientDependencyInjectionGenerator implements Runnable {
 
-  private static final String MS_EXT_DI = "Microsoft.Extensions.DependencyInjection";
-
   private final GenerationContext context;
   private final CSharpWriter writer;
   private final ServiceShape service;
@@ -52,7 +50,7 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
     String typeName = CSharpNaming.typeName(service.getId().getName());
     String clientName = typeName + "Client";
     String interfaceName = "I" + clientName;
-    String primaryProtocol = ProtocolSupport.protocolType(kinds.get(0));
+    String primaryProtocol = writer.typeName(ProtocolSupport.protocolType(kinds.get(0)));
     String modeledHttpVersionPreference =
         ClientGenerator.httpVersionPreferenceLiteral(
             writer,
@@ -64,9 +62,7 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
     String namespace = context.settings().csharpNamespace(service.getId().getNamespace());
     String clientKey = (namespace.isEmpty() ? "" : namespace + ".") + clientName;
 
-    writer.addImport(MS_EXT_DI);
-    writer.addImport(RuntimeTypes.NSMITHY_CLIENT);
-    writer.addImport(ProtocolSupport.runtimeProtocolNamespace(kinds.get(0)));
+    writer.addImport(RuntimeTypes.MS_EXT_DI);
 
     writer.write("public static class $LServiceCollectionExtensions", clientName);
     writer.openBlock(
@@ -79,12 +75,10 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
                   + " (IHttpClientFactory) for the given endpoint. Set the protocol, auth schemes,"
                   + " and interceptors via <paramref name=\"configure\"/>.</summary>",
               interfaceName);
-          writer.write("public static IHttpClientBuilder Add$L(", clientName);
-          writer.write("    this IServiceCollection services,");
-          writer.write("    " + writer.frameworkType("System.Uri") + " endpoint,");
-          writer.write(
-              "    " + writer.frameworkType("System.Action") + "<$LConfig>? configure = null) =>",
-              clientName);
+          writer.write("public static $T Add$L(", RuntimeTypes.I_HTTP_CLIENT_BUILDER, clientName);
+          writer.write("    this $T services,", RuntimeTypes.I_SERVICE_COLLECTION);
+          writer.write("    $T endpoint,", RuntimeTypes.URI);
+          writer.write("    $T<$LConfig>? configure = null) =>", RuntimeTypes.ACTION, clientName);
           writer.write(
               "    services.Add$L(client => client.BaseAddress = endpoint, configure);",
               clientName);
@@ -97,24 +91,16 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
                   + " via <paramref name=\"configureClient\"/>; set the protocol, auth schemes, and"
                   + " interceptors via <paramref name=\"configure\"/>.</summary>",
               interfaceName);
-          writer.write("public static IHttpClientBuilder Add$L(", clientName);
-          writer.write("    this IServiceCollection services,");
+          writer.write("public static $T Add$L(", RuntimeTypes.I_HTTP_CLIENT_BUILDER, clientName);
+          writer.write("    this $T services,", RuntimeTypes.I_SERVICE_COLLECTION);
           writer.write(
-              "    "
-                  + writer.frameworkType("System.Action")
-                  + "<"
-                  + writer.frameworkType("System.Net.Http.HttpClient")
-                  + ">? configureClient = null,");
-          writer.write(
-              "    " + writer.frameworkType("System.Action") + "<$LConfig>? configure = null)",
-              clientName);
+              "    $T<$T>? configureClient = null,", RuntimeTypes.ACTION, RuntimeTypes.HTTP_CLIENT);
+          writer.write("    $T<$LConfig>? configure = null)", RuntimeTypes.ACTION, clientName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(services);");
+                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write("var config = new $LConfig();", clientName);
                 writer.write("configure?.Invoke(config);");
                 writer.write("return services");
@@ -123,8 +109,9 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
                 writer.write("        client =>");
                 writer.write("        {");
                 writer.write(
-                    "            SmithyHttpClientEnvironment.ConfigureHttpClient(client, config,"
-                        + " static () => new $L(), $L);",
+                    "            $T.ConfigureHttpClient(client, config, static () => new $L(),"
+                        + " $L);",
+                    RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
                     primaryProtocol,
                     modeledHttpVersionPreference);
                 writer.write("            configureClient?.Invoke(client);");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientDependencyInjectionGenerator.java
@@ -50,7 +50,6 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
     String typeName = CSharpNaming.typeName(service.getId().getName());
     String clientName = typeName + "Client";
     String interfaceName = "I" + clientName;
-    String primaryProtocol = writer.typeName(ProtocolSupport.protocolType(kinds.get(0)));
     String modeledHttpVersionPreference =
         ClientGenerator.httpVersionPreferenceLiteral(
             writer,
@@ -64,63 +63,54 @@ public final class ClientDependencyInjectionGenerator implements Runnable {
 
     writer.addImport(RuntimeTypes.MS_EXT_DI);
 
-    writer.write("public static class $LServiceCollectionExtensions", clientName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          // Overload 1: endpoint (turnkey).
-          writer.write(
-              "/// <summary>Registers <see cref=\"$L\"/> as a typed HttpClient"
-                  + " (IHttpClientFactory) for the given endpoint. Set the protocol, auth schemes,"
-                  + " and interceptors via <paramref name=\"configure\"/>.</summary>",
-              interfaceName);
-          writer.write("public static $T Add$L(", RuntimeTypes.I_HTTP_CLIENT_BUILDER, clientName);
-          writer.write("    this $T services,", RuntimeTypes.I_SERVICE_COLLECTION);
-          writer.write("    $T endpoint,", RuntimeTypes.URI);
-          writer.write("    $T<$LConfig>? configure = null) =>", RuntimeTypes.ACTION, clientName);
-          writer.write(
-              "    services.Add$L(client => client.BaseAddress = endpoint, configure);",
-              clientName);
-          writer.write("");
+    writer.pushState();
+    try {
+      writer.putContext("client", clientName);
+      writer.putContext("clientInterface", interfaceName);
+      writer.putContext("clientKey", CSharpNaming.formatString(clientKey));
+      writer.putContext("protocol", ProtocolSupport.protocolType(kinds.get(0)));
+      writer.putContext("httpVersionPreference", modeledHttpVersionPreference);
+      writer.putContext("httpClientBuilder", RuntimeTypes.I_HTTP_CLIENT_BUILDER);
+      writer.putContext("serviceCollection", RuntimeTypes.I_SERVICE_COLLECTION);
+      writer.putContext("uri", RuntimeTypes.URI);
+      writer.putContext("action", RuntimeTypes.ACTION);
+      writer.putContext("httpClient", RuntimeTypes.HTTP_CLIENT);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("httpClientEnvironment", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
+      writer.write(
+          """
+          public static class ${client:L}ServiceCollectionExtensions
+          {
+              /// <summary>Registers <see cref="${clientInterface:L}"/> as a typed HttpClient (IHttpClientFactory) for the given endpoint. Set the protocol, auth schemes, and interceptors via <paramref name="configure"/>.</summary>
+              public static ${httpClientBuilder:T} Add${client:L}(
+                  this ${serviceCollection:T} services,
+                  ${uri:T} endpoint,
+                  ${action:T}<${client:L}Config>? configure = null) =>
+                  services.Add${client:L}(client => client.BaseAddress = endpoint, configure);
 
-          // Overload 2: configure callbacks (Refit-style HttpClient setup + client config).
-          writer.write(
-              "/// <summary>Registers <see cref=\"$L\"/> as a typed HttpClient"
-                  + " (IHttpClientFactory). Configure the HttpClient (at minimum its BaseAddress)"
-                  + " via <paramref name=\"configureClient\"/>; set the protocol, auth schemes, and"
-                  + " interceptors via <paramref name=\"configure\"/>.</summary>",
-              interfaceName);
-          writer.write("public static $T Add$L(", RuntimeTypes.I_HTTP_CLIENT_BUILDER, clientName);
-          writer.write("    this $T services,", RuntimeTypes.I_SERVICE_COLLECTION);
-          writer.write(
-              "    $T<$T>? configureClient = null,", RuntimeTypes.ACTION, RuntimeTypes.HTTP_CLIENT);
-          writer.write("    $T<$LConfig>? configure = null)", RuntimeTypes.ACTION, clientName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write("var config = new $LConfig();", clientName);
-                writer.write("configure?.Invoke(config);");
-                writer.write("return services");
-                writer.write("    .AddHttpClient(");
-                writer.write("        $L,", CSharpNaming.formatString(clientKey));
-                writer.write("        client =>");
-                writer.write("        {");
-                writer.write(
-                    "            $T.ConfigureHttpClient(client, config, static () => new $L(),"
-                        + " $L);",
-                    RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
-                    primaryProtocol,
-                    modeledHttpVersionPreference);
-                writer.write("            configureClient?.Invoke(client);");
-                writer.write("        })");
-                writer.write(
-                    "    .AddTypedClient<$L>((httpClient, _) => new $L(httpClient, config));",
-                    interfaceName,
-                    clientName);
-              });
-        });
+              /// <summary>Registers <see cref="${clientInterface:L}"/> as a typed HttpClient (IHttpClientFactory). Configure the HttpClient (at minimum its BaseAddress) via <paramref name="configureClient"/>; set the protocol, auth schemes, and interceptors via <paramref name="configure"/>.</summary>
+              public static ${httpClientBuilder:T} Add${client:L}(
+                  this ${serviceCollection:T} services,
+                  ${action:T}<${httpClient:T}>? configureClient = null,
+                  ${action:T}<${client:L}Config>? configure = null)
+              {
+                  ${argumentNullException:T}.ThrowIfNull(services);
+                  var config = new ${client:L}Config();
+                  configure?.Invoke(config);
+                  return services
+                      .AddHttpClient(
+                          ${clientKey:L},
+                          client =>
+                          {
+                              ${httpClientEnvironment:T}.ConfigureHttpClient(client, config, static () => new ${protocol:T}(), ${httpVersionPreference:L});
+                              configureClient?.Invoke(client);
+                          })
+                      .AddTypedClient<${clientInterface:L}>((httpClient, _) => new ${client:L}(httpClient, config));
+              }
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -45,7 +45,6 @@ public final class ClientGenerator implements Runnable {
 
   public ClientGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -62,15 +62,12 @@ public final class ClientGenerator implements Runnable {
       operations.forEach(op -> ShapeSupport.requireGrpcEventStreamWrapperIsFlattenable(model, op));
     }
 
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-
     String typeName = CSharpNaming.typeName(service.getId().getName()) + "Client";
     String interfaceName = "I" + typeName;
 
     // Interface — IDisposable so a client that owns its HttpClient is released via `using` or DI.
     writer.writeXmlDocs(service);
-    writer.write(
-        "public interface $L : " + writer.frameworkType("System.IDisposable"), interfaceName);
+    writer.write("public interface $L : $T", interfaceName, RuntimeTypes.I_DISPOSABLE);
     writer.openBlock(
         "{",
         "}",
@@ -100,14 +97,150 @@ public final class ClientGenerator implements Runnable {
       return;
     }
 
-    writer.addImport(RuntimeTypes.NSMITHY_CLIENT);
-    writer.addImport(RuntimeTypes.NSMITHY_HTTP);
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
     // The generated client only names the primary protocol (the default constructor argument);
     // callers selecting another declared protocol reference its namespace from their own code.
-    writer.addImport(ProtocolSupport.runtimeProtocolNamespace(kinds.get(0)));
 
     writeClient(model, operations, typeName, interfaceName, kinds);
+  }
+
+  static String httpVersionPreferenceLiteral(
+      CSharpWriter writer, Optional<ProtocolSupport.HttpVersionPreference> preference) {
+    if (preference.isEmpty()) {
+      return "null";
+    }
+    String version =
+        switch (preference.get().alpnId()) {
+          case "h3" -> writer.typeName(RuntimeTypes.HTTP_VERSION) + ".Version30";
+          case "h2" -> writer.typeName(RuntimeTypes.HTTP_VERSION) + ".Version20";
+          case "http/1.1" -> writer.typeName(RuntimeTypes.HTTP_VERSION) + ".Version11";
+          default -> throw new IllegalArgumentException(preference.get().alpnId());
+        };
+    return ("new " + writer.typeName(RuntimeTypes.SMITHY_HTTP_VERSION_PREFERENCE) + "(")
+        + version
+        + ", allowDowngrade: "
+        + preference.get().allowDowngrade()
+        + ")";
+  }
+
+  // ---------------- paginators ----------------
+
+  /**
+   * Resolved pagination for an operation: present when the operation carries {@code @paginated}
+   * (merged with the service-level defaults). Event-stream operations are never paginated. Static
+   * (like the signature helpers below) so FakeClientGenerator renders the same paginator surface.
+   */
+  static Optional<PaginationInfo> paginationInfo(
+      GenerationContext context, ServiceShape service, OperationShape op) {
+    if (isEventStreamOperation(context.model(), op)) {
+      return Optional.empty();
+    }
+    return PaginatedIndex.of(context.model()).getPaginationInfo(service, op);
+  }
+
+  static String paginatorPagesSignature(
+      CSharpWriter writer, GenerationContext context, OperationShape op) {
+    SymbolProvider sp = context.symbolProvider();
+    Model model = context.model();
+    String inputType = writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape())));
+    String outputType = writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())));
+    return writer.typeName(RuntimeTypes.I_ASYNC_ENUMERABLE)
+        + "<"
+        + outputType
+        + "> "
+        + CSharpNaming.typeName(op.getId().getName())
+        + "PagesAsync("
+        + inputType
+        + " input, "
+        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
+        + " cancellationToken = default)";
+  }
+
+  /**
+   * The items-level paginator signature, present when {@code @paginated} names an {@code items}
+   * member that resolves to a list. Map-valued items are rare and not generated yet — the pages
+   * paginator still covers them.
+   */
+  static Optional<String> paginatorItemsSignature(
+      CSharpWriter writer, GenerationContext context, PaginationInfo info) {
+    return paginatorItemElementType(writer, context, info)
+        .map(
+            elementType ->
+                writer.typeName(RuntimeTypes.I_ASYNC_ENUMERABLE)
+                    + "<"
+                    + elementType
+                    + "> "
+                    + CSharpNaming.typeName(info.getOperation().getId().getName())
+                    + "ItemsAsync("
+                    + writer.typeName(
+                        context
+                            .symbolProvider()
+                            .toSymbol(
+                                context.model().expectShape(info.getOperation().getInputShape())))
+                    + " input, "
+                    + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
+                    + " cancellationToken = default)");
+  }
+
+  /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */
+  static String memberPathExpr(String root, List<MemberShape> path) {
+    StringBuilder expr = new StringBuilder(root);
+    for (int i = 0; i < path.size(); i++) {
+      expr.append(i == 0 ? "." : "?.")
+          .append(CSharpNaming.propertyName(path.get(i).getMemberName()));
+    }
+    return expr.toString();
+  }
+
+  // =====================================================================
+  // shared helpers
+  // =====================================================================
+
+  public static List<MemberShape> responseBodyMembers(StructureShape output) {
+    return ShapeSupport.constructorMembers(output).stream()
+        .filter(
+            m ->
+                !ShapeSupport.isHttpHeader(m)
+                    && !ShapeSupport.isHttpPrefixHeaders(m)
+                    && !ShapeSupport.isHttpResponseCode(m)
+                    && !ShapeSupport.isHttpPayload(m))
+        .collect(Collectors.toList());
+  }
+
+  /** Adds [EnumeratorCancellation] to a paginator signature's cancellation-token parameter. */
+  static String withEnumeratorCancellation(CSharpWriter writer, String signature) {
+    return signature.replace(
+        writer.typeName(RuntimeTypes.CANCELLATION_TOKEN) + " cancellationToken",
+        "["
+            + writer.attributeName(RuntimeTypes.ENUMERATOR_CANCELLATION_ATTRIBUTE)
+            + "]"
+            + " "
+            + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
+            + " cancellationToken");
+  }
+
+  static String operationSignature(
+      CSharpWriter writer, GenerationContext context, OperationShape op) {
+    SymbolProvider sp = context.symbolProvider();
+    Model model = context.model();
+    boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
+    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
+    String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
+    String inputType =
+        hasInput ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) : null;
+    String outputType =
+        hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
+    String returnType =
+        hasOutput
+            ? writer.typeName(RuntimeTypes.TASK) + "<" + outputType + ">"
+            : writer.typeName(RuntimeTypes.TASK);
+    String params = hasInput ? inputType + " input, " : "";
+    return returnType
+        + " "
+        + name
+        + "("
+        + params
+        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
+        + " cancellationToken = default)";
   }
 
   // =====================================================================
@@ -120,7 +253,7 @@ public final class ClientGenerator implements Runnable {
       String typeName,
       String interfaceName,
       List<Kind> kinds) {
-    String primaryProtocol = ProtocolSupport.protocolType(kinds.get(0));
+    String primaryProtocol = writer.typeName(ProtocolSupport.protocolType(kinds.get(0)));
     String modeledHttpVersionPreference =
         httpVersionPreferenceLiteral(
             writer,
@@ -140,15 +273,14 @@ public final class ClientGenerator implements Runnable {
         "}",
         () -> {
           if (needsRuntime) {
-            writer.write("private readonly SmithyClientRuntime runtime;");
+            writer.write("private readonly $T runtime;", RuntimeTypes.SMITHY_CLIENT_RUNTIME);
             // The environment owns only resources created by the runtime factory.
-            writer.write("private readonly SmithyHttpClientEnvironment environment;");
+            writer.write(
+                "private readonly $T environment;", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
           }
           if (needsIdempotency) {
             writer.write(
-                "private readonly "
-                    + writer.frameworkType("System.Func")
-                    + "<string> idempotencyTokenProvider;");
+                "private readonly $T<string> idempotencyTokenProvider;", RuntimeTypes.FUNC);
           }
           // The protocol is bound at construction; per-operation protocols are built once from it.
           for (OperationShape op : operations) {
@@ -156,7 +288,8 @@ public final class ClientGenerator implements Runnable {
               continue;
             }
             writer.write(
-                "private readonly SmithyOperationBinding<$L, $L> $LBinding;",
+                "private readonly $T<$L, $L> $LBinding;",
+                RuntimeTypes.SMITHY_OPERATION_BINDING,
                 SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
                 SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
                 CSharpNaming.typeName(op.getId().getName()));
@@ -167,11 +300,10 @@ public final class ClientGenerator implements Runnable {
           // Endpoint already present on config; construction then flows through the config
           // constructor so there is only one implementation path.
           writer.write(
-              "public $L("
-                  + writer.frameworkType("System.Uri")
-                  + " endpoint, $LConfig? config = null) :"
-                  + " this(WithEndpoint(endpoint, config))",
+              "public $L($T endpoint, $LConfig? config = null) : this(WithEndpoint(endpoint,"
+                  + " config))",
               typeName,
+              RuntimeTypes.URI,
               typeName);
           writer.openBlock("{", "}", () -> {});
           writer.write("");
@@ -184,8 +316,7 @@ public final class ClientGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(config);");
+                writer.write("$T.ThrowIfNull(config);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 if (needsRuntime) {
                   writeEnvironmentCreation(
                       serviceSchema, primaryProtocol, modeledHttpVersionPreference, "null");
@@ -201,18 +332,15 @@ public final class ClientGenerator implements Runnable {
           // AddHttpClient<I,T>). The endpoint comes from Config.Endpoint, falling back to the
           // HttpClient's BaseAddress.
           writer.write(
-              "public $L("
-                  + writer.frameworkType("System.Net.Http.HttpClient")
-                  + " httpClient, $LConfig? config = null)",
+              "public $L($T httpClient, $LConfig? config = null)",
               typeName,
+              RuntimeTypes.HTTP_CLIENT,
               typeName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(httpClient);");
+                writer.write("$T.ThrowIfNull(httpClient);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 if (needsRuntime) {
                   writer.write("config ??= new $LConfig();", typeName);
                   writeEnvironmentCreation(
@@ -231,8 +359,9 @@ public final class ClientGenerator implements Runnable {
             // config.Interceptors do not apply here; only Protocol and IdempotencyTokenProvider are
             // read.
             writer.write(
-                "public $L(SmithyClientRuntime runtime, $LConfig? config = null)",
+                "public $L($T runtime, $LConfig? config = null)",
                 typeName,
+                RuntimeTypes.SMITHY_CLIENT_RUNTIME,
                 typeName);
             writer.openBlock(
                 "{",
@@ -240,8 +369,9 @@ public final class ClientGenerator implements Runnable {
                 () -> {
                   writer.write("config ??= new $LConfig();", typeName);
                   writer.write(
-                      "this.environment = SmithyHttpClientEnvironment.FromRuntime($L, runtime,"
-                          + " config, static () => new $L());",
+                      "this.environment = $T.FromRuntime($L, runtime, config, static () => new"
+                          + " $L());",
+                      RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
                       serviceSchema,
                       primaryProtocol);
                   writer.write("this.runtime = environment.Runtime;");
@@ -255,18 +385,15 @@ public final class ClientGenerator implements Runnable {
           // Copies the caller's config before setting the endpoint, so constructing a client
           // never mutates a config instance the caller may share with other clients.
           writer.write(
-              "private static $LConfig WithEndpoint("
-                  + writer.frameworkType("System.Uri")
-                  + " endpoint, $LConfig? config)",
+              "private static $LConfig WithEndpoint($T endpoint, $LConfig? config)",
               typeName,
+              RuntimeTypes.URI,
               typeName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(endpoint);");
+                writer.write("$T.ThrowIfNull(endpoint);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write(
                     "var copy = config is null ? new $LConfig() : new $LConfig(config);",
                     typeName,
@@ -280,20 +407,16 @@ public final class ClientGenerator implements Runnable {
           // introduced solely by an operation-level @auth override, so constructor validation does
           // not reject a client configured specifically for such an operation.
           writer.write(
-              "private static readonly "
-                  + writer.frameworkType("System.Collections.Generic.IReadOnlyList")
-                  + "<string>"
-                  + " ModeledAuthSchemes = $L;",
+              "private static readonly $T<string> ModeledAuthSchemes = $L;",
+              RuntimeTypes.I_READ_ONLY_LIST,
               modeledAuthSchemesLiteral());
           writer.write("");
 
           if (needsIdempotency) {
             writer.write("");
             writer.write(
-                "private static string DefaultIdempotencyToken() =>"
-                    + " "
-                    + writer.frameworkType("System.Guid")
-                    + ".NewGuid().ToString();");
+                "private static string DefaultIdempotencyToken() => $T.NewGuid().ToString();",
+                RuntimeTypes.GUID);
           }
           writer.write("");
 
@@ -332,8 +455,9 @@ public final class ClientGenerator implements Runnable {
   private void writeEnvironmentCreation(
       String serviceSchema, String primaryProtocol, String preference, String httpClient) {
     writer.write(
-        "this.environment = SmithyHttpClientEnvironment.Create($L, config, static () => new $L(),"
-            + " ModeledAuthSchemes, $L, $L);",
+        "this.environment = $T.Create($L, config, static () => new $L(), ModeledAuthSchemes, $L,"
+            + " $L);",
+        RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
         serviceSchema,
         primaryProtocol,
         preference,
@@ -349,7 +473,7 @@ public final class ClientGenerator implements Runnable {
    * constructor surface. The copy constructor backs the client's copy-at-construction semantics.
    */
   private void writeConfigClass(String typeName) {
-    writer.write("public sealed class $LConfig : SmithyClientConfig", typeName);
+    writer.write("public sealed class $LConfig : $T", typeName, RuntimeTypes.SMITHY_CLIENT_CONFIG);
     writer.openBlock(
         "{",
         "}",
@@ -359,7 +483,8 @@ public final class ClientGenerator implements Runnable {
             writer.openBlock(
                 "{",
                 "}",
-                () -> writer.write("Interceptors.Add(new NSmithy.Aws.GlacierInterceptor());"));
+                () ->
+                    writer.write("Interceptors.Add(new $T());", RuntimeTypes.GLACIER_INTERCEPTOR));
           } else {
             writer.write("public $LConfig() { }", typeName);
           }
@@ -391,7 +516,7 @@ public final class ClientGenerator implements Runnable {
                     .forEach(id -> uniqueIds.put(id.toString(), Boolean.TRUE)));
     List<String> ids = uniqueIds.keySet().stream().toList();
     if (ids.isEmpty()) {
-      return writer.frameworkType("System.Array") + ".Empty<string>()";
+      return writer.typeName(RuntimeTypes.ARRAY) + ".Empty<string>()";
     }
     return "new string[] { "
         + ids.stream().map(CSharpNaming::formatString).collect(Collectors.joining(", "))
@@ -434,9 +559,10 @@ public final class ClientGenerator implements Runnable {
       }
       String operationSchema = SchemaGenerator.operationSchemaAccessor(writer, context, op);
       writer.write(
-          "this.$LBinding = new SmithyOperationBinding<$L, $L>($L.Id, $L.Id,"
-              + " serviceProtocol.ForClientOperation($L), $L, $L);",
+          "this.$LBinding = new $T<$L, $L>($L.Id, $L.Id, serviceProtocol.ForClientOperation($L),"
+              + " $L, $L);",
           CSharpNaming.typeName(op.getId().getName()),
+          RuntimeTypes.SMITHY_OPERATION_BINDING,
           SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
           SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
           SchemaGenerator.serviceSchemaAccessor(writer, context, service),
@@ -459,7 +585,7 @@ public final class ClientGenerator implements Runnable {
             .map(ShapeId::toString)
             .collect(Collectors.toList());
     if (ids.isEmpty()) {
-      return writer.frameworkType("System.Array") + ".Empty<string>()";
+      return writer.typeName(RuntimeTypes.ARRAY) + ".Empty<string>()";
     }
     return "new string[] { "
         + ids.stream().map(CSharpNaming::formatString).collect(Collectors.joining(", "))
@@ -480,7 +606,7 @@ public final class ClientGenerator implements Runnable {
                 label -> {
                   String name = label.getContent();
                   MemberShape member = input.getMember(name).orElseThrow();
-                  return "new SmithyHostLabel("
+                  return ("new " + writer.typeName(RuntimeTypes.SMITHY_HOST_LABEL) + "(")
                       + CSharpNaming.formatString(name)
                       + ", input."
                       + CSharpNaming.propertyName(member.getMemberName())
@@ -491,25 +617,8 @@ public final class ClientGenerator implements Runnable {
         labels.isEmpty()
             ? CSharpNaming.formatString(endpoint.get().getHostPrefix().toString())
             : CSharpNaming.formatString(endpoint.get().getHostPrefix().toString()) + ", " + labels;
-    return "static input => SmithyHostPrefix.Expand(" + arguments + ")";
-  }
-
-  static String httpVersionPreferenceLiteral(
-      CSharpWriter writer, Optional<ProtocolSupport.HttpVersionPreference> preference) {
-    if (preference.isEmpty()) {
-      return "null";
-    }
-    String version =
-        switch (preference.get().alpnId()) {
-          case "h3" -> writer.frameworkType("System.Net.HttpVersion") + ".Version30";
-          case "h2" -> writer.frameworkType("System.Net.HttpVersion") + ".Version20";
-          case "http/1.1" -> writer.frameworkType("System.Net.HttpVersion") + ".Version11";
-          default -> throw new IllegalArgumentException(preference.get().alpnId());
-        };
-    return "new SmithyHttpVersionPreference("
-        + version
-        + ", allowDowngrade: "
-        + preference.get().allowDowngrade()
+    return ("static input => " + writer.typeName(RuntimeTypes.SMITHY_HOST_PREFIX) + ".Expand(")
+        + arguments
         + ")";
   }
 
@@ -524,10 +633,9 @@ public final class ClientGenerator implements Runnable {
           "}",
           () ->
               writer.write(
-                  "throw new "
-                      + writer.frameworkType("System.NotSupportedException")
-                      + "(\"Event-stream operations are not"
-                      + " supported by the declared service protocols.\");"));
+                  "throw new $T(\"Event-stream operations are not supported by the declared service"
+                      + " protocols.\");",
+                  RuntimeTypes.NOT_SUPPORTED_EXCEPTION));
       writer.write("");
       return;
     }
@@ -535,7 +643,7 @@ public final class ClientGenerator implements Runnable {
     boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
     boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     String opName = CSharpNaming.typeName(op.getId().getName());
-    String inputArg = hasInput ? "input" : "SmithyUnit.Value";
+    String inputArg = hasInput ? "input" : (writer.typeName(RuntimeTypes.SMITHY_UNIT) + ".Value");
 
     writer.write(
         hasOutput ? "public $L" : "public async $L", operationSignature(writer, context, op));
@@ -544,8 +652,7 @@ public final class ClientGenerator implements Runnable {
         "}",
         () -> {
           if (hasInput) {
-            writer.write(
-                writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(input);");
+            writer.write("$T.ThrowIfNull(input);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
             writeIdempotencyTokenDefaults(
                 model.expectShape(op.getInputShape(), StructureShape.class));
           }
@@ -587,65 +694,6 @@ public final class ClientGenerator implements Runnable {
         });
   }
 
-  // ---------------- paginators ----------------
-
-  /**
-   * Resolved pagination for an operation: present when the operation carries {@code @paginated}
-   * (merged with the service-level defaults). Event-stream operations are never paginated. Static
-   * (like the signature helpers below) so FakeClientGenerator renders the same paginator surface.
-   */
-  static Optional<PaginationInfo> paginationInfo(
-      GenerationContext context, ServiceShape service, OperationShape op) {
-    if (isEventStreamOperation(context.model(), op)) {
-      return Optional.empty();
-    }
-    return PaginatedIndex.of(context.model()).getPaginationInfo(service, op);
-  }
-
-  static String paginatorPagesSignature(
-      CSharpWriter writer, GenerationContext context, OperationShape op) {
-    SymbolProvider sp = context.symbolProvider();
-    Model model = context.model();
-    String inputType = writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape())));
-    String outputType = writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())));
-    return writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
-        + "<"
-        + outputType
-        + "> "
-        + CSharpNaming.typeName(op.getId().getName())
-        + "PagesAsync("
-        + inputType
-        + " input, "
-        + writer.frameworkType("System.Threading.CancellationToken")
-        + " cancellationToken = default)";
-  }
-
-  /**
-   * The items-level paginator signature, present when {@code @paginated} names an {@code items}
-   * member that resolves to a list. Map-valued items are rare and not generated yet — the pages
-   * paginator still covers them.
-   */
-  static Optional<String> paginatorItemsSignature(
-      CSharpWriter writer, GenerationContext context, PaginationInfo info) {
-    return paginatorItemElementType(writer, context, info)
-        .map(
-            elementType ->
-                writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
-                    + "<"
-                    + elementType
-                    + "> "
-                    + CSharpNaming.typeName(info.getOperation().getId().getName())
-                    + "ItemsAsync("
-                    + writer.typeName(
-                        context
-                            .symbolProvider()
-                            .toSymbol(
-                                context.model().expectShape(info.getOperation().getInputShape())))
-                    + " input, "
-                    + writer.frameworkType("System.Threading.CancellationToken")
-                    + " cancellationToken = default)");
-  }
-
   private static Optional<String> paginatorItemElementType(
       CSharpWriter writer, GenerationContext context, PaginationInfo info) {
     List<MemberShape> path = info.getItemsMemberPath();
@@ -658,16 +706,6 @@ public final class ClientGenerator implements Runnable {
     }
     var element = context.model().expectShape(target.asListShape().get().getMember().getTarget());
     return Optional.of(writer.typeName(context.symbolProvider().toSymbol(element)));
-  }
-
-  /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */
-  static String memberPathExpr(String root, List<MemberShape> path) {
-    StringBuilder expr = new StringBuilder(root);
-    for (int i = 0; i < path.size(); i++) {
-      expr.append(i == 0 ? "." : "?.")
-          .append(CSharpNaming.propertyName(path.get(i).getMemberName()));
-    }
-    return expr.toString();
   }
 
   /**
@@ -688,8 +726,7 @@ public final class ClientGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write(
-              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(input);");
+          writer.write("$T.ThrowIfNull(input);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
           writer.write(
               "var output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
               opName);
@@ -737,59 +774,6 @@ public final class ClientGenerator implements Runnable {
                   });
               writer.write("");
             });
-  }
-
-  // =====================================================================
-  // shared helpers
-  // =====================================================================
-
-  public static List<MemberShape> responseBodyMembers(StructureShape output) {
-    return ShapeSupport.constructorMembers(output).stream()
-        .filter(
-            m ->
-                !ShapeSupport.isHttpHeader(m)
-                    && !ShapeSupport.isHttpPrefixHeaders(m)
-                    && !ShapeSupport.isHttpResponseCode(m)
-                    && !ShapeSupport.isHttpPayload(m))
-        .collect(Collectors.toList());
-  }
-
-  /** Adds [EnumeratorCancellation] to a paginator signature's cancellation-token parameter. */
-  static String withEnumeratorCancellation(CSharpWriter writer, String signature) {
-    return signature.replace(
-        writer.frameworkType("System.Threading.CancellationToken") + " cancellationToken",
-        "["
-            + writer.frameworkAttribute(
-                "System.Runtime.CompilerServices.EnumeratorCancellationAttribute")
-            + "]"
-            + " "
-            + writer.frameworkType("System.Threading.CancellationToken")
-            + " cancellationToken");
-  }
-
-  static String operationSignature(
-      CSharpWriter writer, GenerationContext context, OperationShape op) {
-    SymbolProvider sp = context.symbolProvider();
-    Model model = context.model();
-    boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
-    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
-    String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
-    String inputType =
-        hasInput ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) : null;
-    String outputType =
-        hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
-    String returnType =
-        hasOutput
-            ? writer.frameworkType("System.Threading.Tasks.Task") + "<" + outputType + ">"
-            : writer.frameworkType("System.Threading.Tasks.Task");
-    String params = hasInput ? inputType + " input, " : "";
-    return returnType
-        + " "
-        + name
-        + "("
-        + params
-        + writer.frameworkType("System.Threading.CancellationToken")
-        + " cancellationToken = default)";
   }
 
   private Map<String, String> operationParameterDocs(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -6,7 +6,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ProtocolSupport;
@@ -78,13 +77,13 @@ public final class ClientGenerator implements Runnable {
           writer.write("");
           for (OperationShape op : operations) {
             writer.writeXmlDocs(op, operationParameterDocs(model, op));
-            writer.write("$L;", operationSignature(context, op));
+            writer.write("$L;", operationSignature(writer, context, op));
             paginationInfo(context, service, op)
                 .ifPresent(
                     info -> {
                       writer.writeXmlDocs(op, operationParameterDocs(model, op));
-                      writer.write("$L;", paginatorPagesSignature(context, op));
-                      paginatorItemsSignature(context, info)
+                      writer.write("$L;", paginatorPagesSignature(writer, context, op));
+                      paginatorItemsSignature(writer, context, info)
                           .ifPresent(
                               signature -> {
                                 writer.writeXmlDocs(op, operationParameterDocs(model, op));
@@ -125,7 +124,7 @@ public final class ClientGenerator implements Runnable {
         httpVersionPreferenceLiteral(
             ProtocolSupport.httpVersionPreference(
                 service, kinds.get(0), ProtocolSupport.hasEventStreamOperations(model, service)));
-    String serviceSchema = SchemaGenerator.serviceSchemaAccessor(context, service);
+    String serviceSchema = SchemaGenerator.serviceSchemaAccessor(writer, context, service);
     // The idempotency-token provider is only stored/used when an operation has a nullable
     // @idempotencyToken member; emitting the field unconditionally would be an unused private
     // field.
@@ -153,8 +152,8 @@ public final class ClientGenerator implements Runnable {
             }
             writer.write(
                 "private readonly SmithyOperationBinding<$L, $L> $LBinding;",
-                SchemaGenerator.operationShapeType(context, op.getInputShape()),
-                SchemaGenerator.operationShapeType(context, op.getOutputShape()),
+                SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
+                SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
                 CSharpNaming.typeName(op.getId().getName()));
           }
           writer.write("");
@@ -413,14 +412,14 @@ public final class ClientGenerator implements Runnable {
       if (!canBindOperation(op)) {
         continue;
       }
-      String operationSchema = SchemaGenerator.operationSchemaAccessor(context, op);
+      String operationSchema = SchemaGenerator.operationSchemaAccessor(writer, context, op);
       writer.write(
           "this.$LBinding = new SmithyOperationBinding<$L, $L>($L.Id, $L.Id,"
               + " serviceProtocol.ForClientOperation($L), $L, $L);",
           CSharpNaming.typeName(op.getId().getName()),
-          SchemaGenerator.operationShapeType(context, op.getInputShape()),
-          SchemaGenerator.operationShapeType(context, op.getOutputShape()),
-          SchemaGenerator.serviceSchemaAccessor(context, service),
+          SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
+          SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
+          SchemaGenerator.serviceSchemaAccessor(writer, context, service),
           operationSchema,
           operationSchema,
           operationAuthSchemesLiteral(op),
@@ -499,7 +498,7 @@ public final class ClientGenerator implements Runnable {
   private void writeOperationMethod(Model model, OperationShape op) {
     writer.writeXmlDocs(op, operationParameterDocs(model, op));
     if (!canBindOperation(op)) {
-      writer.write("public $L", operationSignature(context, op));
+      writer.write("public $L", operationSignature(writer, context, op));
       writer.openBlock(
           "{",
           "}",
@@ -516,7 +515,8 @@ public final class ClientGenerator implements Runnable {
     String opName = CSharpNaming.typeName(op.getId().getName());
     String inputArg = hasInput ? "input" : "SmithyUnit.Value";
 
-    writer.write(hasOutput ? "public $L" : "public async $L", operationSignature(context, op));
+    writer.write(
+        hasOutput ? "public $L" : "public async $L", operationSignature(writer, context, op));
     writer.openBlock(
         "{",
         "}",
@@ -579,13 +579,12 @@ public final class ClientGenerator implements Runnable {
     return PaginatedIndex.of(context.model()).getPaginationInfo(service, op);
   }
 
-  static String paginatorPagesSignature(GenerationContext context, OperationShape op) {
+  static String paginatorPagesSignature(
+      CSharpWriter writer, GenerationContext context, OperationShape op) {
     SymbolProvider sp = context.symbolProvider();
     Model model = context.model();
-    String inputType =
-        CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getInputShape())));
-    String outputType =
-        CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getOutputShape())));
+    String inputType = writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape())));
+    String outputType = writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())));
     return "System.Collections.Generic.IAsyncEnumerable<"
         + outputType
         + "> "
@@ -600,8 +599,9 @@ public final class ClientGenerator implements Runnable {
    * member that resolves to a list. Map-valued items are rare and not generated yet — the pages
    * paginator still covers them.
    */
-  static Optional<String> paginatorItemsSignature(GenerationContext context, PaginationInfo info) {
-    return paginatorItemElementType(context, info)
+  static Optional<String> paginatorItemsSignature(
+      CSharpWriter writer, GenerationContext context, PaginationInfo info) {
+    return paginatorItemElementType(writer, context, info)
         .map(
             elementType ->
                 "System.Collections.Generic.IAsyncEnumerable<"
@@ -609,7 +609,7 @@ public final class ClientGenerator implements Runnable {
                     + "> "
                     + CSharpNaming.typeName(info.getOperation().getId().getName())
                     + "ItemsAsync("
-                    + CSharpSymbolProvider.qualified(
+                    + writer.typeName(
                         context
                             .symbolProvider()
                             .toSymbol(
@@ -618,7 +618,7 @@ public final class ClientGenerator implements Runnable {
   }
 
   private static Optional<String> paginatorItemElementType(
-      GenerationContext context, PaginationInfo info) {
+      CSharpWriter writer, GenerationContext context, PaginationInfo info) {
     List<MemberShape> path = info.getItemsMemberPath();
     if (path.isEmpty()) {
       return Optional.empty();
@@ -628,7 +628,7 @@ public final class ClientGenerator implements Runnable {
       return Optional.empty();
     }
     var element = context.model().expectShape(target.asListShape().get().getMember().getTarget());
-    return Optional.of(CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(element)));
+    return Optional.of(writer.typeName(context.symbolProvider().toSymbol(element)));
   }
 
   /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */
@@ -653,7 +653,8 @@ public final class ClientGenerator implements Runnable {
 
     writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
     writer.write(
-        "public async $L", withEnumeratorCancellation(paginatorPagesSignature(context, op)));
+        "public async $L",
+        withEnumeratorCancellation(paginatorPagesSignature(writer, context, op)));
     writer.openBlock(
         "{",
         "}",
@@ -679,7 +680,7 @@ public final class ClientGenerator implements Runnable {
         });
     writer.write("");
 
-    paginatorItemsSignature(context, info)
+    paginatorItemsSignature(writer, context, info)
         .ifPresent(
             signature -> {
               String itemsExpr = memberPathExpr("page", info.getItemsMemberPath());
@@ -731,20 +732,17 @@ public final class ClientGenerator implements Runnable {
             + " System.Threading.CancellationToken cancellationToken");
   }
 
-  static String operationSignature(GenerationContext context, OperationShape op) {
+  static String operationSignature(
+      CSharpWriter writer, GenerationContext context, OperationShape op) {
     SymbolProvider sp = context.symbolProvider();
     Model model = context.model();
     boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
     boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
     String inputType =
-        hasInput
-            ? CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getInputShape())))
-            : null;
+        hasInput ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) : null;
     String outputType =
-        hasOutput
-            ? CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getOutputShape())))
-            : null;
+        hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
     String returnType =
         hasOutput
             ? "System.Threading.Tasks.Task<" + outputType + ">"

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -296,112 +296,14 @@ public final class ClientGenerator implements Runnable {
           }
           writer.write("");
 
-          // Constructor: endpoint convenience overload. The endpoint argument wins over any
-          // Endpoint already present on config; construction then flows through the config
-          // constructor so there is only one implementation path.
-          writer.write(
-              "public $L($T endpoint, $LConfig? config = null) : this(WithEndpoint(endpoint,"
-                  + " config))",
+          writeConstructors(
               typeName,
-              RuntimeTypes.URI,
-              typeName);
-          writer.openBlock("{", "}", () -> {});
-          writer.write("");
-
-          // Canonical config implementation for the endpoint constructor. This stays private so
-          // the public surface has one direct-construction path (`endpoint, config?`) while config
-          // remains the internal model.
-          writer.write("private $L($LConfig config)", typeName, typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(config);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                if (needsRuntime) {
-                  writeEnvironmentCreation(
-                      serviceSchema, primaryProtocol, modeledHttpVersionPreference, "null");
-                }
-                writeIdempotencyAssignment(needsIdempotency);
-                if (needsRuntime) {
-                  writeSafeOperationBindings(operations);
-                }
-              });
-          writer.write("");
-
-          // Constructor: bring your own HttpClient (e.g. from IHttpClientFactory /
-          // AddHttpClient<I,T>). The endpoint comes from Config.Endpoint, falling back to the
-          // HttpClient's BaseAddress.
-          writer.write(
-              "public $L($T httpClient, $LConfig? config = null)",
-              typeName,
-              RuntimeTypes.HTTP_CLIENT,
-              typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(httpClient);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                if (needsRuntime) {
-                  writer.write("config ??= new $LConfig();", typeName);
-                  writeEnvironmentCreation(
-                      serviceSchema, primaryProtocol, modeledHttpVersionPreference, "httpClient");
-                }
-                writeIdempotencyAssignment(needsIdempotency);
-                if (needsRuntime) {
-                  writeSafeOperationBindings(operations);
-                }
-              });
-          writer.write("");
-
-          if (needsRuntime) {
-            // Constructor: bring your own runtime (custom transport/interceptors, DI, testing). The
-            // runtime already owns the transport/interceptor pipeline, so config.AuthSchemes and
-            // config.Interceptors do not apply here; only Protocol and IdempotencyTokenProvider are
-            // read.
-            writer.write(
-                "public $L($T runtime, $LConfig? config = null)",
-                typeName,
-                RuntimeTypes.SMITHY_CLIENT_RUNTIME,
-                typeName);
-            writer.openBlock(
-                "{",
-                "}",
-                () -> {
-                  writer.write("config ??= new $LConfig();", typeName);
-                  writer.write(
-                      "this.environment = $T.FromRuntime($L, runtime, config, static () => new"
-                          + " $L());",
-                      RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
-                      serviceSchema,
-                      primaryProtocol);
-                  writer.write("this.runtime = environment.Runtime;");
-                  writer.write("var serviceProtocol = environment.ServiceProtocol;");
-                  writeIdempotencyAssignment(needsIdempotency);
-                  writeSafeOperationBindings(operations);
-                });
-            writer.write("");
-          }
-
-          // Copies the caller's config before setting the endpoint, so constructing a client
-          // never mutates a config instance the caller may share with other clients.
-          writer.write(
-              "private static $LConfig WithEndpoint($T endpoint, $LConfig? config)",
-              typeName,
-              RuntimeTypes.URI,
-              typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(endpoint);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write(
-                    "var copy = config is null ? new $LConfig() : new $LConfig(config);",
-                    typeName,
-                    typeName);
-                writer.write("copy.Endpoint = endpoint;");
-                writer.write("return copy;");
-              });
-          writer.write("");
+              serviceSchema,
+              primaryProtocol,
+              modeledHttpVersionPreference,
+              needsRuntime,
+              needsIdempotency,
+              operations);
 
           // Every auth scheme that can be effective for a service operation. This includes schemes
           // introduced solely by an operation-level @auth override, so constructor validation does
@@ -437,6 +339,113 @@ public final class ClientGenerator implements Runnable {
         });
     writer.write("");
     writeConfigClass(typeName);
+  }
+
+  private void writeConstructors(
+      String typeName,
+      String serviceSchema,
+      String primaryProtocol,
+      String modeledHttpVersionPreference,
+      boolean needsRuntime,
+      boolean needsIdempotency,
+      List<OperationShape> operations) {
+    writer.pushState();
+    try {
+      writer.putContext("client", typeName);
+      writer.putContext("uri", RuntimeTypes.URI);
+      writer.putContext("httpClient", RuntimeTypes.HTTP_CLIENT);
+      writer.putContext("runtime", RuntimeTypes.SMITHY_CLIENT_RUNTIME);
+      writer.putContext("environment", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("serviceSchema", serviceSchema);
+      writer.putContext("protocol", primaryProtocol);
+      writer.putContext(
+          "ownedInitialization",
+          writer.consumer(
+              w -> {
+                if (needsRuntime) {
+                  writeEnvironmentCreation(
+                      serviceSchema, primaryProtocol, modeledHttpVersionPreference, "null");
+                }
+                writeConstructorBindings(needsRuntime, needsIdempotency, operations);
+              }));
+      writer.putContext(
+          "httpClientInitialization",
+          writer.consumer(
+              w -> {
+                if (needsRuntime) {
+                  w.write("config ??= new ${client:L}Config();");
+                  writeEnvironmentCreation(
+                      serviceSchema, primaryProtocol, modeledHttpVersionPreference, "httpClient");
+                }
+                writeConstructorBindings(needsRuntime, needsIdempotency, operations);
+              }));
+      writer.putContext(
+          "bindings",
+          writer.consumer(
+              w -> writeConstructorBindings(needsRuntime, needsIdempotency, operations)));
+
+      // The explicit endpoint wins over config.Endpoint. The private constructor receives a copy.
+      writer.write(
+          """
+          public ${client:L}(${uri:T} endpoint, ${client:L}Config? config = null) : this(WithEndpoint(endpoint, config))
+          {
+          }
+
+          private ${client:L}(${client:L}Config config)
+          {
+              ${argumentNullException:T}.ThrowIfNull(config);
+              ${ownedInitialization:C|}
+          }
+
+          public ${client:L}(${httpClient:T} httpClient, ${client:L}Config? config = null)
+          {
+              ${argumentNullException:T}.ThrowIfNull(httpClient);
+              ${httpClientInitialization:C|}
+          }
+          """);
+      writer.write("");
+
+      if (needsRuntime) {
+        // An injected runtime already owns its transport and interceptor pipeline.
+        // Only Protocol and IdempotencyTokenProvider are read from config in this overload.
+        writer.write(
+            """
+            public ${client:L}(${runtime:T} runtime, ${client:L}Config? config = null)
+            {
+                config ??= new ${client:L}Config();
+                this.environment = ${environment:T}.FromRuntime(${serviceSchema:L}, runtime, config, static () => new ${protocol:L}());
+                this.runtime = environment.Runtime;
+                var serviceProtocol = environment.ServiceProtocol;
+                ${bindings:C|}
+            }
+            """);
+        writer.write("");
+      }
+
+      // Copy before assigning the endpoint so a config shared by callers remains unchanged.
+      writer.write(
+          """
+          private static ${client:L}Config WithEndpoint(${uri:T} endpoint, ${client:L}Config? config)
+          {
+              ${argumentNullException:T}.ThrowIfNull(endpoint);
+              var copy = config is null ? new ${client:L}Config() : new ${client:L}Config(config);
+              copy.Endpoint = endpoint;
+              return copy;
+          }
+          """);
+      writer.write("");
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeConstructorBindings(
+      boolean needsRuntime, boolean needsIdempotency, List<OperationShape> operations) {
+    writeIdempotencyAssignment(needsIdempotency);
+    if (needsRuntime) {
+      writeSafeOperationBindings(operations);
+    }
   }
 
   private void writeSafeOperationBindings(List<OperationShape> operations) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -473,24 +473,32 @@ public final class ClientGenerator implements Runnable {
    * constructor surface. The copy constructor backs the client's copy-at-construction semantics.
    */
   private void writeConfigClass(String typeName) {
-    writer.write("public sealed class $LConfig : $T", typeName, RuntimeTypes.SMITHY_CLIENT_CONFIG);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (service.getId().equals(GLACIER_SERVICE)) {
-            writer.write("public $LConfig()", typeName);
-            writer.openBlock(
-                "{",
-                "}",
-                () ->
-                    writer.write("Interceptors.Add(new $T());", RuntimeTypes.GLACIER_INTERCEPTOR));
-          } else {
-            writer.write("public $LConfig() { }", typeName);
+    writer.pushState();
+    try {
+      writer.putContext("config", typeName + "Config");
+      writer.putContext("baseConfig", RuntimeTypes.SMITHY_CLIENT_CONFIG);
+      writer.putContext("defaults", writer.consumer(this::writeConfigDefaults));
+      writer.write(
+          """
+          public sealed class ${config:L} : ${baseConfig:T}
+          {
+              public ${config:L}()
+              {
+                  ${defaults:C|}
+              }
+
+              public ${config:L}(${config:L} source) : base(source) { }
           }
-          writer.write("");
-          writer.write("public $LConfig($LConfig source) : base(source) { }", typeName, typeName);
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeConfigDefaults(CSharpWriter writer) {
+    if (service.getId().equals(GLACIER_SERVICE)) {
+      writer.write("Interceptors.Add(new $T());", RuntimeTypes.GLACIER_INTERCEPTOR);
+    }
   }
 
   /**

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -45,6 +45,7 @@ public final class ClientGenerator implements Runnable {
 
   public ClientGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }
@@ -69,7 +70,8 @@ public final class ClientGenerator implements Runnable {
 
     // Interface — IDisposable so a client that owns its HttpClient is released via `using` or DI.
     writer.writeXmlDocs(service);
-    writer.write("public interface $L : System.IDisposable", interfaceName);
+    writer.write(
+        "public interface $L : " + writer.frameworkType("System.IDisposable"), interfaceName);
     writer.openBlock(
         "{",
         "}",
@@ -122,6 +124,7 @@ public final class ClientGenerator implements Runnable {
     String primaryProtocol = ProtocolSupport.protocolType(kinds.get(0));
     String modeledHttpVersionPreference =
         httpVersionPreferenceLiteral(
+            writer,
             ProtocolSupport.httpVersionPreference(
                 service, kinds.get(0), ProtocolSupport.hasEventStreamOperations(model, service)));
     String serviceSchema = SchemaGenerator.serviceSchemaAccessor(writer, context, service);
@@ -143,7 +146,10 @@ public final class ClientGenerator implements Runnable {
             writer.write("private readonly SmithyHttpClientEnvironment environment;");
           }
           if (needsIdempotency) {
-            writer.write("private readonly System.Func<string> idempotencyTokenProvider;");
+            writer.write(
+                "private readonly "
+                    + writer.frameworkType("System.Func")
+                    + "<string> idempotencyTokenProvider;");
           }
           // The protocol is bound at construction; per-operation protocols are built once from it.
           for (OperationShape op : operations) {
@@ -162,7 +168,9 @@ public final class ClientGenerator implements Runnable {
           // Endpoint already present on config; construction then flows through the config
           // constructor so there is only one implementation path.
           writer.write(
-              "public $L(System.Uri endpoint, $LConfig? config = null) :"
+              "public $L("
+                  + writer.frameworkType("System.Uri")
+                  + " endpoint, $LConfig? config = null) :"
                   + " this(WithEndpoint(endpoint, config))",
               typeName,
               typeName);
@@ -177,7 +185,8 @@ public final class ClientGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(config);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(config);");
                 if (needsRuntime) {
                   writeEnvironmentCreation(
                       serviceSchema, primaryProtocol, modeledHttpVersionPreference, "null");
@@ -193,14 +202,18 @@ public final class ClientGenerator implements Runnable {
           // AddHttpClient<I,T>). The endpoint comes from Config.Endpoint, falling back to the
           // HttpClient's BaseAddress.
           writer.write(
-              "public $L(System.Net.Http.HttpClient httpClient, $LConfig? config = null)",
+              "public $L("
+                  + writer.frameworkType("System.Net.Http.HttpClient")
+                  + " httpClient, $LConfig? config = null)",
               typeName,
               typeName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(httpClient);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(httpClient);");
                 if (needsRuntime) {
                   writer.write("config ??= new $LConfig();", typeName);
                   writeEnvironmentCreation(
@@ -243,14 +256,18 @@ public final class ClientGenerator implements Runnable {
           // Copies the caller's config before setting the endpoint, so constructing a client
           // never mutates a config instance the caller may share with other clients.
           writer.write(
-              "private static $LConfig WithEndpoint(System.Uri endpoint, $LConfig? config)",
+              "private static $LConfig WithEndpoint("
+                  + writer.frameworkType("System.Uri")
+                  + " endpoint, $LConfig? config)",
               typeName,
               typeName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(endpoint);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(endpoint);");
                 writer.write(
                     "var copy = config is null ? new $LConfig() : new $LConfig(config);",
                     typeName,
@@ -264,7 +281,9 @@ public final class ClientGenerator implements Runnable {
           // introduced solely by an operation-level @auth override, so constructor validation does
           // not reject a client configured specifically for such an operation.
           writer.write(
-              "private static readonly System.Collections.Generic.IReadOnlyList<string>"
+              "private static readonly "
+                  + writer.frameworkType("System.Collections.Generic.IReadOnlyList")
+                  + "<string>"
                   + " ModeledAuthSchemes = $L;",
               modeledAuthSchemesLiteral());
           writer.write("");
@@ -273,7 +292,9 @@ public final class ClientGenerator implements Runnable {
             writer.write("");
             writer.write(
                 "private static string DefaultIdempotencyToken() =>"
-                    + " System.Guid.NewGuid().ToString();");
+                    + " "
+                    + writer.frameworkType("System.Guid")
+                    + ".NewGuid().ToString();");
           }
           writer.write("");
 
@@ -371,7 +392,7 @@ public final class ClientGenerator implements Runnable {
                     .forEach(id -> uniqueIds.put(id.toString(), Boolean.TRUE)));
     List<String> ids = uniqueIds.keySet().stream().toList();
     if (ids.isEmpty()) {
-      return "System.Array.Empty<string>()";
+      return writer.frameworkType("System.Array") + ".Empty<string>()";
     }
     return "new string[] { "
         + ids.stream().map(CSharpNaming::formatString).collect(Collectors.joining(", "))
@@ -439,7 +460,7 @@ public final class ClientGenerator implements Runnable {
             .map(ShapeId::toString)
             .collect(Collectors.toList());
     if (ids.isEmpty()) {
-      return "System.Array.Empty<string>()";
+      return writer.frameworkType("System.Array") + ".Empty<string>()";
     }
     return "new string[] { "
         + ids.stream().map(CSharpNaming::formatString).collect(Collectors.joining(", "))
@@ -475,15 +496,15 @@ public final class ClientGenerator implements Runnable {
   }
 
   static String httpVersionPreferenceLiteral(
-      Optional<ProtocolSupport.HttpVersionPreference> preference) {
+      CSharpWriter writer, Optional<ProtocolSupport.HttpVersionPreference> preference) {
     if (preference.isEmpty()) {
       return "null";
     }
     String version =
         switch (preference.get().alpnId()) {
-          case "h3" -> "System.Net.HttpVersion.Version30";
-          case "h2" -> "System.Net.HttpVersion.Version20";
-          case "http/1.1" -> "System.Net.HttpVersion.Version11";
+          case "h3" -> writer.frameworkType("System.Net.HttpVersion") + ".Version30";
+          case "h2" -> writer.frameworkType("System.Net.HttpVersion") + ".Version20";
+          case "http/1.1" -> writer.frameworkType("System.Net.HttpVersion") + ".Version11";
           default -> throw new IllegalArgumentException(preference.get().alpnId());
         };
     return "new SmithyHttpVersionPreference("
@@ -504,7 +525,9 @@ public final class ClientGenerator implements Runnable {
           "}",
           () ->
               writer.write(
-                  "throw new System.NotSupportedException(\"Event-stream operations are not"
+                  "throw new "
+                      + writer.frameworkType("System.NotSupportedException")
+                      + "(\"Event-stream operations are not"
                       + " supported by the declared service protocols.\");"));
       writer.write("");
       return;
@@ -522,7 +545,8 @@ public final class ClientGenerator implements Runnable {
         "}",
         () -> {
           if (hasInput) {
-            writer.write("System.ArgumentNullException.ThrowIfNull(input);");
+            writer.write(
+                writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(input);");
             writeIdempotencyTokenDefaults(
                 model.expectShape(op.getInputShape(), StructureShape.class));
           }
@@ -585,13 +609,16 @@ public final class ClientGenerator implements Runnable {
     Model model = context.model();
     String inputType = writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape())));
     String outputType = writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())));
-    return "System.Collections.Generic.IAsyncEnumerable<"
+    return writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
+        + "<"
         + outputType
         + "> "
         + CSharpNaming.typeName(op.getId().getName())
         + "PagesAsync("
         + inputType
-        + " input, System.Threading.CancellationToken cancellationToken = default)";
+        + " input, "
+        + writer.frameworkType("System.Threading.CancellationToken")
+        + " cancellationToken = default)";
   }
 
   /**
@@ -604,7 +631,8 @@ public final class ClientGenerator implements Runnable {
     return paginatorItemElementType(writer, context, info)
         .map(
             elementType ->
-                "System.Collections.Generic.IAsyncEnumerable<"
+                writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
+                    + "<"
                     + elementType
                     + "> "
                     + CSharpNaming.typeName(info.getOperation().getId().getName())
@@ -614,7 +642,9 @@ public final class ClientGenerator implements Runnable {
                             .symbolProvider()
                             .toSymbol(
                                 context.model().expectShape(info.getOperation().getInputShape())))
-                    + " input, System.Threading.CancellationToken cancellationToken = default)");
+                    + " input, "
+                    + writer.frameworkType("System.Threading.CancellationToken")
+                    + " cancellationToken = default)");
   }
 
   private static Optional<String> paginatorItemElementType(
@@ -654,12 +684,13 @@ public final class ClientGenerator implements Runnable {
     writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
     writer.write(
         "public async $L",
-        withEnumeratorCancellation(paginatorPagesSignature(writer, context, op)));
+        withEnumeratorCancellation(writer, paginatorPagesSignature(writer, context, op)));
     writer.openBlock(
         "{",
         "}",
         () -> {
-          writer.write("System.ArgumentNullException.ThrowIfNull(input);");
+          writer.write(
+              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(input);");
           writer.write(
               "var output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
               opName);
@@ -685,7 +716,7 @@ public final class ClientGenerator implements Runnable {
             signature -> {
               String itemsExpr = memberPathExpr("page", info.getItemsMemberPath());
               writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
-              writer.write("public async $L", withEnumeratorCancellation(signature));
+              writer.write("public async $L", withEnumeratorCancellation(writer, signature));
               writer.openBlock(
                   "{",
                   "}",
@@ -725,11 +756,16 @@ public final class ClientGenerator implements Runnable {
   }
 
   /** Adds [EnumeratorCancellation] to a paginator signature's cancellation-token parameter. */
-  static String withEnumeratorCancellation(String signature) {
+  static String withEnumeratorCancellation(CSharpWriter writer, String signature) {
     return signature.replace(
-        "System.Threading.CancellationToken cancellationToken",
-        "[System.Runtime.CompilerServices.EnumeratorCancellation]"
-            + " System.Threading.CancellationToken cancellationToken");
+        writer.frameworkType("System.Threading.CancellationToken") + " cancellationToken",
+        "["
+            + writer.frameworkAttribute(
+                "System.Runtime.CompilerServices.EnumeratorCancellationAttribute")
+            + "]"
+            + " "
+            + writer.frameworkType("System.Threading.CancellationToken")
+            + " cancellationToken");
   }
 
   static String operationSignature(
@@ -745,15 +781,16 @@ public final class ClientGenerator implements Runnable {
         hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
     String returnType =
         hasOutput
-            ? "System.Threading.Tasks.Task<" + outputType + ">"
-            : "System.Threading.Tasks.Task";
+            ? writer.frameworkType("System.Threading.Tasks.Task") + "<" + outputType + ">"
+            : writer.frameworkType("System.Threading.Tasks.Task");
     String params = hasInput ? inputType + " input, " : "";
     return returnType
         + " "
         + name
         + "("
         + params
-        + "System.Threading.CancellationToken cancellationToken = default)";
+        + writer.frameworkType("System.Threading.CancellationToken")
+        + " cancellationToken = default)";
   }
 
   private Map<String, String> operationParameterDocs(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -643,50 +643,62 @@ public final class ClientGenerator implements Runnable {
 
   private void writeOperationMethod(Model model, OperationShape op) {
     writer.writeXmlDocs(op, operationParameterDocs(model, op));
-    if (!canBindOperation(op)) {
-      writer.write("public $L", operationSignature(writer, context, op));
-      writer.openBlock(
-          "{",
-          "}",
-          () ->
-              writer.write(
-                  "throw new $T(\"Event-stream operations are not supported by the declared service"
-                      + " protocols.\");",
-                  RuntimeTypes.NOT_SUPPORTED_EXCEPTION));
+    writer.pushState();
+    try {
+      writer.putContext("signature", operationSignature(writer, context, op));
+      if (!canBindOperation(op)) {
+        writer.putContext("notSupportedException", RuntimeTypes.NOT_SUPPORTED_EXCEPTION);
+        writer.write(
+            """
+            public ${signature:L}
+            {
+                throw new ${notSupportedException:T}("Event-stream operations are not supported by the declared service protocols.");
+            }
+            """);
+        writer.write("");
+        return;
+      }
+
+      boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
+      boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
+      writer.putContext("operation", CSharpNaming.typeName(op.getId().getName()));
+      writer.putContext(
+          "inputArgument",
+          hasInput ? "input" : writer.typeName(RuntimeTypes.SMITHY_UNIT) + ".Value");
+      writer.putContext(
+          "prepareInput",
+          writer.consumer(
+              w -> {
+                if (hasInput) {
+                  w.write("$T.ThrowIfNull(input);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+                  writeIdempotencyTokenDefaults(
+                      model.expectShape(op.getInputShape(), StructureShape.class));
+                }
+              }));
+      if (hasOutput) {
+        writer.write(
+            """
+            public ${signature:L}
+            {
+                ${prepareInput:C|}
+                return runtime.InvokeAsync(${operation:L}Binding, ${inputArgument:L}, cancellationToken);
+            }
+            """);
+      } else {
+        writer.write(
+            """
+            public async ${signature:L}
+            {
+                ${prepareInput:C|}
+                await runtime.InvokeAsync(${operation:L}Binding, ${inputArgument:L}, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            """);
+      }
       writer.write("");
-      return;
+    } finally {
+      writer.popState();
     }
-
-    boolean hasInput = !ShapeSupport.isUnit(op.getInputShape());
-    boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
-    String opName = CSharpNaming.typeName(op.getId().getName());
-    String inputArg = hasInput ? "input" : (writer.typeName(RuntimeTypes.SMITHY_UNIT) + ".Value");
-
-    writer.write(
-        hasOutput ? "public $L" : "public async $L", operationSignature(writer, context, op));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (hasInput) {
-            writer.write("$T.ThrowIfNull(input);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-            writeIdempotencyTokenDefaults(
-                model.expectShape(op.getInputShape(), StructureShape.class));
-          }
-
-          if (hasOutput) {
-            writer.write(
-                "return runtime.InvokeAsync($LBinding, $L, cancellationToken);", opName, inputArg);
-          } else {
-            writer.write(
-                "await runtime.InvokeAsync($LBinding, $L,"
-                    + " cancellationToken).ConfigureAwait(false);",
-                opName,
-                inputArg);
-            writer.write("return;");
-          }
-        });
-    writer.write("");
   }
 
   private void writeIdempotencyTokenDefaults(StructureShape input) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -66,30 +66,7 @@ public final class ClientGenerator implements Runnable {
     String interfaceName = "I" + typeName;
 
     // Interface — IDisposable so a client that owns its HttpClient is released via `using` or DI.
-    writer.writeXmlDocs(service);
-    writer.write("public interface $L : $T", interfaceName, RuntimeTypes.I_DISPOSABLE);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("");
-          for (OperationShape op : operations) {
-            writer.writeXmlDocs(op, operationParameterDocs(model, op));
-            writer.write("$L;", operationSignature(writer, context, op));
-            paginationInfo(context, service, op)
-                .ifPresent(
-                    info -> {
-                      writer.writeXmlDocs(op, operationParameterDocs(model, op));
-                      writer.write("$L;", paginatorPagesSignature(writer, context, op));
-                      paginatorItemsSignature(writer, context, info)
-                          .ifPresent(
-                              signature -> {
-                                writer.writeXmlDocs(op, operationParameterDocs(model, op));
-                                writer.write("$L;", signature);
-                              });
-                    });
-          }
-        });
+    writeInterface(model, operations, interfaceName);
     writer.write("");
 
     // Services with no supported protocol get the interface only; there is nothing to wire.
@@ -115,11 +92,11 @@ public final class ClientGenerator implements Runnable {
           case "http/1.1" -> writer.typeName(RuntimeTypes.HTTP_VERSION) + ".Version11";
           default -> throw new IllegalArgumentException(preference.get().alpnId());
         };
-    return ("new " + writer.typeName(RuntimeTypes.SMITHY_HTTP_VERSION_PREFERENCE) + "(")
-        + version
-        + ", allowDowngrade: "
-        + preference.get().allowDowngrade()
-        + ")";
+    return writer.format(
+        "new $T($L, allowDowngrade: $L)",
+        RuntimeTypes.SMITHY_HTTP_VERSION_PREFERENCE,
+        version,
+        preference.get().allowDowngrade());
   }
 
   // ---------------- paginators ----------------
@@ -143,16 +120,13 @@ public final class ClientGenerator implements Runnable {
     Model model = context.model();
     String inputType = writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape())));
     String outputType = writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())));
-    return writer.typeName(RuntimeTypes.I_ASYNC_ENUMERABLE)
-        + "<"
-        + outputType
-        + "> "
-        + CSharpNaming.typeName(op.getId().getName())
-        + "PagesAsync("
-        + inputType
-        + " input, "
-        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
-        + " cancellationToken = default)";
+    return writer.format(
+        "$T<$L> $LPagesAsync($L input, $T cancellationToken = default)",
+        RuntimeTypes.I_ASYNC_ENUMERABLE,
+        outputType,
+        CSharpNaming.typeName(op.getId().getName()),
+        inputType,
+        RuntimeTypes.CANCELLATION_TOKEN);
   }
 
   /**
@@ -165,20 +139,15 @@ public final class ClientGenerator implements Runnable {
     return paginatorItemElementType(writer, context, info)
         .map(
             elementType ->
-                writer.typeName(RuntimeTypes.I_ASYNC_ENUMERABLE)
-                    + "<"
-                    + elementType
-                    + "> "
-                    + CSharpNaming.typeName(info.getOperation().getId().getName())
-                    + "ItemsAsync("
-                    + writer.typeName(
-                        context
-                            .symbolProvider()
-                            .toSymbol(
-                                context.model().expectShape(info.getOperation().getInputShape())))
-                    + " input, "
-                    + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
-                    + " cancellationToken = default)");
+                writer.format(
+                    "$T<$L> $LItemsAsync($T input, $T cancellationToken = default)",
+                    RuntimeTypes.I_ASYNC_ENUMERABLE,
+                    elementType,
+                    CSharpNaming.typeName(info.getOperation().getId().getName()),
+                    context
+                        .symbolProvider()
+                        .toSymbol(context.model().expectShape(info.getOperation().getInputShape())),
+                    RuntimeTypes.CANCELLATION_TOKEN));
   }
 
   /** Renders a null-safe property access chain for a member path, e.g. {@code output.A?.B}. */
@@ -234,18 +203,57 @@ public final class ClientGenerator implements Runnable {
             ? writer.typeName(RuntimeTypes.TASK) + "<" + outputType + ">"
             : writer.typeName(RuntimeTypes.TASK);
     String params = hasInput ? inputType + " input, " : "";
-    return returnType
-        + " "
-        + name
-        + "("
-        + params
-        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
-        + " cancellationToken = default)";
+    return writer.format(
+        "$L $L($L$T cancellationToken = default)",
+        returnType,
+        name,
+        params,
+        RuntimeTypes.CANCELLATION_TOKEN);
   }
 
   // =====================================================================
   // client
   // =====================================================================
+
+  private void writeInterface(Model model, List<OperationShape> operations, String interfaceName) {
+    writer.pushState();
+    try {
+      writer.putContext("interfaceName", interfaceName);
+      writer.putContext("disposable", RuntimeTypes.I_DISPOSABLE);
+      writer.putContext(
+          "operations",
+          writer.consumer(
+              w -> {
+                w.write("");
+                for (OperationShape op : operations) {
+                  w.writeXmlDocs(op, operationParameterDocs(model, op));
+                  w.write("$L;", operationSignature(w, context, op));
+                  paginationInfo(context, service, op)
+                      .ifPresent(
+                          info -> {
+                            w.writeXmlDocs(op, operationParameterDocs(model, op));
+                            w.write("$L;", paginatorPagesSignature(w, context, op));
+                            paginatorItemsSignature(w, context, info)
+                                .ifPresent(
+                                    signature -> {
+                                      w.writeXmlDocs(op, operationParameterDocs(model, op));
+                                      w.write("$L;", signature);
+                                    });
+                          });
+                }
+              }));
+      writer.writeXmlDocs(service);
+      writer.write(
+          """
+          public interface ${interfaceName:L} : ${disposable:T}
+          {
+              ${operations:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
 
   private void writeClient(
       Model model,
@@ -266,79 +274,96 @@ public final class ClientGenerator implements Runnable {
     boolean needsRuntime = operations.stream().anyMatch(op -> canBindOperation(op));
     boolean needsIdempotency =
         operations.stream().anyMatch(op -> operationCanDefaultIdempotencyToken(model, op));
-    writer.writeXmlDocs(service);
-    writer.write("public sealed class $L : $L", typeName, interfaceName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (needsRuntime) {
-            writer.write("private readonly $T runtime;", RuntimeTypes.SMITHY_CLIENT_RUNTIME);
-            // The environment owns only resources created by the runtime factory.
-            writer.write(
-                "private readonly $T environment;", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
-          }
-          if (needsIdempotency) {
-            writer.write(
-                "private readonly $T<string> idempotencyTokenProvider;", RuntimeTypes.FUNC);
-          }
-          // The protocol is bound at construction; per-operation protocols are built once from it.
-          for (OperationShape op : operations) {
-            if (!canBindOperation(op)) {
-              continue;
-            }
-            writer.write(
-                "private readonly $T<$L, $L> $LBinding;",
-                RuntimeTypes.SMITHY_OPERATION_BINDING,
-                SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
-                SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
-                CSharpNaming.typeName(op.getId().getName()));
-          }
-          writer.write("");
+    writer.pushState();
+    try {
+      writer.putContext("client", typeName);
+      writer.putContext("interfaceName", interfaceName);
+      writer.putContext(
+          "fields", writer.consumer(w -> writeFields(operations, needsRuntime, needsIdempotency)));
+      writer.putContext(
+          "constructors",
+          writer.consumer(
+              w ->
+                  writeConstructors(
+                      typeName,
+                      serviceSchema,
+                      primaryProtocol,
+                      modeledHttpVersionPreference,
+                      needsRuntime,
+                      needsIdempotency,
+                      operations)));
+      writer.putContext("readOnlyList", RuntimeTypes.I_READ_ONLY_LIST);
+      // Include auth schemes introduced by operation-level overrides for constructor validation.
+      writer.putContext("authSchemes", modeledAuthSchemesLiteral());
+      writer.putContext(
+          "lifecycle",
+          writer.consumer(
+              w -> {
+                if (needsIdempotency) {
+                  w.write("");
+                  w.write(
+                      "private static string DefaultIdempotencyToken() => $T.NewGuid().ToString();",
+                      RuntimeTypes.GUID);
+                }
+                w.write("");
+                // Only dispose resources owned by the environment; injected transports stay open.
+                w.write(
+                    needsRuntime
+                        ? "public void Dispose() => environment.Dispose();"
+                        : "public void Dispose() { }");
+                w.write("");
+              }));
+      writer.putContext(
+          "operations",
+          writer.consumer(
+              w -> {
+                for (OperationShape op : operations) {
+                  writeOperationMethod(model, op);
+                  paginationInfo(context, service, op)
+                      .ifPresent(info -> writePaginatorMethods(op, info));
+                }
+              }));
+      writer.writeXmlDocs(service);
+      writer.write(
+          """
+          public sealed class ${client:L} : ${interfaceName:L}
+          {
+              ${fields:C|}
 
-          writeConstructors(
-              typeName,
-              serviceSchema,
-              primaryProtocol,
-              modeledHttpVersionPreference,
-              needsRuntime,
-              needsIdempotency,
-              operations);
+              ${constructors:C|}
+              private static readonly ${readOnlyList:T}<string> ModeledAuthSchemes = ${authSchemes:L};
 
-          // Every auth scheme that can be effective for a service operation. This includes schemes
-          // introduced solely by an operation-level @auth override, so constructor validation does
-          // not reject a client configured specifically for such an operation.
-          writer.write(
-              "private static readonly $T<string> ModeledAuthSchemes = $L;",
-              RuntimeTypes.I_READ_ONLY_LIST,
-              modeledAuthSchemesLiteral());
-          writer.write("");
-
-          if (needsIdempotency) {
-            writer.write("");
-            writer.write(
-                "private static string DefaultIdempotencyToken() => $T.NewGuid().ToString();",
-                RuntimeTypes.GUID);
+              ${lifecycle:C|}
+              ${operations:C|}
           }
-          writer.write("");
-
-          // Disposes the HttpClient the client created itself; a no-op when the caller supplied the
-          // HttpClient or runtime, so injected transports are never
-          // closed.
-          if (needsRuntime) {
-            writer.write("public void Dispose() => environment.Dispose();");
-          } else {
-            writer.write("public void Dispose() { }");
-          }
-          writer.write("");
-
-          for (OperationShape op : operations) {
-            writeOperationMethod(model, op);
-            paginationInfo(context, service, op).ifPresent(info -> writePaginatorMethods(op, info));
-          }
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
     writer.write("");
     writeConfigClass(typeName);
+  }
+
+  private void writeFields(
+      List<OperationShape> operations, boolean needsRuntime, boolean needsIdempotency) {
+    if (needsRuntime) {
+      writer.write("private readonly $T runtime;", RuntimeTypes.SMITHY_CLIENT_RUNTIME);
+      writer.write("private readonly $T environment;", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
+    }
+    if (needsIdempotency) {
+      writer.write("private readonly $T<string> idempotencyTokenProvider;", RuntimeTypes.FUNC);
+    }
+    // Bind each operation's protocol once, during construction.
+    for (OperationShape op : operations) {
+      if (canBindOperation(op)) {
+        writer.write(
+            "private readonly $T<$L, $L> $LBinding;",
+            RuntimeTypes.SMITHY_OPERATION_BINDING,
+            SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
+            SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
+            CSharpNaming.typeName(op.getId().getName()));
+      }
+    }
   }
 
   private void writeConstructors(
@@ -388,7 +413,8 @@ public final class ClientGenerator implements Runnable {
       // The explicit endpoint wins over config.Endpoint. The private constructor receives a copy.
       writer.write(
           """
-          public ${client:L}(${uri:T} endpoint, ${client:L}Config? config = null) : this(WithEndpoint(endpoint, config))
+          public ${client:L}(${uri:T} endpoint, ${client:L}Config? config = null)
+              : this(WithEndpoint(endpoint, config))
           {
           }
 
@@ -414,7 +440,8 @@ public final class ClientGenerator implements Runnable {
             public ${client:L}(${runtime:T} runtime, ${client:L}Config? config = null)
             {
                 config ??= new ${client:L}Config();
-                this.environment = ${environment:T}.FromRuntime(${serviceSchema:L}, runtime, config, static () => new ${protocol:L}());
+                this.environment = ${environment:T}.FromRuntime(
+                    ${serviceSchema:L}, runtime, config, static () => new ${protocol:L}());
                 this.runtime = environment.Runtime;
                 var serviceProtocol = environment.ServiceProtocol;
                 ${bindings:C|}
@@ -449,30 +476,46 @@ public final class ClientGenerator implements Runnable {
   }
 
   private void writeSafeOperationBindings(List<OperationShape> operations) {
-    writer.write("try");
-    writer.openBlock("{", "}", () -> writeOperationBindings(operations));
-    writer.write("catch");
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("environment.Dispose();");
-          writer.write("throw;");
-        });
+    writer.pushState();
+    try {
+      writer.putContext("bindings", writer.consumer(w -> writeOperationBindings(operations)));
+      writer.write(
+          """
+          try
+          {
+              ${bindings:C|}
+          }
+          catch
+          {
+              environment.Dispose();
+              throw;
+          }\
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeEnvironmentCreation(
       String serviceSchema, String primaryProtocol, String preference, String httpClient) {
-    writer.write(
-        "this.environment = $T.Create($L, config, static () => new $L(), ModeledAuthSchemes, $L,"
-            + " $L);",
-        RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT,
-        serviceSchema,
-        primaryProtocol,
-        preference,
-        httpClient);
-    writer.write("this.runtime = environment.Runtime;");
-    writer.write("var serviceProtocol = environment.ServiceProtocol;");
+    writer.pushState();
+    try {
+      writer.putContext("environment", RuntimeTypes.SMITHY_HTTP_CLIENT_ENVIRONMENT);
+      writer.putContext("serviceSchema", serviceSchema);
+      writer.putContext("protocol", primaryProtocol);
+      writer.putContext("preference", preference);
+      writer.putContext("httpClientArgument", httpClient);
+      writer.write(
+          """
+          this.environment = ${environment:T}.Create(
+              ${serviceSchema:L}, config, static () => new ${protocol:L}(),
+              ModeledAuthSchemes, ${preference:L}, ${httpClientArgument:L});
+          this.runtime = environment.Runtime;
+          var serviceProtocol = environment.ServiceProtocol;\
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   /**
@@ -570,23 +613,34 @@ public final class ClientGenerator implements Runnable {
    * Binds each operation's protocol from the local {@code serviceProtocol} in a constructor body.
    */
   private void writeOperationBindings(List<OperationShape> operations) {
-    for (OperationShape op : operations) {
-      if (!canBindOperation(op)) {
-        continue;
+    writer.pushState();
+    try {
+      writer.putContext("binding", RuntimeTypes.SMITHY_OPERATION_BINDING);
+      writer.putContext(
+          "serviceSchema", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
+      for (OperationShape op : operations) {
+        if (!canBindOperation(op)) {
+          continue;
+        }
+        writer.putContext("operation", CSharpNaming.typeName(op.getId().getName()));
+        writer.putContext(
+            "inputType", SchemaGenerator.operationShapeType(writer, context, op.getInputShape()));
+        writer.putContext(
+            "outputType", SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()));
+        writer.putContext(
+            "operationSchema", SchemaGenerator.operationSchemaAccessor(writer, context, op));
+        writer.putContext("authSchemes", operationAuthSchemesLiteral(op));
+        writer.putContext("hostPrefix", operationHostPrefixLiteral(op));
+        writer.write(
+            """
+            this.${operation:L}Binding = new ${binding:T}<${inputType:L}, ${outputType:L}>(
+                ${serviceSchema:L}.Id, ${operationSchema:L}.Id,
+                serviceProtocol.ForClientOperation(${operationSchema:L}),
+                ${authSchemes:L}, ${hostPrefix:L});\
+            """);
       }
-      String operationSchema = SchemaGenerator.operationSchemaAccessor(writer, context, op);
-      writer.write(
-          "this.$LBinding = new $T<$L, $L>($L.Id, $L.Id, serviceProtocol.ForClientOperation($L),"
-              + " $L, $L);",
-          CSharpNaming.typeName(op.getId().getName()),
-          RuntimeTypes.SMITHY_OPERATION_BINDING,
-          SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
-          SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
-          SchemaGenerator.serviceSchemaAccessor(writer, context, service),
-          operationSchema,
-          operationSchema,
-          operationAuthSchemesLiteral(op),
-          operationHostPrefixLiteral(op));
+    } finally {
+      writer.popState();
     }
   }
 
@@ -652,7 +706,8 @@ public final class ClientGenerator implements Runnable {
             """
             public ${signature:L}
             {
-                throw new ${notSupportedException:T}("Event-stream operations are not supported by the declared service protocols.");
+                throw new ${notSupportedException:T}(
+                  "Event-stream operations are not supported by the declared service protocols.");
             }
             """);
         writer.write("");
@@ -690,7 +745,8 @@ public final class ClientGenerator implements Runnable {
             public async ${signature:L}
             {
                 ${prepareInput:C|}
-                await runtime.InvokeAsync(${operation:L}Binding, ${inputArgument:L}, cancellationToken).ConfigureAwait(false);
+                await runtime.InvokeAsync(${operation:L}Binding, ${inputArgument:L}, cancellationToken)
+                  .ConfigureAwait(false);
                 return;
             }
             """);
@@ -711,16 +767,27 @@ public final class ClientGenerator implements Runnable {
       return;
     }
 
-    writer.write("input = input with");
-    writer.openBlock(
-        "{",
-        "};",
-        () -> {
-          for (MemberShape member : idempotencyMembers) {
-            String prop = CSharpNaming.propertyName(member.getMemberName());
-            writer.write("$L = input.$L ?? this.idempotencyTokenProvider(),", prop, prop);
-          }
-        });
+    writer.pushState();
+    try {
+      writer.putContext(
+          "defaults",
+          writer.consumer(
+              w -> {
+                for (MemberShape member : idempotencyMembers) {
+                  String property = CSharpNaming.propertyName(member.getMemberName());
+                  w.write("$L = input.$L ?? this.idempotencyTokenProvider(),", property, property);
+                }
+              }));
+      writer.write(
+          """
+          input = input with
+          {
+              ${defaults:C|}
+          };\
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private static Optional<String> paginatorItemElementType(
@@ -781,21 +848,22 @@ public final class ClientGenerator implements Runnable {
                 writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
                 writer.write(
                     """
-                    public async ${itemsSignature:L}
-                    {
-                        await foreach (var page in ${operation:L}PagesAsync(input, cancellationToken).ConfigureAwait(false))
-                        {
-                            var items = ${items:L};
-                            if (items is null)
-                            {
-                                continue;
-                            }
-                            foreach (var item in items.Values)
-                            {
-                                yield return item;
-                            }
-                        }
-                    }
+                      public async ${itemsSignature:L}
+                      {
+                          await foreach (var page in ${operation:L}PagesAsync(input, cancellationToken)
+                    .ConfigureAwait(false))
+                          {
+                              var items = ${items:L};
+                              if (items is null)
+                              {
+                                  continue;
+                              }
+                              foreach (var item in items.Values)
+                              {
+                                  yield return item;
+                              }
+                          }
+                      }
                     """);
                 writer.write("");
               });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGenerator.java
@@ -743,66 +743,65 @@ public final class ClientGenerator implements Runnable {
    * lifecycle (auth, retries, endpoint resolution, telemetry).
    */
   private void writePaginatorMethods(OperationShape op, PaginationInfo info) {
-    String opName = CSharpNaming.typeName(op.getId().getName());
-    String tokenProperty = CSharpNaming.propertyName(info.getInputTokenMember().getMemberName());
-    String outputTokenExpr = memberPathExpr("output", info.getOutputTokenMemberPath());
+    writer.pushState();
+    try {
+      writer.putContext("operation", CSharpNaming.typeName(op.getId().getName()));
+      writer.putContext(
+          "tokenProperty", CSharpNaming.propertyName(info.getInputTokenMember().getMemberName()));
+      writer.putContext("outputToken", memberPathExpr("output", info.getOutputTokenMemberPath()));
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext(
+          "pagesSignature",
+          withEnumeratorCancellation(writer, paginatorPagesSignature(writer, context, op)));
+      writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
+      writer.write(
+          """
+          public async ${pagesSignature:L}
+          {
+              ${argumentNullException:T}.ThrowIfNull(input);
+              var output = await ${operation:L}Async(input, cancellationToken).ConfigureAwait(false);
+              yield return output;
+              var token = ${outputToken:L};
+              while (token is not null)
+              {
+                  input = input with { ${tokenProperty:L} = token };
+                  output = await ${operation:L}Async(input, cancellationToken).ConfigureAwait(false);
+                  yield return output;
+                  token = ${outputToken:L};
+              }
+          }
+          """);
+      writer.write("");
 
-    writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
-    writer.write(
-        "public async $L",
-        withEnumeratorCancellation(writer, paginatorPagesSignature(writer, context, op)));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("$T.ThrowIfNull(input);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-          writer.write(
-              "var output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
-              opName);
-          writer.write("yield return output;");
-          writer.write("var token = $L;", outputTokenExpr);
-          writer.write("while (token is not null)");
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("input = input with { $L = token };", tokenProperty);
+      paginatorItemsSignature(writer, context, info)
+          .ifPresent(
+              signature -> {
+                writer.putContext("itemsSignature", withEnumeratorCancellation(writer, signature));
+                writer.putContext("items", memberPathExpr("page", info.getItemsMemberPath()));
+                writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
                 writer.write(
-                    "output = await $LAsync(input, cancellationToken).ConfigureAwait(false);",
-                    opName);
-                writer.write("yield return output;");
-                writer.write("token = $L;", outputTokenExpr);
+                    """
+                    public async ${itemsSignature:L}
+                    {
+                        await foreach (var page in ${operation:L}PagesAsync(input, cancellationToken).ConfigureAwait(false))
+                        {
+                            var items = ${items:L};
+                            if (items is null)
+                            {
+                                continue;
+                            }
+                            foreach (var item in items.Values)
+                            {
+                                yield return item;
+                            }
+                        }
+                    }
+                    """);
+                writer.write("");
               });
-        });
-    writer.write("");
-
-    paginatorItemsSignature(writer, context, info)
-        .ifPresent(
-            signature -> {
-              String itemsExpr = memberPathExpr("page", info.getItemsMemberPath());
-              writer.writeXmlDocs(op, operationParameterDocs(context.model(), op));
-              writer.write("public async $L", withEnumeratorCancellation(writer, signature));
-              writer.openBlock(
-                  "{",
-                  "}",
-                  () -> {
-                    writer.write(
-                        "await foreach (var page in $LPagesAsync(input,"
-                            + " cancellationToken).ConfigureAwait(false))",
-                        opName);
-                    writer.openBlock(
-                        "{",
-                        "}",
-                        () -> {
-                          writer.write("var items = $L;", itemsExpr);
-                          writer.write("if (items is null)");
-                          writer.openBlock("{", "}", () -> writer.write("continue;"));
-                          writer.write("foreach (var item in items.Values)");
-                          writer.openBlock("{", "}", () -> writer.write("yield return item;"));
-                        });
-                  });
-              writer.write("");
-            });
+    } finally {
+      writer.popState();
+    }
   }
 
   private Map<String, String> operationParameterDocs(Model model, OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -30,6 +30,7 @@ public final class ErrorGenerator implements Runnable {
 
   public ErrorGenerator(GenerationContext c, CSharpWriter w, StructureShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }
@@ -47,10 +48,13 @@ public final class ErrorGenerator implements Runnable {
     writer.writeXmlDocs(shape);
     if (retryable.isPresent()) {
       writer.write(
-          "public sealed partial class $L : System.Exception, NSmithy.Core.ISmithyRetryableError",
+          "public sealed partial class $L : "
+              + writer.frameworkType("System.Exception")
+              + ", NSmithy.Core.ISmithyRetryableError",
           typeName);
     } else {
-      writer.write("public sealed partial class $L : System.Exception", typeName);
+      writer.write(
+          "public sealed partial class $L : " + writer.frameworkType("System.Exception"), typeName);
     }
     writer.openBlock(
         "{",
@@ -122,7 +126,9 @@ public final class ErrorGenerator implements Runnable {
               String param = CSharpNaming.parameterName(m.getMemberName());
               if (!ShapeSupport.isNullable(m) && ShapeSupport.isReferenceType(model, m)) {
                 writer.write(
-                    "$L = $L ?? throw new System.ArgumentNullException(nameof($L));",
+                    "$L = $L ?? throw new "
+                        + writer.frameworkType("System.ArgumentNullException")
+                        + "(nameof($L));",
                     prop,
                     param,
                     param);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -7,6 +7,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.LinkedHashMap;
@@ -47,13 +48,12 @@ public final class ErrorGenerator implements Runnable {
     writer.writeXmlDocs(shape);
     if (retryable.isPresent()) {
       writer.write(
-          "public sealed partial class $L : "
-              + writer.frameworkType("System.Exception")
-              + ", NSmithy.Core.ISmithyRetryableError",
-          typeName);
+          "public sealed partial class $L : $T, $T",
+          typeName,
+          RuntimeTypes.EXCEPTION,
+          RuntimeTypes.I_SMITHY_RETRYABLE_ERROR);
     } else {
-      writer.write(
-          "public sealed partial class $L : " + writer.frameworkType("System.Exception"), typeName);
+      writer.write("public sealed partial class $L : $T", typeName, RuntimeTypes.EXCEPTION);
     }
     writer.openBlock(
         "{",
@@ -62,7 +62,8 @@ public final class ErrorGenerator implements Runnable {
           retryable.ifPresent(
               trait -> {
                 writer.write(
-                    "bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => $L;",
+                    "bool $T.IsThrottlingError => $L;",
+                    RuntimeTypes.I_SMITHY_RETRYABLE_ERROR,
                     trait.getThrottling() ? "true" : "false");
                 writer.write("");
               });
@@ -125,11 +126,10 @@ public final class ErrorGenerator implements Runnable {
               String param = CSharpNaming.parameterName(m.getMemberName());
               if (!ShapeSupport.isNullable(m) && ShapeSupport.isReferenceType(model, m)) {
                 writer.write(
-                    "$L = $L ?? throw new "
-                        + writer.frameworkType("System.ArgumentNullException")
-                        + "(nameof($L));",
+                    "$L = $L ?? throw new $T(nameof($L));",
                     prop,
                     param,
+                    RuntimeTypes.ARGUMENT_NULL_EXCEPTION,
                     param);
               } else {
                 writer.write("$L = $L;", prop, param);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -30,7 +30,6 @@ public final class ErrorGenerator implements Runnable {
 
   public ErrorGenerator(GenerationContext c, CSharpWriter w, StructureShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -36,6 +36,7 @@ public final class ErrorGenerator implements Runnable {
 
   @Override
   public void run() {
+    writer.reserveMemberNames(shape);
     SymbolProvider sp = context.symbolProvider();
     Model model = context.model();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
@@ -101,7 +102,7 @@ public final class ErrorGenerator implements Runnable {
     if (!hasRequired) sig.append(" = null");
     for (MemberShape m : ctor) {
       sig.append(", ")
-          .append(ShapeSupport.parameterTypeExpr(model, sp, m))
+          .append(ShapeSupport.parameterTypeExpr(writer, model, sp, m))
           .append(' ')
           .append(CSharpNaming.parameterName(m.getMemberName()));
       if (ShapeSupport.isOptionalParameter(m)) sig.append(" = null");
@@ -138,7 +139,7 @@ public final class ErrorGenerator implements Runnable {
     for (MemberShape m : ShapeSupport.sortedMembers(shape, excluded)) {
       String prop = CSharpNaming.propertyName(m.getMemberName());
       boolean nullable = ShapeSupport.isNullable(m);
-      String type = ShapeSupport.memberTypeExpr(model, sp, m, nullable);
+      String type = ShapeSupport.memberTypeExpr(writer, model, sp, m, nullable);
       writer.writeXmlDocs(m);
       writer.write("public $L $L { get; }", type, prop);
     }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGenerator.java
@@ -45,37 +45,47 @@ public final class ErrorGenerator implements Runnable {
     List<MemberShape> members = ShapeSupport.sortedMembers(shape);
 
     Optional<RetryableTrait> retryable = shape.getTrait(RetryableTrait.class);
-    writer.writeXmlDocs(shape);
-    if (retryable.isPresent()) {
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("exception", RuntimeTypes.EXCEPTION);
+      writer.putContext(
+          "retryableInterface",
+          retryable.isPresent()
+              ? writer.format(", $T", RuntimeTypes.I_SMITHY_RETRYABLE_ERROR)
+              : "");
+      writer.putContext(
+          "members",
+          writer.consumer(
+              w -> {
+                retryable.ifPresent(
+                    trait -> {
+                      w.write(
+                          "bool $T.IsThrottlingError => $L;",
+                          RuntimeTypes.I_SMITHY_RETRYABLE_ERROR,
+                          trait.getThrottling() ? "true" : "false");
+                      w.write("");
+                    });
+                writeConstructor(typeName, messageMember.orElse(null));
+                messageMember.ifPresent(
+                    member -> {
+                      w.writeXmlDocs(member);
+                      w.write("public override string Message => base.Message!;");
+                      w.write("");
+                    });
+                writeProperties(sp, model, messageMember.orElse(null));
+              }));
+      writer.writeXmlDocs(shape);
       writer.write(
-          "public sealed partial class $L : $T, $T",
-          typeName,
-          RuntimeTypes.EXCEPTION,
-          RuntimeTypes.I_SMITHY_RETRYABLE_ERROR);
-    } else {
-      writer.write("public sealed partial class $L : $T", typeName, RuntimeTypes.EXCEPTION);
+          """
+          public sealed partial class ${typeName:L} : ${exception:T}${retryableInterface:L}
+          {
+              ${members:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
     }
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          retryable.ifPresent(
-              trait -> {
-                writer.write(
-                    "bool $T.IsThrottlingError => $L;",
-                    RuntimeTypes.I_SMITHY_RETRYABLE_ERROR,
-                    trait.getThrottling() ? "true" : "false");
-                writer.write("");
-              });
-          writeConstructor(typeName, messageMember.orElse(null));
-          messageMember.ifPresent(
-              mm -> {
-                writer.writeXmlDocs(mm);
-                writer.write("public override string Message => base.Message!;");
-                writer.write("");
-              });
-          writeProperties(sp, model, messageMember.orElse(null));
-        });
     writer.write("");
     SchemaGenerator.writeStructureSchema(writer, context, shape, members);
   }
@@ -101,43 +111,66 @@ public final class ErrorGenerator implements Runnable {
     }
     writer.writeXmlDocs(shape, parameterDocs);
 
-    StringBuilder sig = new StringBuilder("public ").append(typeName).append("(");
-    sig.append("string? message");
-    if (!hasRequired) sig.append(" = null");
-    for (MemberShape m : ctor) {
-      sig.append(", ")
-          .append(ShapeSupport.parameterTypeExpr(writer, model, sp, m))
-          .append(' ')
-          .append(CSharpNaming.parameterName(m.getMemberName()));
-      if (ShapeSupport.isOptionalParameter(m)) sig.append(" = null");
-    }
-    sig.append(")");
-    writer.write(sig.toString());
-    writer.write("    : base(message)");
-    if (ctor.isEmpty()) {
-      writer.write("{ }");
-    } else {
-      writer.openBlock(
-          "{",
-          "}",
-          () -> {
-            for (MemberShape m : ctor) {
-              String prop = CSharpNaming.propertyName(m.getMemberName());
-              String param = CSharpNaming.parameterName(m.getMemberName());
-              if (!ShapeSupport.isNullable(m) && ShapeSupport.isReferenceType(model, m)) {
-                writer.write(
-                    "$L = $L ?? throw new $T(nameof($L));",
-                    prop,
-                    param,
-                    RuntimeTypes.ARGUMENT_NULL_EXCEPTION,
-                    param);
-              } else {
-                writer.write("$L = $L;", prop, param);
-              }
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      if (ctor.isEmpty()) {
+        writer.write(
+            """
+            public ${typeName:L}(string? message = null)
+                : base(message)
+            { }
+            """);
+      } else {
+        writer.putContext(
+            "parameters",
+            writer.consumer(
+                w -> {
+                  w.write("string? message$L,", hasRequired ? "" : " = null");
+                  for (int i = 0; i < ctor.size(); i++) {
+                    MemberShape member = ctor.get(i);
+                    w.write(
+                        "$L $L$L$L",
+                        ShapeSupport.parameterTypeExpr(w, model, sp, member),
+                        CSharpNaming.parameterName(member.getMemberName()),
+                        ShapeSupport.isOptionalParameter(member) ? " = null" : "",
+                        i + 1 == ctor.size() ? "" : ",");
+                  }
+                }));
+        writer.putContext("assignments", writer.consumer(w -> writeAssignments(ctor)));
+        writer.write(
+            """
+            public ${typeName:L}(
+                ${parameters:C|}
+            )
+                : base(message)
+            {
+                ${assignments:C|}
             }
-          });
+            """);
+      }
+    } finally {
+      writer.popState();
     }
     writer.write("");
+  }
+
+  private void writeAssignments(List<MemberShape> members) {
+    for (MemberShape member : members) {
+      String property = CSharpNaming.propertyName(member.getMemberName());
+      String parameter = CSharpNaming.parameterName(member.getMemberName());
+      if (!ShapeSupport.isNullable(member)
+          && ShapeSupport.isReferenceType(context.model(), member)) {
+        writer.write(
+            "$L = $L ?? throw new $T(nameof($L));",
+            property,
+            parameter,
+            RuntimeTypes.ARGUMENT_NULL_EXCEPTION,
+            parameter);
+      } else {
+        writer.write("$L = $L;", property, parameter);
+      }
+    }
   }
 
   private void writeProperties(SymbolProvider sp, Model model, MemberShape excluded) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -37,10 +37,11 @@ public final class FakeClientGenerator implements Runnable {
 
   public FakeClientGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, w, "fake client");
-    this.matcher = new FakeExampleMatcher(c, values);
+    this.matcher = new FakeExampleMatcher(c, w, values);
   }
 
   @Override
@@ -105,7 +106,7 @@ public final class FakeClientGenerator implements Runnable {
     writer.write(
         "public virtual async $L",
         ClientGenerator.withEnumeratorCancellation(
-            ClientGenerator.paginatorPagesSignature(writer, context, op)));
+            writer, ClientGenerator.paginatorPagesSignature(writer, context, op)));
     writer.openBlock(
         "{",
         "}",
@@ -120,7 +121,8 @@ public final class FakeClientGenerator implements Runnable {
               String itemsExpr = ClientGenerator.memberPathExpr("page", info.getItemsMemberPath());
               writer.write("");
               writer.write(
-                  "public virtual async $L", ClientGenerator.withEnumeratorCancellation(signature));
+                  "public virtual async $L",
+                  ClientGenerator.withEnumeratorCancellation(writer, signature));
               writer.openBlock(
                   "{",
                   "}",

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -13,7 +13,6 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
-import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.Comparator;
 import java.util.List;
@@ -51,8 +50,6 @@ public final class FakeClientGenerator implements Runnable {
         idx.getContainedOperations(service).stream()
             .sorted(Comparator.comparing(o -> o.getId().toString()))
             .collect(Collectors.toList());
-
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
 
     String typeName = CSharpNaming.typeName(service.getId().getName()) + "Client";
     String interfaceName = "I" + typeName;

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -37,7 +37,6 @@ public final class FakeClientGenerator implements Runnable {
 
   public FakeClientGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, w, "fake client");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -39,7 +39,7 @@ public final class FakeClientGenerator implements Runnable {
     this.context = c;
     this.writer = w;
     this.service = s;
-    this.values = new FakeValueSynthesizer(c, "fake client");
+    this.values = new FakeValueSynthesizer(c, w, "fake client");
     this.matcher = new FakeExampleMatcher(c, values);
   }
 
@@ -89,7 +89,7 @@ public final class FakeClientGenerator implements Runnable {
   // ---------------- operation methods ----------------
 
   private void writeOperationMethod(OperationShape op) {
-    writer.write("public virtual $L", ClientGenerator.operationSignature(context, op));
+    writer.write("public virtual $L", ClientGenerator.operationSignature(writer, context, op));
     writer.openBlock("{", "}", () -> matcher.writeOperationBody(writer, op));
   }
 
@@ -105,7 +105,7 @@ public final class FakeClientGenerator implements Runnable {
     writer.write(
         "public virtual async $L",
         ClientGenerator.withEnumeratorCancellation(
-            ClientGenerator.paginatorPagesSignature(context, op)));
+            ClientGenerator.paginatorPagesSignature(writer, context, op)));
     writer.openBlock(
         "{",
         "}",
@@ -114,7 +114,7 @@ public final class FakeClientGenerator implements Runnable {
                 "yield return await $LAsync(input, cancellationToken).ConfigureAwait(false);",
                 opName));
 
-    ClientGenerator.paginatorItemsSignature(context, info)
+    ClientGenerator.paginatorItemsSignature(writer, context, info)
         .ifPresent(
             signature -> {
               String itemsExpr = ClientGenerator.memberPathExpr("page", info.getItemsMemberPath());

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGenerator.java
@@ -66,28 +66,59 @@ public final class FakeClientGenerator implements Runnable {
             + " synthesized from the model otherwise. Responses are deterministic. Override an"
             + " operation method in a subclass to replace individual operations.",
         Map.of());
-    writer.write("public class $L : $L", fakeClass, interfaceName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          for (OperationShape op : ops) {
-            writeOperationMethod(op);
-            ClientGenerator.paginationInfo(context, service, op)
-                .ifPresent(info -> writePaginatorMethods(op, info));
-            writer.write("");
+    writer.pushState();
+    try {
+      writer.putContext("fakeClass", fakeClass);
+      writer.putContext("interfaceName", interfaceName);
+      writer.putContext(
+          "operations",
+          writer.consumer(
+              w -> {
+                for (OperationShape op : ops) {
+                  writeOperationMethod(op);
+                  ClientGenerator.paginationInfo(context, service, op)
+                      .ifPresent(info -> writePaginatorMethods(op, info));
+                  w.write("");
+                }
+              }));
+      writer.putContext(
+          "helpers",
+          writer.consumer(
+              w -> {
+                w.write("public virtual void Dispose() { }");
+                matcher.writePendingMatchers(w);
+                values.writePendingIterators(w);
+              }));
+      writer.write(
+          """
+          public class ${fakeClass:L} : ${interfaceName:L}
+          {
+              ${operations:C|}
+              ${helpers:C|}
           }
-          writer.write("public virtual void Dispose() { }");
-          matcher.writePendingMatchers(writer);
-          values.writePendingIterators(writer);
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   // ---------------- operation methods ----------------
 
   private void writeOperationMethod(OperationShape op) {
-    writer.write("public virtual $L", ClientGenerator.operationSignature(writer, context, op));
-    writer.openBlock("{", "}", () -> matcher.writeOperationBody(writer, op));
+    writer.pushState();
+    try {
+      writer.putContext("signature", ClientGenerator.operationSignature(writer, context, op));
+      writer.putContext("body", writer.consumer(w -> matcher.writeOperationBody(w, op)));
+      writer.write(
+          """
+          public virtual ${signature:L}
+          {
+              ${body:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   /**
@@ -96,48 +127,52 @@ public final class FakeClientGenerator implements Runnable {
    * virtual unary method, so overriding it also changes what the paginators yield.
    */
   private void writePaginatorMethods(OperationShape op, PaginationInfo info) {
-    String opName = CSharpNaming.typeName(op.getId().getName());
-
-    writer.write("");
-    writer.write(
-        "public virtual async $L",
-        ClientGenerator.withEnumeratorCancellation(
-            writer, ClientGenerator.paginatorPagesSignature(writer, context, op)));
-    writer.openBlock(
-        "{",
-        "}",
-        () ->
-            writer.write(
-                "yield return await $LAsync(input, cancellationToken).ConfigureAwait(false);",
-                opName));
-
-    ClientGenerator.paginatorItemsSignature(writer, context, info)
-        .ifPresent(
-            signature -> {
-              String itemsExpr = ClientGenerator.memberPathExpr("page", info.getItemsMemberPath());
-              writer.write("");
-              writer.write(
-                  "public virtual async $L",
-                  ClientGenerator.withEnumeratorCancellation(writer, signature));
-              writer.openBlock(
-                  "{",
-                  "}",
-                  () -> {
-                    writer.write(
-                        "await foreach (var page in $LPagesAsync(input,"
-                            + " cancellationToken).ConfigureAwait(false))",
-                        opName);
-                    writer.openBlock(
-                        "{",
-                        "}",
-                        () -> {
-                          writer.write("var items = $L;", itemsExpr);
-                          writer.write("if (items is null)");
-                          writer.openBlock("{", "}", () -> writer.write("continue;"));
-                          writer.write("foreach (var item in items.Values)");
-                          writer.openBlock("{", "}", () -> writer.write("yield return item;"));
-                        });
-                  });
-            });
+    writer.pushState();
+    try {
+      writer.putContext("operation", CSharpNaming.typeName(op.getId().getName()));
+      writer.putContext(
+          "pagesSignature",
+          ClientGenerator.withEnumeratorCancellation(
+              writer, ClientGenerator.paginatorPagesSignature(writer, context, op)));
+      writer.write("");
+      writer.write(
+          """
+          public virtual async ${pagesSignature:L}
+          {
+              yield return await ${operation:L}Async(input, cancellationToken).ConfigureAwait(false);
+          }
+          """);
+      ClientGenerator.paginatorItemsSignature(writer, context, info)
+          .ifPresent(
+              signature -> {
+                writer.putContext(
+                    "itemsSignature",
+                    ClientGenerator.withEnumeratorCancellation(writer, signature));
+                writer.putContext(
+                    "items", ClientGenerator.memberPathExpr("page", info.getItemsMemberPath()));
+                writer.write("");
+                writer.write(
+                    """
+                    public virtual async ${itemsSignature:L}
+                    {
+                        await foreach (var page in ${operation:L}PagesAsync(input, cancellationToken)
+                            .ConfigureAwait(false))
+                        {
+                            var items = ${items:L};
+                            if (items is null)
+                            {
+                                continue;
+                            }
+                            foreach (var item in items.Values)
+                            {
+                                yield return item;
+                            }
+                        }
+                    }
+                    """);
+              });
+    } finally {
+      writer.popState();
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
@@ -39,6 +39,7 @@ final class FakeExampleMatcher {
   private static final Logger LOGGER = Logger.getLogger(FakeExampleMatcher.class.getName());
 
   private final GenerationContext context;
+  private final CSharpWriter writer;
   private final FakeValueSynthesizer values;
   private final List<PendingMatcher> pendingMatchers = new ArrayList<>();
 
@@ -47,8 +48,9 @@ final class FakeExampleMatcher {
 
   private record Arm(String matchMethod, String title, String statement) {}
 
-  FakeExampleMatcher(GenerationContext context, FakeValueSynthesizer values) {
+  FakeExampleMatcher(GenerationContext context, CSharpWriter writer, FakeValueSynthesizer values) {
     this.context = context;
+    this.writer = writer;
     this.values = values;
   }
 
@@ -64,9 +66,12 @@ final class FakeExampleMatcher {
       writer.openBlock("{", "}", () -> writer.write("$L", arm.statement()));
     }
     if (hasOutput) {
-      writer.write("return System.Threading.Tasks.Task.FromResult($L);", values.outputExpr(op));
+      writer.write(
+          "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".FromResult($L);",
+          values.outputExpr(op));
     } else {
-      writer.write("return System.Threading.Tasks.Task.CompletedTask;");
+      writer.write(
+          "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".CompletedTask;");
     }
   }
 
@@ -131,20 +136,29 @@ final class FakeExampleMatcher {
         String errorExpr = values.errorExpr(error.get().getShapeId(), error.get().getContent());
         statement =
             hasOutput
-                ? "return System.Threading.Tasks.Task.FromException<"
+                ? "return "
+                    + writer.frameworkType("System.Threading.Tasks.Task")
+                    + ".FromException<"
                     + outputType
                     + ">("
                     + errorExpr
                     + ");"
-                : "return System.Threading.Tasks.Task.FromException(" + errorExpr + ");";
+                : "return "
+                    + writer.frameworkType("System.Threading.Tasks.Task")
+                    + ".FromException("
+                    + errorExpr
+                    + ");";
       } else if (hasOutput) {
         ObjectNode output = example.getOutput().orElse(Node.objectNode());
         statement =
-            "return System.Threading.Tasks.Task.FromResult("
+            "return "
+                + writer.frameworkType("System.Threading.Tasks.Task")
+                + ".FromResult("
                 + values.outputExprFor(op, output)
                 + ");";
       } else {
-        statement = "return System.Threading.Tasks.Task.CompletedTask;";
+        statement =
+            "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".CompletedTask;";
       }
       arms.add(new Arm(name, example.getTitle(), statement));
     }
@@ -212,7 +226,8 @@ final class FakeExampleMatcher {
         String v = nextVar(counter);
         out.add(expr + " is { } " + v);
         out.add(
-            "System.Linq.Enumerable.SequenceEqual("
+            writer.frameworkType("System.Linq.Enumerable")
+                + ".SequenceEqual("
                 + v
                 + ", "
                 + values.blobBytesExpr(node, "")

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeExampleMatcher.java
@@ -13,6 +13,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.ArrayList;
@@ -43,11 +44,6 @@ final class FakeExampleMatcher {
   private final FakeValueSynthesizer values;
   private final List<PendingMatcher> pendingMatchers = new ArrayList<>();
 
-  private record PendingMatcher(
-      String name, String title, String inputType, List<String> conditions) {}
-
-  private record Arm(String matchMethod, String title, String statement) {}
-
   FakeExampleMatcher(GenerationContext context, CSharpWriter writer, FakeValueSynthesizer values) {
     this.context = context;
     this.writer = writer;
@@ -66,12 +62,9 @@ final class FakeExampleMatcher {
       writer.openBlock("{", "}", () -> writer.write("$L", arm.statement()));
     }
     if (hasOutput) {
-      writer.write(
-          "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".FromResult($L);",
-          values.outputExpr(op));
+      writer.write("return $T.FromResult($L);", RuntimeTypes.TASK, values.outputExpr(op));
     } else {
-      writer.write(
-          "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".CompletedTask;");
+      writer.write("return $T.CompletedTask;", RuntimeTypes.TASK);
     }
   }
 
@@ -94,6 +87,11 @@ final class FakeExampleMatcher {
           });
     }
   }
+
+  private record PendingMatcher(
+      String name, String title, String inputType, List<String> conditions) {}
+
+  private record Arm(String matchMethod, String title, String statement) {}
 
   private List<Arm> arms(OperationShape op) {
     List<ExamplesTrait.Example> examples =
@@ -137,14 +135,14 @@ final class FakeExampleMatcher {
         statement =
             hasOutput
                 ? "return "
-                    + writer.frameworkType("System.Threading.Tasks.Task")
+                    + writer.typeName(RuntimeTypes.TASK)
                     + ".FromException<"
                     + outputType
                     + ">("
                     + errorExpr
                     + ");"
                 : "return "
-                    + writer.frameworkType("System.Threading.Tasks.Task")
+                    + writer.typeName(RuntimeTypes.TASK)
                     + ".FromException("
                     + errorExpr
                     + ");";
@@ -152,13 +150,12 @@ final class FakeExampleMatcher {
         ObjectNode output = example.getOutput().orElse(Node.objectNode());
         statement =
             "return "
-                + writer.frameworkType("System.Threading.Tasks.Task")
+                + writer.typeName(RuntimeTypes.TASK)
                 + ".FromResult("
                 + values.outputExprFor(op, output)
                 + ");";
       } else {
-        statement =
-            "return " + writer.frameworkType("System.Threading.Tasks.Task") + ".CompletedTask;";
+        statement = "return " + writer.typeName(RuntimeTypes.TASK) + ".CompletedTask;";
       }
       arms.add(new Arm(name, example.getTitle(), statement));
     }
@@ -226,7 +223,7 @@ final class FakeExampleMatcher {
         String v = nextVar(counter);
         out.add(expr + " is { } " + v);
         out.add(
-            writer.frameworkType("System.Linq.Enumerable")
+            writer.typeName(RuntimeTypes.ENUMERABLE)
                 + ".SequenceEqual("
                 + v
                 + ", "

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -39,10 +39,11 @@ public final class FakeHandlerGenerator implements Runnable {
 
   public FakeHandlerGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, w, "fake handler");
-    this.matcher = new FakeExampleMatcher(c, values);
+    this.matcher = new FakeExampleMatcher(c, w, values);
   }
 
   @Override
@@ -108,10 +109,11 @@ public final class FakeHandlerGenerator implements Runnable {
     String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
     String returnType =
         hasOutput
-            ? "System.Threading.Tasks.Task<"
+            ? writer.frameworkType("System.Threading.Tasks.Task")
+                + "<"
                 + writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())))
                 + ">"
-            : "System.Threading.Tasks.Task";
+            : writer.frameworkType("System.Threading.Tasks.Task");
     String params =
         hasInput
             ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) + " input, "
@@ -121,6 +123,7 @@ public final class FakeHandlerGenerator implements Runnable {
         + name
         + "("
         + params
-        + "System.Threading.CancellationToken cancellationToken = default)";
+        + writer.frameworkType("System.Threading.CancellationToken")
+        + " cancellationToken = default)";
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -54,8 +54,6 @@ public final class FakeHandlerGenerator implements Runnable {
             .sorted(Comparator.comparing(o -> o.getId().toString()))
             .collect(Collectors.toList());
 
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-
     String serviceTypeName = CSharpNaming.typeName(service.getId().getName());
     String contract =
         serviceTypeName.endsWith("Service") ? serviceTypeName : serviceTypeName + "Service";
@@ -108,11 +106,11 @@ public final class FakeHandlerGenerator implements Runnable {
     String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
     String returnType =
         hasOutput
-            ? writer.frameworkType("System.Threading.Tasks.Task")
+            ? writer.typeName(RuntimeTypes.TASK)
                 + "<"
                 + writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())))
                 + ">"
-            : writer.frameworkType("System.Threading.Tasks.Task");
+            : writer.typeName(RuntimeTypes.TASK);
     String params =
         hasInput
             ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) + " input, "
@@ -122,7 +120,7 @@ public final class FakeHandlerGenerator implements Runnable {
         + name
         + "("
         + params
-        + writer.frameworkType("System.Threading.CancellationToken")
+        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
         + " cancellationToken = default)";
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -13,7 +13,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
@@ -42,7 +41,7 @@ public final class FakeHandlerGenerator implements Runnable {
     this.context = c;
     this.writer = w;
     this.service = s;
-    this.values = new FakeValueSynthesizer(c, "fake handler");
+    this.values = new FakeValueSynthesizer(c, w, "fake handler");
     this.matcher = new FakeExampleMatcher(c, values);
   }
 
@@ -110,14 +109,12 @@ public final class FakeHandlerGenerator implements Runnable {
     String returnType =
         hasOutput
             ? "System.Threading.Tasks.Task<"
-                + CSharpSymbolProvider.qualified(
-                    sp.toSymbol(model.expectShape(op.getOutputShape())))
+                + writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape())))
                 + ">"
             : "System.Threading.Tasks.Task";
     String params =
         hasInput
-            ? CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getInputShape())))
-                + " input, "
+            ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) + " input, "
             : "";
     return returnType
         + " "

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -39,7 +39,6 @@ public final class FakeHandlerGenerator implements Runnable {
 
   public FakeHandlerGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
     this.values = new FakeValueSynthesizer(c, w, "fake handler");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGenerator.java
@@ -72,29 +72,54 @@ public final class FakeHandlerGenerator implements Runnable {
             + " register a real per-operation handler after this one, to replace individual"
             + " operations.",
         Map.of());
-    writer.write("public class $L : $L", fakeClass, aggInterface);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          boolean first = true;
-          for (OperationShape op : ops) {
-            if (!first) {
-              writer.write("");
-            }
-            first = false;
-            writeOperationMethod(op);
+    writer.pushState();
+    try {
+      writer.putContext("fakeClass", fakeClass);
+      writer.putContext("handler", aggInterface);
+      writer.putContext(
+          "members",
+          writer.consumer(
+              w -> {
+                boolean first = true;
+                for (OperationShape op : ops) {
+                  if (!first) {
+                    w.write("");
+                  }
+                  first = false;
+                  writeOperationMethod(op);
+                }
+                matcher.writePendingMatchers(w);
+                values.writePendingIterators(w);
+              }));
+      writer.write(
+          """
+          public class ${fakeClass:L} : ${handler:L}
+          {
+              ${members:C|}
           }
-          matcher.writePendingMatchers(writer);
-          values.writePendingIterators(writer);
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   // ---------------- operation methods ----------------
 
   private void writeOperationMethod(OperationShape op) {
-    writer.write("public virtual $L", operationSignature(op));
-    writer.openBlock("{", "}", () -> matcher.writeOperationBody(writer, op));
+    writer.pushState();
+    try {
+      writer.putContext("signature", operationSignature(op));
+      writer.putContext("body", writer.consumer(w -> matcher.writeOperationBody(w, op)));
+      writer.write(
+          """
+          public virtual ${signature:L}
+          {
+              ${body:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   /** Same delegate shape the handler interfaces declare; see ServerGenerator. */
@@ -115,12 +140,11 @@ public final class FakeHandlerGenerator implements Runnable {
         hasInput
             ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) + " input, "
             : "";
-    return returnType
-        + " "
-        + name
-        + "("
-        + params
-        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
-        + " cancellationToken = default)";
+    return writer.format(
+        "$L $L($L$T cancellationToken = default)",
+        returnType,
+        name,
+        params,
+        RuntimeTypes.CANCELLATION_TOKEN);
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
@@ -147,14 +147,19 @@ final class FakeValueSynthesizer {
     for (PendingIterator iterator : pendingIterators) {
       writer.write("");
       writer.write(
-          "private static async System.Collections.Generic.IAsyncEnumerable<$L> $L()",
+          "private static async "
+              + writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
+              + "<$L> $L()",
           iterator.eventType(),
           iterator.name());
       writer.openBlock(
           "{",
           "}",
           () -> {
-            writer.write("await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);");
+            writer.write(
+                "await "
+                    + writer.frameworkType("System.Threading.Tasks.Task")
+                    + ".CompletedTask.ConfigureAwait(false);");
             for (String event : iterator.events()) {
               writer.write("yield return $L;", event);
             }
@@ -200,7 +205,9 @@ final class FakeValueSynthesizer {
           expr = eventStreamExpr(op, member, valueNode, stack);
         } else if (op != null && ShapeSupport.isStreamingBlobMember(model, member)) {
           expr =
-              "new System.IO.MemoryStream("
+              "new "
+                  + writer.frameworkType("System.IO.MemoryStream")
+                  + "("
                   + blobBytesExpr(valueNode, CSharpNaming.camel(member.getMemberName()))
                   + ")";
         } else {
@@ -246,7 +253,7 @@ final class FakeValueSynthesizer {
       case TIMESTAMP -> timestampExpr(node);
       case DOCUMENT ->
           node != null
-              ? ShapeSupport.documentLiteral(node)
+              ? ShapeSupport.documentLiteral(writer, node)
               : "NSmithy.Core.Document.From(" + CSharpNaming.formatString(hint) + ")";
       case ENUM -> enumExpr(target, node);
       case INT_ENUM -> intEnumExpr(target, node);
@@ -357,7 +364,13 @@ final class FakeValueSynthesizer {
 
     String typeName = qualifiedType(target);
     if (elements.isEmpty()) {
-      return "new " + typeName + "(System.Array.Empty<" + elementType + ">())";
+      return "new "
+          + typeName
+          + "("
+          + writer.frameworkType("System.Array")
+          + ".Empty<"
+          + elementType
+          + ">())";
     }
     return "new "
         + typeName
@@ -400,7 +413,11 @@ final class FakeValueSynthesizer {
     }
 
     String typeName = qualifiedType(map);
-    String dictionary = "System.Collections.Generic.Dictionary<string, " + valueType + ">";
+    String dictionary =
+        writer.frameworkType("System.Collections.Generic.Dictionary")
+            + "<string, "
+            + valueType
+            + ">";
     if (entries.isEmpty()) {
       return "new " + typeName + "(new " + dictionary + "())";
     }
@@ -456,25 +473,36 @@ final class FakeValueSynthesizer {
 
   String blobBytesExpr(Node node, String hint) {
     if (node != null && node.isStringNode()) {
-      return "System.Convert.FromBase64String("
+      return writer.frameworkType("System.Convert")
+          + ".FromBase64String("
           + CSharpNaming.formatString(node.expectStringNode().getValue())
           + ")";
     }
-    return "System.Text.Encoding.UTF8.GetBytes(" + CSharpNaming.formatString(hint) + ")";
+    return writer.frameworkType("System.Text.Encoding")
+        + ".UTF8.GetBytes("
+        + CSharpNaming.formatString(hint)
+        + ")";
   }
 
   String timestampExpr(Node node) {
     if (node != null && node.isNumberNode()) {
-      return "System.DateTimeOffset.FromUnixTimeSeconds("
+      return writer.frameworkType("System.DateTimeOffset")
+          + ".FromUnixTimeSeconds("
           + node.expectNumberNode().getValue().longValue()
           + ")";
     }
     if (node != null && node.isStringNode()) {
-      return "System.DateTimeOffset.Parse("
+      return writer.frameworkType("System.DateTimeOffset")
+          + ".Parse("
           + CSharpNaming.formatString(node.expectStringNode().getValue())
-          + ", System.Globalization.CultureInfo.InvariantCulture)";
+          + ", "
+          + writer.frameworkType("System.Globalization.CultureInfo")
+          + ".InvariantCulture)";
     }
-    return "System.DateTimeOffset.FromUnixTimeSeconds(" + PLACEHOLDER_EPOCH_SECONDS + ")";
+    return writer.frameworkType("System.DateTimeOffset")
+        + ".FromUnixTimeSeconds("
+        + PLACEHOLDER_EPOCH_SECONDS
+        + ")";
   }
 
   String numberExpr(ShapeType type, Node node, MemberShape member, Shape target) {
@@ -501,7 +529,11 @@ final class FakeValueSynthesizer {
       case LONG -> value.longValue() + "L";
       case FLOAT -> value.floatValue() + "f";
       case DOUBLE -> value.doubleValue() + "d";
-      case BIG_INTEGER -> "System.Numerics.BigInteger.Parse(\"" + value.toBigInteger() + "\")";
+      case BIG_INTEGER ->
+          writer.frameworkType("System.Numerics.BigInteger")
+              + ".Parse(\""
+              + value.toBigInteger()
+              + "\")";
       case BIG_DECIMAL -> value.toPlainString() + "m";
       default -> throw new CodegenException("Not a numeric shape type: " + type);
     };

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
@@ -10,7 +10,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
@@ -50,14 +49,16 @@ final class FakeValueSynthesizer {
   private static final long PLACEHOLDER_EPOCH_SECONDS = 1704067200L;
 
   private final GenerationContext context;
+  private final CSharpWriter writer;
   private final String subject;
   private final List<PendingIterator> pendingIterators = new ArrayList<>();
 
   private record PendingIterator(String name, String eventType, List<String> events) {}
 
   /** `subject` names the consuming fake ("fake handler", "fake client") in codegen warnings. */
-  FakeValueSynthesizer(GenerationContext context, String subject) {
+  FakeValueSynthesizer(GenerationContext context, CSharpWriter writer, String subject) {
     this.context = context;
+    this.writer = writer;
     this.subject = subject;
   }
 
@@ -329,7 +330,7 @@ final class FakeValueSynthesizer {
             : target.asSetShape().orElseThrow().getMember();
     Shape elementTarget = model.expectShape(elementMember.getTarget());
     String elementType =
-        CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(elementTarget))
+        writer.typeName(context.symbolProvider().toSymbol(elementTarget))
             + (ShapeSupport.isSparse(target) ? "?" : "");
 
     List<String> elements = new ArrayList<>();
@@ -372,7 +373,7 @@ final class FakeValueSynthesizer {
     Shape keyTarget = model.expectShape(map.getKey().getTarget());
     Shape valueTarget = model.expectShape(map.getValue().getTarget());
     String valueType =
-        CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(valueTarget))
+        writer.typeName(context.symbolProvider().toSymbol(valueTarget))
             + (ShapeSupport.isSparse(map) ? "?" : "");
 
     List<String> entries = new ArrayList<>();
@@ -551,6 +552,6 @@ final class FakeValueSynthesizer {
   }
 
   String qualifiedType(Shape shape) {
-    return CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(shape));
+    return writer.typeName(context.symbolProvider().toSymbol(shape));
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeValueSynthesizer.java
@@ -11,6 +11,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.math.BigDecimal;
@@ -52,8 +53,6 @@ final class FakeValueSynthesizer {
   private final CSharpWriter writer;
   private final String subject;
   private final List<PendingIterator> pendingIterators = new ArrayList<>();
-
-  private record PendingIterator(String name, String eventType, List<String> events) {}
 
   /** `subject` names the consuming fake ("fake handler", "fake client") in codegen warnings. */
   FakeValueSynthesizer(GenerationContext context, CSharpWriter writer, String subject) {
@@ -147,25 +146,114 @@ final class FakeValueSynthesizer {
     for (PendingIterator iterator : pendingIterators) {
       writer.write("");
       writer.write(
-          "private static async "
-              + writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
-              + "<$L> $L()",
+          "private static async $T<$L> $L()",
+          RuntimeTypes.I_ASYNC_ENUMERABLE,
           iterator.eventType(),
           iterator.name());
       writer.openBlock(
           "{",
           "}",
           () -> {
-            writer.write(
-                "await "
-                    + writer.frameworkType("System.Threading.Tasks.Task")
-                    + ".CompletedTask.ConfigureAwait(false);");
+            writer.write("await $T.CompletedTask.ConfigureAwait(false);", RuntimeTypes.TASK);
             for (String event : iterator.events()) {
               writer.write("yield return $L;", event);
             }
           });
     }
   }
+
+  String enumExpr(Shape target, Node node) {
+    String typeName = qualifiedType(target);
+    if (node != null && node.isStringNode()) {
+      return "new "
+          + typeName
+          + "("
+          + CSharpNaming.formatString(node.expectStringNode().getValue())
+          + ")";
+    }
+    List<MemberShape> members = ShapeSupport.sortedMembers(target);
+    return typeName + "." + CSharpNaming.propertyName(members.get(0).getMemberName());
+  }
+
+  String intEnumExpr(Shape target, Node node) {
+    String typeName = qualifiedType(target);
+    if (node != null && node.isNumberNode()) {
+      return "(" + typeName + ")" + node.expectNumberNode().getValue().longValue();
+    }
+    List<MemberShape> members = ShapeSupport.sortedMembers(target);
+    return typeName + "." + CSharpNaming.propertyName(members.get(0).getMemberName());
+  }
+
+  String blobBytesExpr(Node node, String hint) {
+    if (node != null && node.isStringNode()) {
+      return writer.typeName(RuntimeTypes.CONVERT)
+          + ".FromBase64String("
+          + CSharpNaming.formatString(node.expectStringNode().getValue())
+          + ")";
+    }
+    return writer.typeName(RuntimeTypes.ENCODING)
+        + ".UTF8.GetBytes("
+        + CSharpNaming.formatString(hint)
+        + ")";
+  }
+
+  String timestampExpr(Node node) {
+    if (node != null && node.isNumberNode()) {
+      return writer.typeName(RuntimeTypes.DATE_TIME_OFFSET)
+          + ".FromUnixTimeSeconds("
+          + node.expectNumberNode().getValue().longValue()
+          + ")";
+    }
+    if (node != null && node.isStringNode()) {
+      return writer.typeName(RuntimeTypes.DATE_TIME_OFFSET)
+          + ".Parse("
+          + CSharpNaming.formatString(node.expectStringNode().getValue())
+          + ", "
+          + writer.typeName(RuntimeTypes.CULTURE_INFO)
+          + ".InvariantCulture)";
+    }
+    return writer.typeName(RuntimeTypes.DATE_TIME_OFFSET)
+        + ".FromUnixTimeSeconds("
+        + PLACEHOLDER_EPOCH_SECONDS
+        + ")";
+  }
+
+  String numberExpr(ShapeType type, Node node, MemberShape member, Shape target) {
+    if (node != null
+        && node.isStringNode()
+        && (type == ShapeType.FLOAT || type == ShapeType.DOUBLE)) {
+      String csType = type == ShapeType.FLOAT ? "float" : "double";
+      return switch (node.expectStringNode().getValue()) {
+        case "NaN" -> csType + ".NaN";
+        case "Infinity" -> csType + ".PositiveInfinity";
+        case "-Infinity" -> csType + ".NegativeInfinity";
+        default -> null;
+      };
+    }
+
+    BigDecimal value;
+    if (node != null && node.isNumberNode()) {
+      value = new BigDecimal(node.expectNumberNode().getValue().toString());
+    } else {
+      value = placeholderNumber(member, target);
+    }
+    return switch (type) {
+      case BYTE, SHORT, INTEGER -> Long.toString(value.longValue());
+      case LONG -> value.longValue() + "L";
+      case FLOAT -> value.floatValue() + "f";
+      case DOUBLE -> value.doubleValue() + "d";
+      case BIG_INTEGER ->
+          writer.typeName(RuntimeTypes.BIG_INTEGER) + ".Parse(\"" + value.toBigInteger() + "\")";
+      case BIG_DECIMAL -> value.toPlainString() + "m";
+      default -> throw new CodegenException("Not a numeric shape type: " + type);
+    };
+  }
+
+  String qualifiedType(Shape shape) {
+    return writer.typeName(context.symbolProvider().toSymbol(shape));
+  }
+
+  private record PendingIterator(String name, String eventType, List<String> events) {}
 
   private ObjectNode firstExampleOutput(OperationShape op) {
     return op.getTrait(ExamplesTrait.class).stream()
@@ -206,7 +294,7 @@ final class FakeValueSynthesizer {
         } else if (op != null && ShapeSupport.isStreamingBlobMember(model, member)) {
           expr =
               "new "
-                  + writer.frameworkType("System.IO.MemoryStream")
+                  + writer.typeName(RuntimeTypes.MEMORY_STREAM)
                   + "("
                   + blobBytesExpr(valueNode, CSharpNaming.camel(member.getMemberName()))
                   + ")";
@@ -254,12 +342,14 @@ final class FakeValueSynthesizer {
       case DOCUMENT ->
           node != null
               ? ShapeSupport.documentLiteral(writer, node)
-              : "NSmithy.Core.Document.From(" + CSharpNaming.formatString(hint) + ")";
+              : (writer.typeName(RuntimeTypes.DOCUMENT) + ".From(")
+                  + CSharpNaming.formatString(hint)
+                  + ")";
       case ENUM -> enumExpr(target, node);
       case INT_ENUM -> intEnumExpr(target, node);
       case STRUCTURE ->
           ShapeSupport.isUnit(target.getId())
-              ? "SmithyUnit.Value"
+              ? (writer.typeName(RuntimeTypes.SMITHY_UNIT) + ".Value")
               : structureExpr(
                   target.asStructureShape().orElseThrow(),
                   node != null && node.isObjectNode() ? node.expectObjectNode() : null,
@@ -270,28 +360,6 @@ final class FakeValueSynthesizer {
       case MAP -> mapExpr(target.asMapShape().orElseThrow(), node, stack, member);
       default -> null;
     };
-  }
-
-  String enumExpr(Shape target, Node node) {
-    String typeName = qualifiedType(target);
-    if (node != null && node.isStringNode()) {
-      return "new "
-          + typeName
-          + "("
-          + CSharpNaming.formatString(node.expectStringNode().getValue())
-          + ")";
-    }
-    List<MemberShape> members = ShapeSupport.sortedMembers(target);
-    return typeName + "." + CSharpNaming.propertyName(members.get(0).getMemberName());
-  }
-
-  String intEnumExpr(Shape target, Node node) {
-    String typeName = qualifiedType(target);
-    if (node != null && node.isNumberNode()) {
-      return "(" + typeName + ")" + node.expectNumberNode().getValue().longValue();
-    }
-    List<MemberShape> members = ShapeSupport.sortedMembers(target);
-    return typeName + "." + CSharpNaming.propertyName(members.get(0).getMemberName());
   }
 
   private String unionExpr(UnionShape union, Node node, Set<ShapeId> stack) {
@@ -367,7 +435,7 @@ final class FakeValueSynthesizer {
       return "new "
           + typeName
           + "("
-          + writer.frameworkType("System.Array")
+          + writer.typeName(RuntimeTypes.ARRAY)
           + ".Empty<"
           + elementType
           + ">())";
@@ -413,11 +481,7 @@ final class FakeValueSynthesizer {
     }
 
     String typeName = qualifiedType(map);
-    String dictionary =
-        writer.frameworkType("System.Collections.Generic.Dictionary")
-            + "<string, "
-            + valueType
-            + ">";
+    String dictionary = writer.typeName(RuntimeTypes.DICTIONARY) + "<string, " + valueType + ">";
     if (entries.isEmpty()) {
       return "new " + typeName + "(new " + dictionary + "())";
     }
@@ -471,74 +535,6 @@ final class FakeValueSynthesizer {
     return pendingIterators.stream().anyMatch(iterator -> iterator.name().equals(name));
   }
 
-  String blobBytesExpr(Node node, String hint) {
-    if (node != null && node.isStringNode()) {
-      return writer.frameworkType("System.Convert")
-          + ".FromBase64String("
-          + CSharpNaming.formatString(node.expectStringNode().getValue())
-          + ")";
-    }
-    return writer.frameworkType("System.Text.Encoding")
-        + ".UTF8.GetBytes("
-        + CSharpNaming.formatString(hint)
-        + ")";
-  }
-
-  String timestampExpr(Node node) {
-    if (node != null && node.isNumberNode()) {
-      return writer.frameworkType("System.DateTimeOffset")
-          + ".FromUnixTimeSeconds("
-          + node.expectNumberNode().getValue().longValue()
-          + ")";
-    }
-    if (node != null && node.isStringNode()) {
-      return writer.frameworkType("System.DateTimeOffset")
-          + ".Parse("
-          + CSharpNaming.formatString(node.expectStringNode().getValue())
-          + ", "
-          + writer.frameworkType("System.Globalization.CultureInfo")
-          + ".InvariantCulture)";
-    }
-    return writer.frameworkType("System.DateTimeOffset")
-        + ".FromUnixTimeSeconds("
-        + PLACEHOLDER_EPOCH_SECONDS
-        + ")";
-  }
-
-  String numberExpr(ShapeType type, Node node, MemberShape member, Shape target) {
-    if (node != null
-        && node.isStringNode()
-        && (type == ShapeType.FLOAT || type == ShapeType.DOUBLE)) {
-      String csType = type == ShapeType.FLOAT ? "float" : "double";
-      return switch (node.expectStringNode().getValue()) {
-        case "NaN" -> csType + ".NaN";
-        case "Infinity" -> csType + ".PositiveInfinity";
-        case "-Infinity" -> csType + ".NegativeInfinity";
-        default -> null;
-      };
-    }
-
-    BigDecimal value;
-    if (node != null && node.isNumberNode()) {
-      value = new BigDecimal(node.expectNumberNode().getValue().toString());
-    } else {
-      value = placeholderNumber(member, target);
-    }
-    return switch (type) {
-      case BYTE, SHORT, INTEGER -> Long.toString(value.longValue());
-      case LONG -> value.longValue() + "L";
-      case FLOAT -> value.floatValue() + "f";
-      case DOUBLE -> value.doubleValue() + "d";
-      case BIG_INTEGER ->
-          writer.frameworkType("System.Numerics.BigInteger")
-              + ".Parse(\""
-              + value.toBigInteger()
-              + "\")";
-      case BIG_DECIMAL -> value.toPlainString() + "m";
-      default -> throw new CodegenException("Not a numeric shape type: " + type);
-    };
-  }
-
   private BigDecimal placeholderNumber(MemberShape member, Shape target) {
     if (member != null && member.hasTrait(HttpResponseCodeTrait.class)) {
       return BigDecimal.valueOf(200);
@@ -581,9 +577,5 @@ final class FakeValueSynthesizer {
       return member.expectTrait(traitClass);
     }
     return target.getTrait(traitClass).orElse(null);
-  }
-
-  String qualifiedType(Shape shape) {
-    return writer.typeName(context.symbolProvider().toSymbol(shape));
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
@@ -25,8 +25,7 @@ public final class IntEnumGenerator implements Runnable {
 
   @Override
   public void run() {
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
+
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     writer.writeXmlDocs(shape);
     writer.write("public enum $L", typeName);
@@ -53,11 +52,13 @@ public final class IntEnumGenerator implements Runnable {
         "}",
         () ->
             writer.write(
-                "public static Schema<$L> Schema { get; } ="
-                    + " Schemas.IntEnum<$L>($L, values: $L, traits: $L);",
+                "public static $T<$L> Schema { get; } = $T.IntEnum<$L>($L, values: $L, traits:"
+                    + " $L);",
+                RuntimeTypes.SCHEMA,
                 typeName,
+                RuntimeTypes.SCHEMAS,
                 typeName,
-                SchemaGenerator.shapeIdExpr(shape.getId()),
+                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
                 SchemaGenerator.intEnumValuesExpr(shape),
                 SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values())));
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
@@ -59,6 +59,6 @@ public final class IntEnumGenerator implements Runnable {
                 typeName,
                 SchemaGenerator.shapeIdExpr(shape.getId()),
                 SchemaGenerator.intEnumValuesExpr(shape),
-                SchemaGenerator.traitsExpr(shape.getAllTraits().values())));
+                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values())));
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/IntEnumGenerator.java
@@ -25,41 +25,48 @@ public final class IntEnumGenerator implements Runnable {
 
   @Override
   public void run() {
-
     String typeName = CSharpNaming.typeName(shape.getId().getName());
-    writer.writeXmlDocs(shape);
-    writer.write("public enum $L", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          for (MemberShape m : ShapeSupport.sortedMembers(shape)) {
-            String prop = CSharpNaming.propertyName(m.getMemberName());
-            Integer value =
-                m.getTrait(EnumValueTrait.class).flatMap(t -> t.getIntValue()).orElse(null);
-            writer.writeXmlDocs(m);
-            if (value != null) {
-              writer.write("$L = $L,", prop, value);
-            } else {
-              writer.write("$L,", prop);
-            }
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("shapeId", SchemaGenerator.shapeIdExpr(writer, shape.getId()));
+      writer.putContext("values", SchemaGenerator.intEnumValuesExpr(shape));
+      writer.putContext(
+          "traits", SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext("variants", writer.consumer(w -> writeVariants()));
+      writer.writeXmlDocs(shape);
+      writer.write(
+          """
+          public enum ${typeName:L}
+          {
+              ${variants:C|}
           }
-        });
-    writer.write("");
-    writer.write("public static partial class $LSchema", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () ->
-            writer.write(
-                "public static $T<$L> Schema { get; } = $T.IntEnum<$L>($L, values: $L, traits:"
-                    + " $L);",
-                RuntimeTypes.SCHEMA,
-                typeName,
-                RuntimeTypes.SCHEMAS,
-                typeName,
-                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
-                SchemaGenerator.intEnumValuesExpr(shape),
-                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values())));
+
+          public static partial class ${typeName:L}Schema
+          {
+              public static ${schema:T}<${typeName:L}> Schema { get; } =
+                  ${schemas:T}.IntEnum<${typeName:L}>(
+                      ${shapeId:L}, values: ${values:L}, traits: ${traits:L});
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeVariants() {
+    for (MemberShape member : ShapeSupport.sortedMembers(shape)) {
+      String property = CSharpNaming.propertyName(member.getMemberName());
+      Integer value =
+          member.getTrait(EnumValueTrait.class).flatMap(EnumValueTrait::getIntValue).orElse(null);
+      writer.writeXmlDocs(member);
+      if (value != null) {
+        writer.write("$L = $L,", property, value);
+      } else {
+        writer.write("$L,", property);
+      }
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -4,7 +4,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
@@ -31,8 +30,7 @@ public final class ListGenerator implements Runnable {
     SymbolProvider sp = context.symbolProvider();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     Symbol member = sp.toSymbol(context.model().expectShape(shape.getMember().getTarget()));
-    String memberType =
-        CSharpSymbolProvider.qualified(member) + (ShapeSupport.isSparse(shape) ? "?" : "");
+    String memberType = writer.typeName(member) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
     writer.writeXmlDocs(shape);
     writer.write("public sealed partial record class $L", typeName);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -21,6 +21,7 @@ public final class ListGenerator implements Runnable {
 
   public ListGenerator(GenerationContext c, CSharpWriter w, ListShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }
@@ -39,29 +40,47 @@ public final class ListGenerator implements Runnable {
         "}",
         () -> {
           writer.write(
-              "public $L(System.Collections.Generic.IEnumerable<$L> values)", typeName, memberType);
+              "public $L("
+                  + writer.frameworkType("System.Collections.Generic.IEnumerable")
+                  + "<$L> values)",
+              typeName,
+              memberType);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(values);");
                 writer.write(
-                    "Values = System.Array.AsReadOnly(System.Linq.Enumerable.ToArray(values));");
+                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(values);");
+                writer.write(
+                    "Values = "
+                        + writer.frameworkType("System.Array")
+                        + ".AsReadOnly("
+                        + writer.frameworkType("System.Linq.Enumerable")
+                        + ".ToArray(values));");
               });
           writer.write("");
           writer.write(
-              "private $L(System.Collections.Generic.List<$L> values)", typeName, memberType);
+              "private $L("
+                  + writer.frameworkType("System.Collections.Generic.List")
+                  + "<$L> values)",
+              typeName,
+              memberType);
           writer.openBlock("{", "}", () -> writer.write("Values = values.AsReadOnly();"));
           writer.write("");
           writer.write(
-              "internal static $L FromOwnedList(System.Collections.Generic.List<$L> values)"
+              "internal static $L FromOwnedList("
+                  + writer.frameworkType("System.Collections.Generic.List")
+                  + "<$L> values)"
                   + " => new(values);",
               typeName,
               memberType);
           writer.write("");
           writer.writeXmlDocs(shape.getMember());
           writer.write(
-              "public System.Collections.Generic.IReadOnlyList<$L> Values { get; }", memberType);
+              "public "
+                  + writer.frameworkType("System.Collections.Generic.IReadOnlyList")
+                  + "<$L> Values { get; }",
+              memberType);
         });
     writer.write("");
     SchemaGenerator.writeListSchema(writer, context, shape);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -21,7 +21,6 @@ public final class ListGenerator implements Runnable {
 
   public ListGenerator(GenerationContext c, CSharpWriter w, ListShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -5,6 +5,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -38,48 +39,29 @@ public final class ListGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write(
-              "public $L("
-                  + writer.frameworkType("System.Collections.Generic.IEnumerable")
-                  + "<$L> values)",
-              typeName,
-              memberType);
+          writer.write("public $L($T<$L> values)", typeName, RuntimeTypes.I_ENUMERABLE, memberType);
           writer.openBlock(
               "{",
               "}",
               () -> {
+                writer.write("$T.ThrowIfNull(values);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write(
-                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(values);");
-                writer.write(
-                    "Values = "
-                        + writer.frameworkType("System.Array")
-                        + ".AsReadOnly("
-                        + writer.frameworkType("System.Linq.Enumerable")
-                        + ".ToArray(values));");
+                    "Values = $T.AsReadOnly($T.ToArray(values));",
+                    RuntimeTypes.ARRAY,
+                    RuntimeTypes.ENUMERABLE);
               });
           writer.write("");
-          writer.write(
-              "private $L("
-                  + writer.frameworkType("System.Collections.Generic.List")
-                  + "<$L> values)",
-              typeName,
-              memberType);
+          writer.write("private $L($T<$L> values)", typeName, RuntimeTypes.LIST, memberType);
           writer.openBlock("{", "}", () -> writer.write("Values = values.AsReadOnly();"));
           writer.write("");
           writer.write(
-              "internal static $L FromOwnedList("
-                  + writer.frameworkType("System.Collections.Generic.List")
-                  + "<$L> values)"
-                  + " => new(values);",
+              "internal static $L FromOwnedList($T<$L> values) => new(values);",
               typeName,
+              RuntimeTypes.LIST,
               memberType);
           writer.write("");
           writer.writeXmlDocs(shape.getMember());
-          writer.write(
-              "public "
-                  + writer.frameworkType("System.Collections.Generic.IReadOnlyList")
-                  + "<$L> Values { get; }",
-              memberType);
+          writer.write("public $T<$L> Values { get; }", RuntimeTypes.I_READ_ONLY_LIST, memberType);
         });
     writer.write("");
     SchemaGenerator.writeListSchema(writer, context, shape);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ListGenerator.java
@@ -33,36 +33,47 @@ public final class ListGenerator implements Runnable {
     Symbol member = sp.toSymbol(context.model().expectShape(shape.getMember().getTarget()));
     String memberType = writer.typeName(member) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
-    writer.writeXmlDocs(shape);
-    writer.write("public sealed partial record class $L", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public $L($T<$L> values)", typeName, RuntimeTypes.I_ENUMERABLE, memberType);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(values);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write(
-                    "Values = $T.AsReadOnly($T.ToArray(values));",
-                    RuntimeTypes.ARRAY,
-                    RuntimeTypes.ENUMERABLE);
-              });
-          writer.write("");
-          writer.write("private $L($T<$L> values)", typeName, RuntimeTypes.LIST, memberType);
-          writer.openBlock("{", "}", () -> writer.write("Values = values.AsReadOnly();"));
-          writer.write("");
-          writer.write(
-              "internal static $L FromOwnedList($T<$L> values) => new(values);",
-              typeName,
-              RuntimeTypes.LIST,
-              memberType);
-          writer.write("");
-          writer.writeXmlDocs(shape.getMember());
-          writer.write("public $T<$L> Values { get; }", RuntimeTypes.I_READ_ONLY_LIST, memberType);
-        });
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("memberType", memberType);
+      writer.putContext("enumerable", RuntimeTypes.I_ENUMERABLE);
+      writer.putContext("list", RuntimeTypes.LIST);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("array", RuntimeTypes.ARRAY);
+      writer.putContext("enumerableMethods", RuntimeTypes.ENUMERABLE);
+      writer.putContext(
+          "valuesProperty",
+          writer.consumer(
+              w -> {
+                w.writeXmlDocs(shape.getMember());
+                w.write("public $T<$L> Values { get; }", RuntimeTypes.I_READ_ONLY_LIST, memberType);
+              }));
+      writer.writeXmlDocs(shape);
+      writer.write(
+          """
+          public sealed partial record class ${typeName:L}
+          {
+              public ${typeName:L}(${enumerable:T}<${memberType:L}> values)
+              {
+                  ${argumentNullException:T}.ThrowIfNull(values);
+                  Values = ${array:T}.AsReadOnly(${enumerableMethods:T}.ToArray(values));
+              }
+
+              private ${typeName:L}(${list:T}<${memberType:L}> values)
+              {
+                  Values = values.AsReadOnly();
+              }
+
+              internal static ${typeName:L} FromOwnedList(${list:T}<${memberType:L}> values) =>
+                  new(values);
+
+              ${valuesProperty:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
     writer.write("");
     SchemaGenerator.writeListSchema(writer, context, shape);
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -5,6 +5,7 @@ package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -43,36 +44,30 @@ public final class MapGenerator implements Runnable {
         "}",
         () -> {
           writer.write(
-              "public $L("
-                  + writer.frameworkType("System.Collections.Generic.IReadOnlyDictionary")
-                  + "<$L, $L> values)",
+              "public $L($T<$L, $L> values)",
               typeName,
+              RuntimeTypes.I_READ_ONLY_DICTIONARY,
               keyType,
               valueType);
           writer.openBlock(
               "{",
               "}",
               () -> {
+                writer.write("$T.ThrowIfNull(values);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write(
-                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(values);");
-                writer.write(
-                    "Values = new "
-                        + writer.frameworkType("System.Collections.ObjectModel.ReadOnlyDictionary")
-                        + "<$L, $L>("
-                        + "new "
-                        + writer.frameworkType("System.Collections.Generic.Dictionary")
-                        + "<$L, $L>(values));",
+                    "Values = new $T<$L, $L>(new $T<$L, $L>(values));",
+                    RuntimeTypes.READ_ONLY_DICTIONARY,
                     keyType,
                     valueType,
+                    RuntimeTypes.DICTIONARY,
                     keyType,
                     valueType);
               });
           writer.write("");
           writer.write(
-              "private $L("
-                  + writer.frameworkType("System.Collections.Generic.Dictionary")
-                  + "<$L, $L> values)",
+              "private $L($T<$L, $L> values)",
               typeName,
+              RuntimeTypes.DICTIONARY,
               keyType,
               valueType);
           writer.openBlock(
@@ -80,27 +75,22 @@ public final class MapGenerator implements Runnable {
               "}",
               () ->
                   writer.write(
-                      "Values = new "
-                          + writer.frameworkType(
-                              "System.Collections.ObjectModel.ReadOnlyDictionary")
-                          + "<$L,"
-                          + " $L>(values);",
+                      "Values = new $T<$L, $L>(values);",
+                      RuntimeTypes.READ_ONLY_DICTIONARY,
                       keyType,
                       valueType));
           writer.write("");
           writer.write(
-              "internal static $L FromOwnedDictionary("
-                  + writer.frameworkType("System.Collections.Generic.Dictionary")
-                  + "<$L, $L> values) => new(values);",
+              "internal static $L FromOwnedDictionary($T<$L, $L> values) => new(values);",
               typeName,
+              RuntimeTypes.DICTIONARY,
               keyType,
               valueType);
           writer.write("");
           writer.writeXmlDocs(shape.getValue());
           writer.write(
-              "public "
-                  + writer.frameworkType("System.Collections.Generic.IReadOnlyDictionary")
-                  + "<$L, $L> Values { get; }",
+              "public $T<$L, $L> Values { get; }",
+              RuntimeTypes.I_READ_ONLY_DICTIONARY,
               keyType,
               valueType);
         });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -4,7 +4,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
@@ -35,8 +34,7 @@ public final class MapGenerator implements Runnable {
     // which has no other form. What the key targets is not lost — the schema carries that shape, so
     // a server holds the key to whatever it says — but it is not what the key is typed as.
     String keyType = "string";
-    String valueType =
-        CSharpSymbolProvider.qualified(value) + (ShapeSupport.isSparse(shape) ? "?" : "");
+    String valueType = writer.typeName(value) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
     writer.writeXmlDocs(shape);
     writer.write("public sealed partial record class $L", typeName);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -21,7 +21,6 @@ public final class MapGenerator implements Runnable {
 
   public MapGenerator(GenerationContext c, CSharpWriter w, MapShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -21,6 +21,7 @@ public final class MapGenerator implements Runnable {
 
   public MapGenerator(GenerationContext c, CSharpWriter w, MapShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }
@@ -43,7 +44,9 @@ public final class MapGenerator implements Runnable {
         "}",
         () -> {
           writer.write(
-              "public $L(System.Collections.Generic.IReadOnlyDictionary<$L, $L> values)",
+              "public $L("
+                  + writer.frameworkType("System.Collections.Generic.IReadOnlyDictionary")
+                  + "<$L, $L> values)",
               typeName,
               keyType,
               valueType);
@@ -51,10 +54,15 @@ public final class MapGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(values);");
                 writer.write(
-                    "Values = new System.Collections.ObjectModel.ReadOnlyDictionary<$L, $L>("
-                        + "new System.Collections.Generic.Dictionary<$L, $L>(values));",
+                    writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(values);");
+                writer.write(
+                    "Values = new "
+                        + writer.frameworkType("System.Collections.ObjectModel.ReadOnlyDictionary")
+                        + "<$L, $L>("
+                        + "new "
+                        + writer.frameworkType("System.Collections.Generic.Dictionary")
+                        + "<$L, $L>(values));",
                     keyType,
                     valueType,
                     keyType,
@@ -62,7 +70,9 @@ public final class MapGenerator implements Runnable {
               });
           writer.write("");
           writer.write(
-              "private $L(System.Collections.Generic.Dictionary<$L, $L> values)",
+              "private $L("
+                  + writer.frameworkType("System.Collections.Generic.Dictionary")
+                  + "<$L, $L> values)",
               typeName,
               keyType,
               valueType);
@@ -71,21 +81,27 @@ public final class MapGenerator implements Runnable {
               "}",
               () ->
                   writer.write(
-                      "Values = new System.Collections.ObjectModel.ReadOnlyDictionary<$L,"
+                      "Values = new "
+                          + writer.frameworkType(
+                              "System.Collections.ObjectModel.ReadOnlyDictionary")
+                          + "<$L,"
                           + " $L>(values);",
                       keyType,
                       valueType));
           writer.write("");
           writer.write(
               "internal static $L FromOwnedDictionary("
-                  + "System.Collections.Generic.Dictionary<$L, $L> values) => new(values);",
+                  + writer.frameworkType("System.Collections.Generic.Dictionary")
+                  + "<$L, $L> values) => new(values);",
               typeName,
               keyType,
               valueType);
           writer.write("");
           writer.writeXmlDocs(shape.getValue());
           writer.write(
-              "public System.Collections.Generic.IReadOnlyDictionary<$L, $L> Values { get; }",
+              "public "
+                  + writer.frameworkType("System.Collections.Generic.IReadOnlyDictionary")
+                  + "<$L, $L> Values { get; }",
               keyType,
               valueType);
         });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/MapGenerator.java
@@ -34,66 +34,52 @@ public final class MapGenerator implements Runnable {
     // Always a string, even when the key targets an enum shape: a map key is a JSON object name,
     // which has no other form. What the key targets is not lost — the schema carries that shape, so
     // a server holds the key to whatever it says — but it is not what the key is typed as.
-    String keyType = "string";
     String valueType = writer.typeName(value) + (ShapeSupport.isSparse(shape) ? "?" : "");
 
-    writer.writeXmlDocs(shape);
-    writer.write("public sealed partial record class $L", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write(
-              "public $L($T<$L, $L> values)",
-              typeName,
-              RuntimeTypes.I_READ_ONLY_DICTIONARY,
-              keyType,
-              valueType);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(values);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write(
-                    "Values = new $T<$L, $L>(new $T<$L, $L>(values));",
-                    RuntimeTypes.READ_ONLY_DICTIONARY,
-                    keyType,
-                    valueType,
-                    RuntimeTypes.DICTIONARY,
-                    keyType,
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("valueType", valueType);
+      writer.putContext("readOnlyDictionaryInterface", RuntimeTypes.I_READ_ONLY_DICTIONARY);
+      writer.putContext("readOnlyDictionary", RuntimeTypes.READ_ONLY_DICTIONARY);
+      writer.putContext("dictionary", RuntimeTypes.DICTIONARY);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext(
+          "valuesProperty",
+          writer.consumer(
+              w -> {
+                w.writeXmlDocs(shape.getValue());
+                w.write(
+                    "public $T<string, $L> Values { get; }",
+                    RuntimeTypes.I_READ_ONLY_DICTIONARY,
                     valueType);
-              });
-          writer.write("");
-          writer.write(
-              "private $L($T<$L, $L> values)",
-              typeName,
-              RuntimeTypes.DICTIONARY,
-              keyType,
-              valueType);
-          writer.openBlock(
-              "{",
-              "}",
-              () ->
-                  writer.write(
-                      "Values = new $T<$L, $L>(values);",
-                      RuntimeTypes.READ_ONLY_DICTIONARY,
-                      keyType,
-                      valueType));
-          writer.write("");
-          writer.write(
-              "internal static $L FromOwnedDictionary($T<$L, $L> values) => new(values);",
-              typeName,
-              RuntimeTypes.DICTIONARY,
-              keyType,
-              valueType);
-          writer.write("");
-          writer.writeXmlDocs(shape.getValue());
-          writer.write(
-              "public $T<$L, $L> Values { get; }",
-              RuntimeTypes.I_READ_ONLY_DICTIONARY,
-              keyType,
-              valueType);
-        });
+              }));
+      writer.writeXmlDocs(shape);
+      writer.write(
+          """
+          public sealed partial record class ${typeName:L}
+          {
+              public ${typeName:L}(${readOnlyDictionaryInterface:T}<string, ${valueType:L}> values)
+              {
+                  ${argumentNullException:T}.ThrowIfNull(values);
+                  Values = new ${readOnlyDictionary:T}<string, ${valueType:L}>(
+                      new ${dictionary:T}<string, ${valueType:L}>(values));
+              }
+
+              private ${typeName:L}(${dictionary:T}<string, ${valueType:L}> values)
+              {
+                  Values = new ${readOnlyDictionary:T}<string, ${valueType:L}>(values);
+              }
+
+              internal static ${typeName:L} FromOwnedDictionary(
+                  ${dictionary:T}<string, ${valueType:L}> values) => new(values);
+
+              ${valuesProperty:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
     writer.write("");
     SchemaGenerator.writeMapSchema(writer, context, shape);
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -31,7 +31,6 @@ public final class OperationSchemaGenerator implements Runnable {
 
   @Override
   public void run() {
-
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     List<ShapeId> errors =
         shape.getErrors().stream()
@@ -40,38 +39,38 @@ public final class OperationSchemaGenerator implements Runnable {
     boolean isStreaming =
         ShapeSupport.isStreamingShape(context.model(), shape.getInputShape())
             || ShapeSupport.isStreamingShape(context.model(), shape.getOutputShape());
-    writer.write("public static partial class $LSchema", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write(
-              "public static $T<$L, $L> Schema { get; } =",
-              RuntimeTypes.OPERATION_SCHEMA,
-              SchemaGenerator.operationShapeType(writer, context, shape.getInputShape()),
-              SchemaGenerator.operationShapeType(writer, context, shape.getOutputShape()));
-          writer.indent();
-          if (isStreaming) {
-            writer.write(
-                "$T.Operation($L, $L, $L, $L, $L, isStreaming: true);",
-                RuntimeTypes.SCHEMAS,
-                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
-                SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
-                SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
-                errorsLiteral(errors),
-                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
-          } else {
-            writer.write(
-                "$T.Operation($L, $L, $L, $L, $L);",
-                RuntimeTypes.SCHEMAS,
-                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
-                SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
-                SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
-                errorsLiteral(errors),
-                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("operationSchema", RuntimeTypes.OPERATION_SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext(
+          "inputType", SchemaGenerator.operationShapeType(writer, context, shape.getInputShape()));
+      writer.putContext(
+          "outputType",
+          SchemaGenerator.operationShapeType(writer, context, shape.getOutputShape()));
+      writer.putContext("shapeId", SchemaGenerator.shapeIdExpr(writer, shape.getId()));
+      writer.putContext(
+          "inputSchema",
+          SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()));
+      writer.putContext(
+          "outputSchema",
+          SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()));
+      writer.putContext("errors", errorsLiteral(errors));
+      writer.putContext(
+          "traits", SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext("streamingArgument", isStreaming ? ", isStreaming: true" : "");
+      writer.write(
+          """
+          public static partial class ${typeName:L}Schema
+          {
+              public static ${operationSchema:T}<${inputType:L}, ${outputType:L}> Schema { get; } =
+                  ${schemas:T}.Operation(${shapeId:L}, ${inputSchema:L}, ${outputSchema:L}, ${errors:L}, ${traits:L}${streamingArgument:L});
           }
-          writer.dedent();
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private String errorsLiteral(List<ShapeId> errors) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -25,7 +25,6 @@ public final class OperationSchemaGenerator implements Runnable {
 
   public OperationSchemaGenerator(GenerationContext c, CSharpWriter w, OperationShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -49,23 +49,23 @@ public final class OperationSchemaGenerator implements Runnable {
         () -> {
           writer.write(
               "public static OperationSchema<$L, $L> Schema { get; } =",
-              SchemaGenerator.operationShapeType(context, shape.getInputShape()),
-              SchemaGenerator.operationShapeType(context, shape.getOutputShape()));
+              SchemaGenerator.operationShapeType(writer, context, shape.getInputShape()),
+              SchemaGenerator.operationShapeType(writer, context, shape.getOutputShape()));
           writer.indent();
           if (isStreaming) {
             writer.write(
                 "Schemas.Operation($L, $L, $L, $L, $L, isStreaming: true);",
                 SchemaGenerator.shapeIdExpr(shape.getId()),
-                SchemaGenerator.operationShapeSchema(context, shape.getInputShape()),
-                SchemaGenerator.operationShapeSchema(context, shape.getOutputShape()),
+                SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
+                SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
                 SchemaGenerator.traitsExpr(shape.getAllTraits().values()));
           } else {
             writer.write(
                 "Schemas.Operation($L, $L, $L, $L, $L);",
                 SchemaGenerator.shapeIdExpr(shape.getId()),
-                SchemaGenerator.operationShapeSchema(context, shape.getInputShape()),
-                SchemaGenerator.operationShapeSchema(context, shape.getOutputShape()),
+                SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
+                SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
                 SchemaGenerator.traitsExpr(shape.getAllTraits().values()));
           }
@@ -86,7 +86,7 @@ public final class OperationSchemaGenerator implements Runnable {
                   return "Schemas.OperationError("
                       + SchemaGenerator.shapeIdExpr(errorId)
                       + ", "
-                      + SchemaGenerator.shapeSchemaAccessor(context, error)
+                      + SchemaGenerator.shapeSchemaAccessor(writer, context, error)
                       + ", "
                       + httpErrorCode(error)
                       + ")";

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -31,8 +31,6 @@ public final class OperationSchemaGenerator implements Runnable {
 
   @Override
   public void run() {
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
 
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     List<ShapeId> errors =
@@ -48,22 +46,25 @@ public final class OperationSchemaGenerator implements Runnable {
         "}",
         () -> {
           writer.write(
-              "public static OperationSchema<$L, $L> Schema { get; } =",
+              "public static $T<$L, $L> Schema { get; } =",
+              RuntimeTypes.OPERATION_SCHEMA,
               SchemaGenerator.operationShapeType(writer, context, shape.getInputShape()),
               SchemaGenerator.operationShapeType(writer, context, shape.getOutputShape()));
           writer.indent();
           if (isStreaming) {
             writer.write(
-                "Schemas.Operation($L, $L, $L, $L, $L, isStreaming: true);",
-                SchemaGenerator.shapeIdExpr(shape.getId()),
+                "$T.Operation($L, $L, $L, $L, $L, isStreaming: true);",
+                RuntimeTypes.SCHEMAS,
+                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
                 SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
           } else {
             writer.write(
-                "Schemas.Operation($L, $L, $L, $L, $L);",
-                SchemaGenerator.shapeIdExpr(shape.getId()),
+                "$T.Operation($L, $L, $L, $L, $L);",
+                RuntimeTypes.SCHEMAS,
+                SchemaGenerator.shapeIdExpr(writer, shape.getId()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
@@ -83,8 +84,8 @@ public final class OperationSchemaGenerator implements Runnable {
             .map(
                 errorId -> {
                   StructureShape error = context.model().expectShape(errorId, StructureShape.class);
-                  return "Schemas.OperationError("
-                      + SchemaGenerator.shapeIdExpr(errorId)
+                  return (writer.typeName(RuntimeTypes.SCHEMAS) + ".OperationError(")
+                      + SchemaGenerator.shapeIdExpr(writer, errorId)
                       + ", "
                       + SchemaGenerator.shapeSchemaAccessor(writer, context, error)
                       + ", "

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/OperationSchemaGenerator.java
@@ -25,6 +25,7 @@ public final class OperationSchemaGenerator implements Runnable {
 
   public OperationSchemaGenerator(GenerationContext c, CSharpWriter w, OperationShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }
@@ -59,7 +60,7 @@ public final class OperationSchemaGenerator implements Runnable {
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
-                SchemaGenerator.traitsExpr(shape.getAllTraits().values()));
+                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
           } else {
             writer.write(
                 "Schemas.Operation($L, $L, $L, $L, $L);",
@@ -67,7 +68,7 @@ public final class OperationSchemaGenerator implements Runnable {
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getInputShape()),
                 SchemaGenerator.operationShapeSchema(writer, context, shape.getOutputShape()),
                 errorsLiteral(errors),
-                SchemaGenerator.traitsExpr(shape.getAllTraits().values()));
+                SchemaGenerator.traitsExpr(writer, shape.getAllTraits().values()));
           }
           writer.dedent();
         });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -1,7 +1,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.SymbolProperties;
@@ -44,7 +43,8 @@ public final class SchemaGenerator {
     writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
   }
 
-  public static String shapeSchemaAccessor(GenerationContext context, Shape shape) {
+  public static String shapeSchemaAccessor(
+      CSharpWriter writer, GenerationContext context, Shape shape) {
     if ("smithy.api".equals(shape.getId().getNamespace())) {
       return switch (shape.getId().getName()) {
         case "Boolean" -> "Schemas.Boolean";
@@ -91,7 +91,7 @@ public final class SchemaGenerator {
       return preludeSchema;
     }
 
-    String accessor = schemaClassName(context, shape) + ".Schema";
+    String accessor = schemaClassName(writer, context, shape) + ".Schema";
 
     // Aggregate shapes can participate in recursive graphs (a shape referencing itself
     // directly or through a cycle). A direct static reference would observe null while the
@@ -127,31 +127,33 @@ public final class SchemaGenerator {
         "Unit");
   }
 
-  public static String schemaClassName(GenerationContext context, Shape shape) {
-    return CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(shape)) + "Schema";
+  public static String schemaClassName(
+      CSharpWriter writer, GenerationContext context, Shape shape) {
+    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema");
   }
 
-  public static String operationSchemaAccessor(GenerationContext context, OperationShape shape) {
-    return CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(shape))
-        + "Schema.Schema";
+  public static String operationSchemaAccessor(
+      CSharpWriter writer, GenerationContext context, OperationShape shape) {
+    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema") + ".Schema";
   }
 
   public static String serviceSchemaAccessor(
-      GenerationContext context, software.amazon.smithy.model.shapes.ServiceShape service) {
-    String ns = context.settings().csharpNamespace(service.getId().getNamespace());
-    String typeName = CSharpNaming.typeName(service.getId().getName());
-    return (ns.isEmpty() ? "" : ns + ".") + typeName + "Schema.Schema";
+      CSharpWriter writer,
+      GenerationContext context,
+      software.amazon.smithy.model.shapes.ServiceShape service) {
+    return writer.typeName(context.symbolProvider().toSymbol(service), "Schema") + ".Schema";
   }
 
-  public static String operationShapeType(GenerationContext context, ShapeId id) {
+  public static String operationShapeType(
+      CSharpWriter writer, GenerationContext context, ShapeId id) {
     if (ShapeSupport.isUnit(id)) return "SmithyUnit";
-    return CSharpSymbolProvider.qualified(
-        context.symbolProvider().toSymbol(context.model().expectShape(id)));
+    return writer.typeName(context.symbolProvider().toSymbol(context.model().expectShape(id)));
   }
 
-  public static String operationShapeSchema(GenerationContext context, ShapeId id) {
+  public static String operationShapeSchema(
+      CSharpWriter writer, GenerationContext context, ShapeId id) {
     if (ShapeSupport.isUnit(id)) return "Schemas.Unit";
-    return shapeSchemaAccessor(context, context.model().expectShape(id));
+    return shapeSchemaAccessor(writer, context, context.model().expectShape(id));
   }
 
   private static String localSchemaClassName(Shape shape) {
@@ -188,7 +190,7 @@ public final class SchemaGenerator {
       CSharpWriter writer, GenerationContext context, Shape shape, List<MemberShape> members) {
     addImports(writer);
     SymbolProvider sp = context.symbolProvider();
-    String typeName = CSharpSymbolProvider.qualified(sp.toSymbol(shape));
+    String typeName = writer.typeName(sp.toSymbol(shape));
 
     writer.write("public static partial class $L", localSchemaClassName(shape));
     writer.openBlock(
@@ -203,7 +205,7 @@ public final class SchemaGenerator {
                 for (MemberShape member : members) {
                   writer.write(
                       "public $L $L { get; set; }",
-                      ShapeSupport.memberTypeExpr(context.model(), sp, member, true),
+                      ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
                       CSharpNaming.propertyName(member.getMemberName()));
                 }
               });
@@ -225,7 +227,7 @@ public final class SchemaGenerator {
                         MemberShape member = members.get(index);
                         writer.write(
                             "writer.WriteMember<$L>($L, value.$L);",
-                            ShapeSupport.memberTypeExpr(context.model(), sp, member, true),
+                            ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
                             index,
                             CSharpNaming.propertyName(member.getMemberName()));
                       }
@@ -249,7 +251,7 @@ public final class SchemaGenerator {
             writer.write("$L,", CSharpNaming.formatString(name));
             writer.write("static value => value.$L,", prop);
             writer.write("static (builder, value) => builder.$L = value,", prop);
-            writer.write("$L,", memberTargetExpr(context, member));
+            writer.write("$L,", memberTargetExpr(writer, context, member));
             writer.write("$L)", memberTraitsExpr(context, member));
             writer.dedent();
           }
@@ -274,13 +276,13 @@ public final class SchemaGenerator {
     addImports(writer);
     SymbolProvider sp = context.symbolProvider();
     Shape memberTarget = context.model().expectShape(shape.getMember().getTarget());
-    String typeName = CSharpSymbolProvider.qualified(sp.toSymbol(shape));
+    String typeName = writer.typeName(sp.toSymbol(shape));
     boolean sparse = ShapeSupport.isSparse(shape);
-    String memberType =
-        CSharpSymbolProvider.qualified(sp.toSymbol(memberTarget)) + (sparse ? "?" : "");
+    String memberType = writer.typeName(sp.toSymbol(memberTarget)) + (sparse ? "?" : "");
     String builderType = "System.Collections.Generic.List<" + memberType + ">";
     String factory = shape.getType() == ShapeType.SET ? "Set" : "List";
-    String elementSchema = elementSchemaExpr(context, shape.getMember(), memberTarget, sparse);
+    String elementSchema =
+        elementSchemaExpr(writer, context, shape.getMember(), memberTarget, sparse);
 
     writer.write("public static partial class $L", localSchemaClassName(shape));
     writer.openBlock(
@@ -317,12 +319,11 @@ public final class SchemaGenerator {
     addImports(writer);
     SymbolProvider sp = context.symbolProvider();
     Shape valueTarget = context.model().expectShape(shape.getValue().getTarget());
-    String typeName = CSharpSymbolProvider.qualified(sp.toSymbol(shape));
+    String typeName = writer.typeName(sp.toSymbol(shape));
     boolean sparse = ShapeSupport.isSparse(shape);
-    String valueType =
-        CSharpSymbolProvider.qualified(sp.toSymbol(valueTarget)) + (sparse ? "?" : "");
+    String valueType = writer.typeName(sp.toSymbol(valueTarget)) + (sparse ? "?" : "");
     String builderType = "System.Collections.Generic.Dictionary<string, " + valueType + ">";
-    String valueSchema = elementSchemaExpr(context, shape.getValue(), valueTarget, sparse);
+    String valueSchema = elementSchemaExpr(writer, context, shape.getValue(), valueTarget, sparse);
 
     writer.write("public static partial class $L", localSchemaClassName(shape));
     writer.openBlock(
@@ -349,7 +350,7 @@ public final class SchemaGenerator {
               memberTraitsExpr(context, shape.getKey()),
               memberTraitsExpr(context, shape.getValue()),
               shapeSchemaAccessor(
-                  context, context.model().expectShape(shape.getKey().getTarget())));
+                  writer, context, context.model().expectShape(shape.getKey().getTarget())));
           writer.dedent();
           writer.dedent();
           writer.write("");
@@ -394,7 +395,7 @@ public final class SchemaGenerator {
   public static void writeUnionSchema(
       CSharpWriter writer, GenerationContext context, UnionShape shape, List<MemberShape> members) {
     addImports(writer);
-    String typeName = CSharpSymbolProvider.qualified(context.symbolProvider().toSymbol(shape));
+    String typeName = writer.typeName(context.symbolProvider().toSymbol(shape));
 
     writer.write("public static partial class $L", localSchemaClassName(shape));
     writer.openBlock(
@@ -417,7 +418,7 @@ public final class SchemaGenerator {
             writer.write("static value => value is $L.$L,", typeName, variantName);
             writer.write("static value => (($L.$L)value).Value,", typeName, variantName);
             writer.write("static value => new $L.$L(value!),", typeName, variantName);
-            writer.write("$L,", rawMemberTargetExpr(context, member));
+            writer.write("$L,", rawMemberTargetExpr(writer, context, member));
             writer.write("$L)", memberTraitsExpr(context, member));
             writer.dedent();
           }
@@ -428,11 +429,13 @@ public final class SchemaGenerator {
         });
   }
 
-  private static String memberTargetExpr(GenerationContext context, MemberShape member) {
+  private static String memberTargetExpr(
+      CSharpWriter writer, GenerationContext context, MemberShape member) {
     Shape target = context.model().expectShape(member.getTarget());
-    String targetExpr = targetSchemaExpr(context, member, target);
+    String targetExpr = targetSchemaExpr(writer, context, member, target);
     String nullableMemberType =
-        ShapeSupport.memberTypeExpr(context.model(), context.symbolProvider(), member, true);
+        ShapeSupport.memberTypeExpr(
+            writer, context.model(), context.symbolProvider(), member, true);
     if (!nullableMemberType.endsWith("?")) {
       return targetExpr;
     }
@@ -443,20 +446,21 @@ public final class SchemaGenerator {
     return "Schemas.NullableReference(" + targetExpr + ")";
   }
 
-  private static String rawMemberTargetExpr(GenerationContext context, MemberShape member) {
+  private static String rawMemberTargetExpr(
+      CSharpWriter writer, GenerationContext context, MemberShape member) {
     Shape target = context.model().expectShape(member.getTarget());
-    return targetSchemaExpr(context, member, target);
+    return targetSchemaExpr(writer, context, member, target);
   }
 
   private static String targetSchemaExpr(
-      GenerationContext context, MemberShape member, Shape target) {
+      CSharpWriter writer, GenerationContext context, MemberShape member, Shape target) {
     if (ShapeSupport.isStreamingBlobMember(context.model(), member)) {
       return "Schemas.StreamingBlob";
     }
     if (ShapeSupport.isEventStreamMember(context.model(), member)) {
-      return "Schemas.EventStream(" + shapeSchemaAccessor(context, target) + ")";
+      return "Schemas.EventStream(" + shapeSchemaAccessor(writer, context, target) + ")";
     }
-    return shapeSchemaAccessor(context, target);
+    return shapeSchemaAccessor(writer, context, target);
   }
 
   /**
@@ -465,8 +469,12 @@ public final class SchemaGenerator {
    * the generated model type, so the schema's element type must match.
    */
   private static String elementSchemaExpr(
-      GenerationContext context, MemberShape member, Shape target, boolean sparse) {
-    String targetExpr = shapeSchemaAccessor(context, target);
+      CSharpWriter writer,
+      GenerationContext context,
+      MemberShape member,
+      Shape target,
+      boolean sparse) {
+    String targetExpr = shapeSchemaAccessor(writer, context, target);
     String base;
     if (!sparse) {
       base = targetExpr;

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -306,76 +306,64 @@ public final class SchemaGenerator {
   }
 
   public static void writeSimpleSchema(CSharpWriter writer, Shape shape) {
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (shape.getType() == ShapeType.ENUM) {
-            String typeName = CSharpNaming.typeName(shape.getId().getName());
-            writer.write(
-                "public static $T<$L> Schema { get; } = $T.StringEnum<$L>($L, values: $L, traits:"
-                    + " $L, internalValues: $L);",
-                RuntimeTypes.SCHEMA,
-                typeName,
-                RuntimeTypes.SCHEMAS,
-                typeName,
-                shapeIdExpr(writer, shape.getId()),
-                stringEnumValuesExpr(shape),
-                traitsExpr(writer, shape.getAllTraits().values()),
-                stringEnumInternalValuesExpr(shape));
-            writer.write("");
-            return;
+    writer.pushState();
+    try {
+      writer.putContext("schemaClass", localSchemaClassName(shape));
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("type", CSharpNaming.typeName(shape.getId().getName()));
+      if (shape.getType() == ShapeType.ENUM) {
+        writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+        writer.putContext("shapeId", shapeIdExpr(writer, shape.getId()));
+        writer.putContext("values", stringEnumValuesExpr(shape));
+        writer.putContext("traits", traitsExpr(writer, shape.getAllTraits().values()));
+        writer.putContext("internalValues", stringEnumInternalValuesExpr(shape));
+        writer.putContext(
+            "initializer",
+            writer.format(
+                "${schemas:T}.StringEnum<${type:L}>(${shapeId:L}, values: ${values:L}, traits:"
+                    + " ${traits:L}, internalValues: ${internalValues:L})"));
+      } else {
+        String prelude = primitiveTypeToPreludeSchema(writer, shape.getType());
+        writer.putContext(
+            "initializer",
+            prelude != null ? prelude : writer.format("$T.String", RuntimeTypes.SCHEMAS));
+      }
+      writer.write(
+          """
+          public static partial class ${schemaClass:L}
+          {
+              public static ${schema:T}<${type:L}> Schema { get; } = ${initializer:L};
           }
-
-          String prelude = primitiveTypeToPreludeSchema(writer, shape.getType());
-          if (prelude == null) {
-            prelude = (writer.typeName(RuntimeTypes.SCHEMAS) + ".String");
-          }
-          writer.write(
-              "public static $T<$L> Schema { get; } = $L;",
-              RuntimeTypes.SCHEMA,
-              CSharpNaming.typeName(shape.getId().getName()),
-              prelude);
-          writer.write("");
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   public static void writeUnionSchema(
       CSharpWriter writer, GenerationContext context, UnionShape shape, List<MemberShape> members) {
-    String typeName = writer.typeName(context.symbolProvider().toSymbol(shape));
-
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
-          writer.indent();
-          writer.write(
-              "$T.Union<$L>($L, $L)",
-              RuntimeTypes.SCHEMAS,
-              typeName,
-              shapeIdExpr(writer, shape.getId()),
-              traitsExpr(writer, shape.getAllTraits().values()));
-          writer.indent();
-          for (MemberShape member : members) {
-            String variantName = CSharpNaming.typeName(member.getMemberName());
-            writer.write(".Case(");
-            writer.indent();
-            writer.write("$L,", CSharpNaming.formatString(member.getMemberName()));
-            writer.write("static value => value is $L.$L,", typeName, variantName);
-            writer.write("static value => (($L.$L)value).Value,", typeName, variantName);
-            writer.write("static value => new $L.$L(value!),", typeName, variantName);
-            writer.write("$L,", rawMemberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(writer, context, member));
-            writer.dedent();
+    writer.pushState();
+    try {
+      writer.putContext("schemaClass", localSchemaClassName(shape));
+      writer.putContext("type", context.symbolProvider().toSymbol(shape));
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("shapeId", shapeIdExpr(writer, shape.getId()));
+      writer.putContext("traits", traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext("cases", writer.consumer(w -> writeUnionCases(w, context, shape, members)));
+      writer.write(
+          """
+          public static partial class ${schemaClass:L}
+          {
+              public static ${schema:T}<${type:T}> Schema { get; } =
+                  ${schemas:T}.Union<${type:T}>(${shapeId:L}, ${traits:L})
+                      ${cases:C|}
+                      .Build();
           }
-          writer.write(".Build();");
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   /**
@@ -422,6 +410,32 @@ public final class SchemaGenerator {
   }
 
   private SchemaGenerator() {}
+
+  private static void writeUnionCases(
+      CSharpWriter writer, GenerationContext context, UnionShape shape, List<MemberShape> members) {
+    for (MemberShape member : members) {
+      writer.pushState();
+      try {
+        writer.putContext("unionType", context.symbolProvider().toSymbol(shape));
+        writer.putContext("variant", CSharpNaming.typeName(member.getMemberName()));
+        writer.putContext("name", CSharpNaming.formatString(member.getMemberName()));
+        writer.putContext("target", rawMemberTargetExpr(writer, context, member));
+        writer.putContext("memberTraits", memberTraitsExpr(writer, context, member));
+        writer.write(
+            """
+            .Case(
+                ${name:L},
+                static value => value is ${unionType:T}.${variant:L},
+                static value => ((${unionType:T}.${variant:L})value).Value,
+                static value => new ${unionType:T}.${variant:L}(value!),
+                ${target:L},
+                ${memberTraits:L})
+            """);
+      } finally {
+        writer.popState();
+      }
+    }
+  }
 
   private static void writeStructureBuilderProperties(
       CSharpWriter writer, GenerationContext context, List<MemberShape> members) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -36,31 +36,24 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class SchemaGenerator {
 
-  private SchemaGenerator() {}
-
-  public static void addImports(CSharpWriter writer) {
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
-  }
-
   public static String shapeSchemaAccessor(
       CSharpWriter writer, GenerationContext context, Shape shape) {
     if ("smithy.api".equals(shape.getId().getNamespace())) {
       return switch (shape.getId().getName()) {
-        case "Boolean" -> "Schemas.Boolean";
-        case "Byte" -> "Schemas.Byte";
-        case "Short" -> "Schemas.Short";
-        case "Integer" -> "Schemas.Integer";
-        case "Long" -> "Schemas.Long";
-        case "Float" -> "Schemas.Float";
-        case "Double" -> "Schemas.Double";
-        case "BigInteger" -> "Schemas.BigInteger";
-        case "BigDecimal" -> "Schemas.BigDecimal";
-        case "String" -> "Schemas.String";
-        case "Blob" -> "Schemas.Blob";
-        case "Timestamp" -> "Schemas.Timestamp";
-        case "Document" -> "Schemas.Document";
-        case "Unit" -> "Schemas.Unit";
+        case "Boolean" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Boolean");
+        case "Byte" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Byte");
+        case "Short" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Short");
+        case "Integer" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Integer");
+        case "Long" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Long");
+        case "Float" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Float");
+        case "Double" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Double");
+        case "BigInteger" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".BigInteger");
+        case "BigDecimal" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".BigDecimal");
+        case "String" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".String");
+        case "Blob" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Blob");
+        case "Timestamp" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Timestamp");
+        case "Document" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Document");
+        case "Unit" -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Unit");
         default ->
             throw new CodegenException(
                 "Unsupported Smithy prelude schema shape "
@@ -81,12 +74,16 @@ public final class SchemaGenerator {
               .filter(t -> t.toShapeId().toString().equals("smithy.api#timestampFormat"))
               .collect(Collectors.toList());
       return tsTraits.isEmpty()
-          ? "Schemas.Timestamp"
-          : "Schemas.TimestampWithTraits(" + traitsExpr(writer, tsTraits) + ")";
+          ? (writer.typeName(RuntimeTypes.SCHEMAS) + ".Timestamp")
+          : (writer.typeName(RuntimeTypes.SCHEMAS) + ".TimestampWithTraits(")
+              + traitsExpr(writer, tsTraits)
+              + ")";
     }
 
     String preludeSchema =
-        shape.getType() == ShapeType.ENUM ? null : primitiveTypeToPreludeSchema(shape.getType());
+        shape.getType() == ShapeType.ENUM
+            ? null
+            : primitiveTypeToPreludeSchema(writer, shape.getType());
     if (preludeSchema != null) {
       return preludeSchema;
     }
@@ -98,8 +95,363 @@ public final class SchemaGenerator {
     // referenced schema's static initializer is still running, so defer it lazily. The
     // null-forgiving '!' suppresses the nullable-flow warning for self-references where the
     // property is not yet definitely assigned at the point the lambda is created.
-    return isCycleCapable(shape.getType()) ? "Schemas.Lazy(() => " + accessor + "!)" : accessor;
+    return isCycleCapable(shape.getType())
+        ? (writer.typeName(RuntimeTypes.SCHEMAS) + ".Lazy(() => ") + accessor + "!)"
+        : accessor;
   }
+
+  public static String schemaClassName(
+      CSharpWriter writer, GenerationContext context, Shape shape) {
+    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema");
+  }
+
+  public static String operationSchemaAccessor(
+      CSharpWriter writer, GenerationContext context, OperationShape shape) {
+    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema") + ".Schema";
+  }
+
+  public static String serviceSchemaAccessor(
+      CSharpWriter writer,
+      GenerationContext context,
+      software.amazon.smithy.model.shapes.ServiceShape service) {
+    return writer.typeName(context.symbolProvider().toSymbol(service), "Schema") + ".Schema";
+  }
+
+  public static String operationShapeType(
+      CSharpWriter writer, GenerationContext context, ShapeId id) {
+    if (ShapeSupport.isUnit(id)) return writer.typeName(RuntimeTypes.SMITHY_UNIT);
+    return writer.typeName(context.symbolProvider().toSymbol(context.model().expectShape(id)));
+  }
+
+  public static String operationShapeSchema(
+      CSharpWriter writer, GenerationContext context, ShapeId id) {
+    if (ShapeSupport.isUnit(id)) return (writer.typeName(RuntimeTypes.SCHEMAS) + ".Unit");
+    return shapeSchemaAccessor(writer, context, context.model().expectShape(id));
+  }
+
+  public static String shapeIdExpr(CSharpWriter writer, ShapeId id) {
+    return (writer.typeName(RuntimeTypes.SHAPE_ID) + ".Parse(")
+        + CSharpNaming.formatString(id.toString())
+        + ")";
+  }
+
+  public static String traitExpr(CSharpWriter writer, Trait trait) {
+    String idExpr = shapeIdExpr(writer, trait.toShapeId());
+    Node node = trait.toNode();
+    if (node.isNullNode()) {
+      return ("new " + writer.typeName(RuntimeTypes.TRAIT) + "(") + idExpr + ")";
+    }
+
+    return ("new " + writer.typeName(RuntimeTypes.TRAIT) + "(")
+        + idExpr
+        + ", "
+        + documentExpr(writer, node)
+        + ")";
+  }
+
+  public static String traitsExpr(CSharpWriter writer, Collection<? extends Trait> traits) {
+    if (traits.isEmpty()) {
+      return "null";
+    }
+
+    List<Trait> sorted = new ArrayList<>(traits);
+    sorted.sort(java.util.Comparator.comparing(t -> t.toShapeId().toString()));
+    return "["
+        + sorted.stream().map(value -> traitExpr(writer, value)).collect(Collectors.joining(", "))
+        + "]";
+  }
+
+  public static void writeStructureSchema(
+      CSharpWriter writer, GenerationContext context, Shape shape, List<MemberShape> members) {
+    SymbolProvider sp = context.symbolProvider();
+    String typeName = writer.typeName(sp.toSymbol(shape));
+
+    writer.write("public static partial class $L", localSchemaClassName(shape));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("public sealed class Builder");
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                for (MemberShape member : members) {
+                  writer.write(
+                      "public $L $L { get; set; }",
+                      ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
+                      CSharpNaming.propertyName(member.getMemberName()));
+                }
+              });
+          writer.write("");
+          writer.write(
+              "private sealed class ValueSerializer : $T<$L>",
+              RuntimeTypes.I_STRUCT_VALUE_SERIALIZER,
+              typeName);
+          writer.openBlock(
+              "{",
+              "}",
+              () -> {
+                writer.write(
+                    "public void WriteMembers<TWriter>($L value, ref TWriter writer)", typeName);
+                writer.write("    where TWriter : struct, $T", RuntimeTypes.I_STRUCT_MEMBER_WRITER);
+                writer.openBlock(
+                    "{",
+                    "}",
+                    () -> {
+                      for (int index = 0; index < members.size(); index++) {
+                        MemberShape member = members.get(index);
+                        writer.write(
+                            "writer.WriteMember<$L>($L, value.$L);",
+                            ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
+                            index,
+                            CSharpNaming.propertyName(member.getMemberName()));
+                      }
+                    });
+              });
+          writer.write("");
+          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
+          writer.indent();
+          writer.write(
+              "$T.Structure<$L, Builder>($L, $L)",
+              RuntimeTypes.SCHEMAS,
+              typeName,
+              shapeIdExpr(writer, shape.getId()),
+              traitsExpr(writer, shape.getAllTraits().values()));
+          writer.indent();
+          for (MemberShape member : members) {
+            String method = ShapeSupport.isRequired(member) ? "Required" : "Optional";
+            String name = member.getMemberName();
+            String prop = CSharpNaming.propertyName(name);
+            writer.write(".$L(", method);
+            writer.indent();
+            writer.write("$L,", CSharpNaming.formatString(name));
+            writer.write("static value => value.$L,", prop);
+            writer.write("static (builder, value) => builder.$L = value,", prop);
+            writer.write("$L,", memberTargetExpr(writer, context, member));
+            writer.write("$L)", memberTraitsExpr(writer, context, member));
+            writer.dedent();
+          }
+          writer.write(".Build(");
+          writer.indent();
+          writer.write("static () => new Builder(),");
+          writer.write(
+              "static builder => new $L($L),",
+              typeName,
+              constructorArguments(writer, context, shape, members));
+          writer.write("new ValueSerializer())");
+          writer.dedent();
+          writer.write(";");
+          writer.dedent();
+          writer.dedent();
+          writer.write("");
+        });
+  }
+
+  public static void writeListSchema(
+      CSharpWriter writer, GenerationContext context, ListShape shape) {
+    SymbolProvider sp = context.symbolProvider();
+    Shape memberTarget = context.model().expectShape(shape.getMember().getTarget());
+    String typeName = writer.typeName(sp.toSymbol(shape));
+    boolean sparse = ShapeSupport.isSparse(shape);
+    String memberType = writer.typeName(sp.toSymbol(memberTarget)) + (sparse ? "?" : "");
+    String builderType = writer.typeName(RuntimeTypes.LIST) + "<" + memberType + ">";
+    String factory = shape.getType() == ShapeType.SET ? "Set" : "List";
+    String elementSchema =
+        elementSchemaExpr(writer, context, shape.getMember(), memberTarget, sparse);
+
+    writer.write("public static partial class $L", localSchemaClassName(shape));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
+          writer.indent();
+          writer.write(
+              "$T.$L<$L, $L, $L>($L, $L,",
+              RuntimeTypes.SCHEMAS,
+              factory,
+              typeName,
+              memberType,
+              builderType,
+              shapeIdExpr(writer, shape.getId()),
+              elementSchema);
+          writer.indent();
+          writer.write("static value => value.Values,");
+          writer.write("static () => new $L(),", builderType);
+          writer.write("static (builder, value) => builder.Add(value),");
+          writer.write("static builder => $L.FromOwnedList(builder),", typeName);
+          writer.write(
+              "$L, elementTraits: $L);",
+              traitsExpr(writer, shape.getAllTraits().values()),
+              memberTraitsExpr(writer, context, shape.getMember()));
+          writer.dedent();
+          writer.dedent();
+          writer.write("");
+        });
+  }
+
+  public static void writeMapSchema(
+      CSharpWriter writer, GenerationContext context, MapShape shape) {
+    SymbolProvider sp = context.symbolProvider();
+    Shape valueTarget = context.model().expectShape(shape.getValue().getTarget());
+    String typeName = writer.typeName(sp.toSymbol(shape));
+    boolean sparse = ShapeSupport.isSparse(shape);
+    String valueType = writer.typeName(sp.toSymbol(valueTarget)) + (sparse ? "?" : "");
+    String builderType = writer.typeName(RuntimeTypes.DICTIONARY) + "<string, " + valueType + ">";
+    String valueSchema = elementSchemaExpr(writer, context, shape.getValue(), valueTarget, sparse);
+
+    writer.write("public static partial class $L", localSchemaClassName(shape));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
+          writer.indent();
+          writer.write(
+              "$T.Map<$L, $L, $L>($L, $L,",
+              RuntimeTypes.SCHEMAS,
+              typeName,
+              valueType,
+              builderType,
+              shapeIdExpr(writer, shape.getId()),
+              valueSchema);
+          writer.indent();
+          writer.write("static value => value.Values,");
+          writer.write(
+              "static () => new $L($T.Ordinal),", builderType, RuntimeTypes.STRING_COMPARER);
+          writer.write("static (builder, key, value) => builder[key] = value,");
+          writer.write("static builder => $L.FromOwnedDictionary(builder),", typeName);
+          writer.write(
+              "$L, keyTraits: $L, valueTraits: $L, key: $L);",
+              traitsExpr(writer, shape.getAllTraits().values()),
+              memberTraitsExpr(writer, context, shape.getKey()),
+              memberTraitsExpr(writer, context, shape.getValue()),
+              shapeSchemaAccessor(
+                  writer, context, context.model().expectShape(shape.getKey().getTarget())));
+          writer.dedent();
+          writer.dedent();
+          writer.write("");
+        });
+  }
+
+  public static void writeSimpleSchema(CSharpWriter writer, Shape shape) {
+    writer.write("public static partial class $L", localSchemaClassName(shape));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          if (shape.getType() == ShapeType.ENUM) {
+            String typeName = CSharpNaming.typeName(shape.getId().getName());
+            writer.write(
+                "public static $T<$L> Schema { get; } = $T.StringEnum<$L>($L, values: $L, traits:"
+                    + " $L, internalValues: $L);",
+                RuntimeTypes.SCHEMA,
+                typeName,
+                RuntimeTypes.SCHEMAS,
+                typeName,
+                shapeIdExpr(writer, shape.getId()),
+                stringEnumValuesExpr(shape),
+                traitsExpr(writer, shape.getAllTraits().values()),
+                stringEnumInternalValuesExpr(shape));
+            writer.write("");
+            return;
+          }
+
+          String prelude = primitiveTypeToPreludeSchema(writer, shape.getType());
+          if (prelude == null) {
+            prelude = (writer.typeName(RuntimeTypes.SCHEMAS) + ".String");
+          }
+          writer.write(
+              "public static $T<$L> Schema { get; } = $L;",
+              RuntimeTypes.SCHEMA,
+              CSharpNaming.typeName(shape.getId().getName()),
+              prelude);
+          writer.write("");
+        });
+  }
+
+  public static void writeUnionSchema(
+      CSharpWriter writer, GenerationContext context, UnionShape shape, List<MemberShape> members) {
+    String typeName = writer.typeName(context.symbolProvider().toSymbol(shape));
+
+    writer.write("public static partial class $L", localSchemaClassName(shape));
+    writer.openBlock(
+        "{",
+        "}",
+        () -> {
+          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
+          writer.indent();
+          writer.write(
+              "$T.Union<$L>($L, $L)",
+              RuntimeTypes.SCHEMAS,
+              typeName,
+              shapeIdExpr(writer, shape.getId()),
+              traitsExpr(writer, shape.getAllTraits().values()));
+          writer.indent();
+          for (MemberShape member : members) {
+            String variantName = CSharpNaming.typeName(member.getMemberName());
+            writer.write(".Case(");
+            writer.indent();
+            writer.write("$L,", CSharpNaming.formatString(member.getMemberName()));
+            writer.write("static value => value is $L.$L,", typeName, variantName);
+            writer.write("static value => (($L.$L)value).Value,", typeName, variantName);
+            writer.write("static value => new $L.$L(value!),", typeName, variantName);
+            writer.write("$L,", rawMemberTargetExpr(writer, context, member));
+            writer.write("$L)", memberTraitsExpr(writer, context, member));
+            writer.dedent();
+          }
+          writer.write(".Build();");
+          writer.dedent();
+          writer.dedent();
+          writer.write("");
+        });
+  }
+
+  /**
+   * The values an enum shape defines, so the runtime can tell a modeled value from one a peer
+   * invented. Generated enum types stay open, so the schema is the only place this is recorded.
+   */
+  public static String stringEnumValuesExpr(Shape shape) {
+    return shape
+        .asEnumShape()
+        .map(
+            e ->
+                e.getEnumValues().values().stream()
+                    .map(CSharpNaming::formatString)
+                    .collect(Collectors.joining(", ", "[", "]")))
+        .orElse("null");
+  }
+
+  /**
+   * The values an enum shape marks {@code @internal}. They are valid on the wire like any other,
+   * but a server leaves them out of the message it sends back when it rejects a value, so the
+   * schema has to record which ones they are.
+   */
+  public static String stringEnumInternalValuesExpr(Shape shape) {
+    return shape
+        .asEnumShape()
+        .map(
+            e ->
+                e.getAllMembers().values().stream()
+                    .filter(m -> m.hasTrait(InternalTrait.class))
+                    .map(m -> m.expectTrait(EnumValueTrait.class).expectStringValue())
+                    .map(CSharpNaming::formatString)
+                    .collect(Collectors.toList()))
+        .filter(values -> !values.isEmpty())
+        .map(values -> String.join(", ", values))
+        .map(values -> "[" + values + "]")
+        .orElse("null");
+  }
+
+  /** The int values an intEnum shape defines. See {@link #stringEnumValuesExpr}. */
+  public static String intEnumValuesExpr(IntEnumShape shape) {
+    return shape.getEnumValues().values().stream()
+        .map(String::valueOf)
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  private SchemaGenerator() {}
 
   private static boolean isCycleCapable(ShapeType type) {
     return switch (type) {
@@ -127,313 +479,8 @@ public final class SchemaGenerator {
         "Unit");
   }
 
-  public static String schemaClassName(
-      CSharpWriter writer, GenerationContext context, Shape shape) {
-    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema");
-  }
-
-  public static String operationSchemaAccessor(
-      CSharpWriter writer, GenerationContext context, OperationShape shape) {
-    return writer.typeName(context.symbolProvider().toSymbol(shape), "Schema") + ".Schema";
-  }
-
-  public static String serviceSchemaAccessor(
-      CSharpWriter writer,
-      GenerationContext context,
-      software.amazon.smithy.model.shapes.ServiceShape service) {
-    return writer.typeName(context.symbolProvider().toSymbol(service), "Schema") + ".Schema";
-  }
-
-  public static String operationShapeType(
-      CSharpWriter writer, GenerationContext context, ShapeId id) {
-    if (ShapeSupport.isUnit(id)) return "SmithyUnit";
-    return writer.typeName(context.symbolProvider().toSymbol(context.model().expectShape(id)));
-  }
-
-  public static String operationShapeSchema(
-      CSharpWriter writer, GenerationContext context, ShapeId id) {
-    if (ShapeSupport.isUnit(id)) return "Schemas.Unit";
-    return shapeSchemaAccessor(writer, context, context.model().expectShape(id));
-  }
-
   private static String localSchemaClassName(Shape shape) {
     return CSharpNaming.typeName(shape.getId().getName()) + "Schema";
-  }
-
-  public static String shapeIdExpr(ShapeId id) {
-    return "ShapeId.Parse(" + CSharpNaming.formatString(id.toString()) + ")";
-  }
-
-  public static String traitExpr(CSharpWriter writer, Trait trait) {
-    String idExpr = shapeIdExpr(trait.toShapeId());
-    Node node = trait.toNode();
-    if (node.isNullNode()) {
-      return "new Trait(" + idExpr + ")";
-    }
-
-    return "new Trait(" + idExpr + ", " + documentExpr(writer, node) + ")";
-  }
-
-  public static String traitsExpr(CSharpWriter writer, Collection<? extends Trait> traits) {
-    if (traits.isEmpty()) {
-      return "null";
-    }
-
-    List<Trait> sorted = new ArrayList<>(traits);
-    sorted.sort(java.util.Comparator.comparing(t -> t.toShapeId().toString()));
-    return "["
-        + sorted.stream().map(value -> traitExpr(writer, value)).collect(Collectors.joining(", "))
-        + "]";
-  }
-
-  public static void writeStructureSchema(
-      CSharpWriter writer, GenerationContext context, Shape shape, List<MemberShape> members) {
-    addImports(writer);
-    SymbolProvider sp = context.symbolProvider();
-    String typeName = writer.typeName(sp.toSymbol(shape));
-
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public sealed class Builder");
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                for (MemberShape member : members) {
-                  writer.write(
-                      "public $L $L { get; set; }",
-                      ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
-                      CSharpNaming.propertyName(member.getMemberName()));
-                }
-              });
-          writer.write("");
-          writer.write(
-              "private sealed class ValueSerializer : IStructValueSerializer<$L>", typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write(
-                    "public void WriteMembers<TWriter>($L value, ref TWriter writer)", typeName);
-                writer.write("    where TWriter : struct, IStructMemberWriter");
-                writer.openBlock(
-                    "{",
-                    "}",
-                    () -> {
-                      for (int index = 0; index < members.size(); index++) {
-                        MemberShape member = members.get(index);
-                        writer.write(
-                            "writer.WriteMember<$L>($L, value.$L);",
-                            ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
-                            index,
-                            CSharpNaming.propertyName(member.getMemberName()));
-                      }
-                    });
-              });
-          writer.write("");
-          writer.write("public static Schema<$L> Schema { get; } =", typeName);
-          writer.indent();
-          writer.write(
-              "Schemas.Structure<$L, Builder>($L, $L)",
-              typeName,
-              shapeIdExpr(shape.getId()),
-              traitsExpr(writer, shape.getAllTraits().values()));
-          writer.indent();
-          for (MemberShape member : members) {
-            String method = ShapeSupport.isRequired(member) ? "Required" : "Optional";
-            String name = member.getMemberName();
-            String prop = CSharpNaming.propertyName(name);
-            writer.write(".$L(", method);
-            writer.indent();
-            writer.write("$L,", CSharpNaming.formatString(name));
-            writer.write("static value => value.$L,", prop);
-            writer.write("static (builder, value) => builder.$L = value,", prop);
-            writer.write("$L,", memberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(writer, context, member));
-            writer.dedent();
-          }
-          writer.write(".Build(");
-          writer.indent();
-          writer.write("static () => new Builder(),");
-          writer.write(
-              "static builder => new $L($L),",
-              typeName,
-              constructorArguments(context, shape, members));
-          writer.write("new ValueSerializer())");
-          writer.dedent();
-          writer.write(";");
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
-  }
-
-  public static void writeListSchema(
-      CSharpWriter writer, GenerationContext context, ListShape shape) {
-    addImports(writer);
-    SymbolProvider sp = context.symbolProvider();
-    Shape memberTarget = context.model().expectShape(shape.getMember().getTarget());
-    String typeName = writer.typeName(sp.toSymbol(shape));
-    boolean sparse = ShapeSupport.isSparse(shape);
-    String memberType = writer.typeName(sp.toSymbol(memberTarget)) + (sparse ? "?" : "");
-    String builderType =
-        writer.frameworkType("System.Collections.Generic.List") + "<" + memberType + ">";
-    String factory = shape.getType() == ShapeType.SET ? "Set" : "List";
-    String elementSchema =
-        elementSchemaExpr(writer, context, shape.getMember(), memberTarget, sparse);
-
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static Schema<$L> Schema { get; } =", typeName);
-          writer.indent();
-          writer.write(
-              "Schemas.$L<$L, $L, $L>($L, $L,",
-              factory,
-              typeName,
-              memberType,
-              builderType,
-              shapeIdExpr(shape.getId()),
-              elementSchema);
-          writer.indent();
-          writer.write("static value => value.Values,");
-          writer.write("static () => new $L(),", builderType);
-          writer.write("static (builder, value) => builder.Add(value),");
-          writer.write("static builder => $L.FromOwnedList(builder),", typeName);
-          writer.write(
-              "$L, elementTraits: $L);",
-              traitsExpr(writer, shape.getAllTraits().values()),
-              memberTraitsExpr(writer, context, shape.getMember()));
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
-  }
-
-  public static void writeMapSchema(
-      CSharpWriter writer, GenerationContext context, MapShape shape) {
-    addImports(writer);
-    SymbolProvider sp = context.symbolProvider();
-    Shape valueTarget = context.model().expectShape(shape.getValue().getTarget());
-    String typeName = writer.typeName(sp.toSymbol(shape));
-    boolean sparse = ShapeSupport.isSparse(shape);
-    String valueType = writer.typeName(sp.toSymbol(valueTarget)) + (sparse ? "?" : "");
-    String builderType =
-        writer.frameworkType("System.Collections.Generic.Dictionary")
-            + "<string, "
-            + valueType
-            + ">";
-    String valueSchema = elementSchemaExpr(writer, context, shape.getValue(), valueTarget, sparse);
-
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static Schema<$L> Schema { get; } =", typeName);
-          writer.indent();
-          writer.write(
-              "Schemas.Map<$L, $L, $L>($L, $L,",
-              typeName,
-              valueType,
-              builderType,
-              shapeIdExpr(shape.getId()),
-              valueSchema);
-          writer.indent();
-          writer.write("static value => value.Values,");
-          writer.write(
-              "static () => new $L(" + writer.frameworkType("System.StringComparer") + ".Ordinal),",
-              builderType);
-          writer.write("static (builder, key, value) => builder[key] = value,");
-          writer.write("static builder => $L.FromOwnedDictionary(builder),", typeName);
-          writer.write(
-              "$L, keyTraits: $L, valueTraits: $L, key: $L);",
-              traitsExpr(writer, shape.getAllTraits().values()),
-              memberTraitsExpr(writer, context, shape.getKey()),
-              memberTraitsExpr(writer, context, shape.getValue()),
-              shapeSchemaAccessor(
-                  writer, context, context.model().expectShape(shape.getKey().getTarget())));
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
-  }
-
-  public static void writeSimpleSchema(CSharpWriter writer, Shape shape) {
-    addImports(writer);
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          if (shape.getType() == ShapeType.ENUM) {
-            String typeName = CSharpNaming.typeName(shape.getId().getName());
-            writer.write(
-                "public static Schema<$L> Schema { get; } ="
-                    + " Schemas.StringEnum<$L>($L, values: $L, traits: $L,"
-                    + " internalValues: $L);",
-                typeName,
-                typeName,
-                shapeIdExpr(shape.getId()),
-                stringEnumValuesExpr(shape),
-                traitsExpr(writer, shape.getAllTraits().values()),
-                stringEnumInternalValuesExpr(shape));
-            writer.write("");
-            return;
-          }
-
-          String prelude = primitiveTypeToPreludeSchema(shape.getType());
-          if (prelude == null) {
-            prelude = "Schemas.String";
-          }
-          writer.write(
-              "public static Schema<$L> Schema { get; } = $L;",
-              CSharpNaming.typeName(shape.getId().getName()),
-              prelude);
-          writer.write("");
-        });
-  }
-
-  public static void writeUnionSchema(
-      CSharpWriter writer, GenerationContext context, UnionShape shape, List<MemberShape> members) {
-    addImports(writer);
-    String typeName = writer.typeName(context.symbolProvider().toSymbol(shape));
-
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static Schema<$L> Schema { get; } =", typeName);
-          writer.indent();
-          writer.write(
-              "Schemas.Union<$L>($L, $L)",
-              typeName,
-              shapeIdExpr(shape.getId()),
-              traitsExpr(writer, shape.getAllTraits().values()));
-          writer.indent();
-          for (MemberShape member : members) {
-            String variantName = CSharpNaming.typeName(member.getMemberName());
-            writer.write(".Case(");
-            writer.indent();
-            writer.write("$L,", CSharpNaming.formatString(member.getMemberName()));
-            writer.write("static value => value is $L.$L,", typeName, variantName);
-            writer.write("static value => (($L.$L)value).Value,", typeName, variantName);
-            writer.write("static value => new $L.$L(value!),", typeName, variantName);
-            writer.write("$L,", rawMemberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(writer, context, member));
-            writer.dedent();
-          }
-          writer.write(".Build();");
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
   }
 
   private static String memberTargetExpr(
@@ -448,9 +495,9 @@ public final class SchemaGenerator {
     }
 
     if (!ShapeSupport.isReferenceType(context.model(), member)) {
-      return "Schemas.Nullable(" + targetExpr + ")";
+      return (writer.typeName(RuntimeTypes.SCHEMAS) + ".Nullable(") + targetExpr + ")";
     }
-    return "Schemas.NullableReference(" + targetExpr + ")";
+    return (writer.typeName(RuntimeTypes.SCHEMAS) + ".NullableReference(") + targetExpr + ")";
   }
 
   private static String rawMemberTargetExpr(
@@ -462,10 +509,12 @@ public final class SchemaGenerator {
   private static String targetSchemaExpr(
       CSharpWriter writer, GenerationContext context, MemberShape member, Shape target) {
     if (ShapeSupport.isStreamingBlobMember(context.model(), member)) {
-      return "Schemas.StreamingBlob";
+      return (writer.typeName(RuntimeTypes.SCHEMAS) + ".StreamingBlob");
     }
     if (ShapeSupport.isEventStreamMember(context.model(), member)) {
-      return "Schemas.EventStream(" + shapeSchemaAccessor(writer, context, target) + ")";
+      return (writer.typeName(RuntimeTypes.SCHEMAS) + ".EventStream(")
+          + shapeSchemaAccessor(writer, context, target)
+          + ")";
     }
     return shapeSchemaAccessor(writer, context, target);
   }
@@ -488,15 +537,15 @@ public final class SchemaGenerator {
     } else {
       base =
           ShapeSupport.isReferenceType(context.model(), member)
-              ? "Schemas.NullableReference(" + targetExpr + ")"
-              : "Schemas.Nullable(" + targetExpr + ")";
+              ? (writer.typeName(RuntimeTypes.SCHEMAS) + ".NullableReference(") + targetExpr + ")"
+              : (writer.typeName(RuntimeTypes.SCHEMAS) + ".Nullable(") + targetExpr + ")";
     }
 
     return base;
   }
 
   private static String constructorArguments(
-      GenerationContext context, Shape shape, List<MemberShape> members) {
+      CSharpWriter writer, GenerationContext context, Shape shape, List<MemberShape> members) {
     if (!shape.isStructureShape()) {
       return members.stream()
           .map(m -> "builder." + CSharpNaming.propertyName(m.getMemberName()))
@@ -533,7 +582,9 @@ public final class SchemaGenerator {
           expr =
               "builder."
                   + prop
-                  + " ?? throw new NSmithy.Core.Serde.MissingRequiredMemberException("
+                  + (" ?? throw new "
+                      + writer.typeName(RuntimeTypes.MISSING_REQUIRED_MEMBER_EXCEPTION)
+                      + "(")
                   + CSharpNaming.formatString(member.getMemberName())
                   + ")";
         }
@@ -583,21 +634,29 @@ public final class SchemaGenerator {
 
   private static String documentExpr(CSharpWriter writer, Node node) {
     return switch (node.getType()) {
-      case NULL -> "NSmithy.Core.Document.Null";
-      case BOOLEAN -> "NSmithy.Core.Document.From(" + node.expectBooleanNode().getValue() + ")";
+      case NULL -> (writer.typeName(RuntimeTypes.DOCUMENT) + ".Null");
+      case BOOLEAN ->
+          (writer.typeName(RuntimeTypes.DOCUMENT) + ".From(")
+              + node.expectBooleanNode().getValue()
+              + ")";
       case STRING ->
-          "NSmithy.Core.Document.From("
+          (writer.typeName(RuntimeTypes.DOCUMENT) + ".From(")
               + CSharpNaming.formatString(node.expectStringNode().getValue())
               + ")";
       case NUMBER ->
-          "NSmithy.Core.Document.From((decimal)" + node.expectNumberNode().getValue() + ")";
+          (writer.typeName(RuntimeTypes.DOCUMENT) + ".From((decimal)")
+              + node.expectNumberNode().getValue()
+              + ")";
       case ARRAY -> arrayDocumentExpr(writer, node.expectArrayNode());
       case OBJECT -> objectDocumentExpr(writer, node.expectObjectNode());
     };
   }
 
   private static String arrayDocumentExpr(CSharpWriter writer, ArrayNode node) {
-    return "NSmithy.Core.Document.From(new NSmithy.Core.Document[] {"
+    return (writer.typeName(RuntimeTypes.DOCUMENT)
+            + ".From(new "
+            + writer.typeName(RuntimeTypes.DOCUMENT)
+            + "[] {")
         + node.getElements().stream()
             .map(value -> documentExpr(writer, value))
             .collect(Collectors.joining(", "))
@@ -605,10 +664,10 @@ public final class SchemaGenerator {
   }
 
   private static String objectDocumentExpr(CSharpWriter writer, ObjectNode node) {
-    return "NSmithy.Core.Document.From("
+    return (writer.typeName(RuntimeTypes.DOCUMENT) + ".From(")
         + "new "
-        + writer.frameworkType("System.Collections.Generic.Dictionary")
-        + "<string, NSmithy.Core.Document>"
+        + writer.typeName(RuntimeTypes.DICTIONARY)
+        + ("<string, " + writer.typeName(RuntimeTypes.DOCUMENT) + ">")
         + " {"
         + node.getMembers().entrySet().stream()
             .map(value -> objectMemberExpr(writer, value))
@@ -624,64 +683,21 @@ public final class SchemaGenerator {
         + "}";
   }
 
-  /**
-   * The values an enum shape defines, so the runtime can tell a modeled value from one a peer
-   * invented. Generated enum types stay open, so the schema is the only place this is recorded.
-   */
-  public static String stringEnumValuesExpr(Shape shape) {
-    return shape
-        .asEnumShape()
-        .map(
-            e ->
-                e.getEnumValues().values().stream()
-                    .map(CSharpNaming::formatString)
-                    .collect(Collectors.joining(", ", "[", "]")))
-        .orElse("null");
-  }
-
-  /**
-   * The values an enum shape marks {@code @internal}. They are valid on the wire like any other,
-   * but a server leaves them out of the message it sends back when it rejects a value, so the
-   * schema has to record which ones they are.
-   */
-  public static String stringEnumInternalValuesExpr(Shape shape) {
-    return shape
-        .asEnumShape()
-        .map(
-            e ->
-                e.getAllMembers().values().stream()
-                    .filter(m -> m.hasTrait(InternalTrait.class))
-                    .map(m -> m.expectTrait(EnumValueTrait.class).expectStringValue())
-                    .map(CSharpNaming::formatString)
-                    .collect(Collectors.toList()))
-        .filter(values -> !values.isEmpty())
-        .map(values -> String.join(", ", values))
-        .map(values -> "[" + values + "]")
-        .orElse("null");
-  }
-
-  /** The int values an intEnum shape defines. See {@link #stringEnumValuesExpr}. */
-  public static String intEnumValuesExpr(IntEnumShape shape) {
-    return shape.getEnumValues().values().stream()
-        .map(String::valueOf)
-        .collect(Collectors.joining(", ", "[", "]"));
-  }
-
-  private static String primitiveTypeToPreludeSchema(ShapeType t) {
+  private static String primitiveTypeToPreludeSchema(CSharpWriter writer, ShapeType t) {
     return switch (t) {
-      case BOOLEAN -> "Schemas.Boolean";
-      case BYTE -> "Schemas.Byte";
-      case SHORT -> "Schemas.Short";
-      case INTEGER -> "Schemas.Integer";
-      case LONG -> "Schemas.Long";
-      case FLOAT -> "Schemas.Float";
-      case DOUBLE -> "Schemas.Double";
-      case BIG_INTEGER -> "Schemas.BigInteger";
-      case BIG_DECIMAL -> "Schemas.BigDecimal";
-      case STRING -> "Schemas.String";
-      case BLOB -> "Schemas.Blob";
-      case TIMESTAMP -> "Schemas.Timestamp";
-      case DOCUMENT -> "Schemas.Document";
+      case BOOLEAN -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Boolean");
+      case BYTE -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Byte");
+      case SHORT -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Short");
+      case INTEGER -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Integer");
+      case LONG -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Long");
+      case FLOAT -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Float");
+      case DOUBLE -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Double");
+      case BIG_INTEGER -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".BigInteger");
+      case BIG_DECIMAL -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".BigDecimal");
+      case STRING -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".String");
+      case BLOB -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Blob");
+      case TIMESTAMP -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Timestamp");
+      case DOCUMENT -> (writer.typeName(RuntimeTypes.SCHEMAS) + ".Document");
       default -> null;
     };
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -163,89 +163,57 @@ public final class SchemaGenerator {
 
   public static void writeStructureSchema(
       CSharpWriter writer, GenerationContext context, Shape shape, List<MemberShape> members) {
-    SymbolProvider sp = context.symbolProvider();
-    String typeName = writer.typeName(sp.toSymbol(shape));
+    writer.pushState();
+    try {
+      writer.putContext("schemaClass", localSchemaClassName(shape));
+      writer.putContext("type", context.symbolProvider().toSymbol(shape));
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("structValueSerializer", RuntimeTypes.I_STRUCT_VALUE_SERIALIZER);
+      writer.putContext("structMemberWriter", RuntimeTypes.I_STRUCT_MEMBER_WRITER);
+      writer.putContext("shapeId", shapeIdExpr(writer, shape.getId()));
+      writer.putContext("traits", traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext(
+          "constructorArguments", constructorArguments(writer, context, shape, members));
+      writer.putContext(
+          "builderProperties",
+          writer.consumer(w -> writeStructureBuilderProperties(w, context, members)));
+      writer.putContext(
+          "serializationCalls",
+          writer.consumer(w -> writeStructureSerializationCalls(w, context, members)));
+      writer.putContext(
+          "memberBindings",
+          writer.consumer(w -> writeStructureMemberBindings(w, context, members)));
+      writer.write(
+          """
+          public static partial class ${schemaClass:L}
+          {
+              public sealed class Builder
+              {
+                  ${builderProperties:C|}
+              }
 
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public sealed class Builder");
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                for (MemberShape member : members) {
-                  writer.write(
-                      "public $L $L { get; set; }",
-                      ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
-                      CSharpNaming.propertyName(member.getMemberName()));
-                }
-              });
-          writer.write("");
-          writer.write(
-              "private sealed class ValueSerializer : $T<$L>",
-              RuntimeTypes.I_STRUCT_VALUE_SERIALIZER,
-              typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write(
-                    "public void WriteMembers<TWriter>($L value, ref TWriter writer)", typeName);
-                writer.write("    where TWriter : struct, $T", RuntimeTypes.I_STRUCT_MEMBER_WRITER);
-                writer.openBlock(
-                    "{",
-                    "}",
-                    () -> {
-                      for (int index = 0; index < members.size(); index++) {
-                        MemberShape member = members.get(index);
-                        writer.write(
-                            "writer.WriteMember<$L>($L, value.$L);",
-                            ShapeSupport.memberTypeExpr(writer, context.model(), sp, member, true),
-                            index,
-                            CSharpNaming.propertyName(member.getMemberName()));
-                      }
-                    });
-              });
-          writer.write("");
-          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
-          writer.indent();
-          writer.write(
-              "$T.Structure<$L, Builder>($L, $L)",
-              RuntimeTypes.SCHEMAS,
-              typeName,
-              shapeIdExpr(writer, shape.getId()),
-              traitsExpr(writer, shape.getAllTraits().values()));
-          writer.indent();
-          for (MemberShape member : members) {
-            String method = ShapeSupport.isRequired(member) ? "Required" : "Optional";
-            String name = member.getMemberName();
-            String prop = CSharpNaming.propertyName(name);
-            writer.write(".$L(", method);
-            writer.indent();
-            writer.write("$L,", CSharpNaming.formatString(name));
-            writer.write("static value => value.$L,", prop);
-            writer.write("static (builder, value) => builder.$L = value,", prop);
-            writer.write("$L,", memberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(writer, context, member));
-            writer.dedent();
+              private sealed class ValueSerializer : ${structValueSerializer:T}<${type:T}>
+              {
+                  public void WriteMembers<TWriter>(${type:T} value, ref TWriter writer)
+                      where TWriter : struct, ${structMemberWriter:T}
+                  {
+                      ${serializationCalls:C|}
+                  }
+              }
+
+              public static ${schema:T}<${type:T}> Schema { get; } =
+                  ${schemas:T}.Structure<${type:T}, Builder>(${shapeId:L}, ${traits:L})
+                      ${memberBindings:C|}
+                      .Build(
+                          static () => new Builder(),
+                          static builder => new ${type:T}(${constructorArguments:L}),
+                          new ValueSerializer());
           }
-          writer.write(".Build(");
-          writer.indent();
-          writer.write("static () => new Builder(),");
-          writer.write(
-              "static builder => new $L($L),",
-              typeName,
-              constructorArguments(writer, context, shape, members));
-          writer.write("new ValueSerializer())");
-          writer.dedent();
-          writer.write(";");
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   public static void writeListSchema(
@@ -452,6 +420,55 @@ public final class SchemaGenerator {
   }
 
   private SchemaGenerator() {}
+
+  private static void writeStructureBuilderProperties(
+      CSharpWriter writer, GenerationContext context, List<MemberShape> members) {
+    for (MemberShape member : members) {
+      writer.write(
+          "public $L $L { get; set; }",
+          ShapeSupport.memberTypeExpr(
+              writer, context.model(), context.symbolProvider(), member, true),
+          CSharpNaming.propertyName(member.getMemberName()));
+    }
+  }
+
+  private static void writeStructureSerializationCalls(
+      CSharpWriter writer, GenerationContext context, List<MemberShape> members) {
+    for (int index = 0; index < members.size(); index++) {
+      MemberShape member = members.get(index);
+      writer.write(
+          "writer.WriteMember<$L>($L, value.$L);",
+          ShapeSupport.memberTypeExpr(
+              writer, context.model(), context.symbolProvider(), member, true),
+          index,
+          CSharpNaming.propertyName(member.getMemberName()));
+    }
+  }
+
+  private static void writeStructureMemberBindings(
+      CSharpWriter writer, GenerationContext context, List<MemberShape> members) {
+    for (MemberShape member : members) {
+      writer.pushState();
+      try {
+        writer.putContext("method", ShapeSupport.isRequired(member) ? "Required" : "Optional");
+        writer.putContext("name", CSharpNaming.formatString(member.getMemberName()));
+        writer.putContext("property", CSharpNaming.propertyName(member.getMemberName()));
+        writer.putContext("target", memberTargetExpr(writer, context, member));
+        writer.putContext("memberTraits", memberTraitsExpr(writer, context, member));
+        writer.write(
+            """
+            .${method:L}(
+                ${name:L},
+                static value => value.${property:L},
+                static (builder, value) => builder.${property:L} = value,
+                ${target:L},
+                ${memberTraits:L})
+            """);
+      } finally {
+        writer.popState();
+      }
+    }
+  }
 
   private static boolean isCycleCapable(ShapeType type) {
     return switch (type) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -228,35 +228,35 @@ public final class SchemaGenerator {
     String elementSchema =
         elementSchemaExpr(writer, context, shape.getMember(), memberTarget, sparse);
 
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
-          writer.indent();
-          writer.write(
-              "$T.$L<$L, $L, $L>($L, $L,",
-              RuntimeTypes.SCHEMAS,
-              factory,
-              typeName,
-              memberType,
-              builderType,
-              shapeIdExpr(writer, shape.getId()),
-              elementSchema);
-          writer.indent();
-          writer.write("static value => value.Values,");
-          writer.write("static () => new $L(),", builderType);
-          writer.write("static (builder, value) => builder.Add(value),");
-          writer.write("static builder => $L.FromOwnedList(builder),", typeName);
-          writer.write(
-              "$L, elementTraits: $L);",
-              traitsExpr(writer, shape.getAllTraits().values()),
-              memberTraitsExpr(writer, context, shape.getMember()));
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
+    writer.pushState();
+    try {
+      writer.putContext("schemaClass", localSchemaClassName(shape));
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("type", typeName);
+      writer.putContext("memberType", memberType);
+      writer.putContext("builderType", builderType);
+      writer.putContext("factory", factory);
+      writer.putContext("shapeId", shapeIdExpr(writer, shape.getId()));
+      writer.putContext("elementSchema", elementSchema);
+      writer.putContext("traits", traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext("elementTraits", memberTraitsExpr(writer, context, shape.getMember()));
+      writer.write(
+          """
+          public static partial class ${schemaClass:L}
+          {
+              public static ${schema:T}<${type:L}> Schema { get; } =
+                  ${schemas:T}.${factory:L}<${type:L}, ${memberType:L}, ${builderType:L}>(${shapeId:L}, ${elementSchema:L},
+                      static value => value.Values,
+                      static () => new ${builderType:L}(),
+                      static (builder, value) => builder.Add(value),
+                      static builder => ${type:L}.FromOwnedList(builder),
+                      ${traits:L}, elementTraits: ${elementTraits:L});
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   public static void writeMapSchema(
@@ -269,38 +269,40 @@ public final class SchemaGenerator {
     String builderType = writer.typeName(RuntimeTypes.DICTIONARY) + "<string, " + valueType + ">";
     String valueSchema = elementSchemaExpr(writer, context, shape.getValue(), valueTarget, sparse);
 
-    writer.write("public static partial class $L", localSchemaClassName(shape));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static $T<$L> Schema { get; } =", RuntimeTypes.SCHEMA, typeName);
-          writer.indent();
-          writer.write(
-              "$T.Map<$L, $L, $L>($L, $L,",
-              RuntimeTypes.SCHEMAS,
-              typeName,
-              valueType,
-              builderType,
-              shapeIdExpr(writer, shape.getId()),
-              valueSchema);
-          writer.indent();
-          writer.write("static value => value.Values,");
-          writer.write(
-              "static () => new $L($T.Ordinal),", builderType, RuntimeTypes.STRING_COMPARER);
-          writer.write("static (builder, key, value) => builder[key] = value,");
-          writer.write("static builder => $L.FromOwnedDictionary(builder),", typeName);
-          writer.write(
-              "$L, keyTraits: $L, valueTraits: $L, key: $L);",
-              traitsExpr(writer, shape.getAllTraits().values()),
-              memberTraitsExpr(writer, context, shape.getKey()),
-              memberTraitsExpr(writer, context, shape.getValue()),
-              shapeSchemaAccessor(
-                  writer, context, context.model().expectShape(shape.getKey().getTarget())));
-          writer.dedent();
-          writer.dedent();
-          writer.write("");
-        });
+    writer.pushState();
+    try {
+      writer.putContext("schemaClass", localSchemaClassName(shape));
+      writer.putContext("schema", RuntimeTypes.SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("stringComparer", RuntimeTypes.STRING_COMPARER);
+      writer.putContext("type", typeName);
+      writer.putContext("valueType", valueType);
+      writer.putContext("builderType", builderType);
+      writer.putContext("shapeId", shapeIdExpr(writer, shape.getId()));
+      writer.putContext("valueSchema", valueSchema);
+      writer.putContext("traits", traitsExpr(writer, shape.getAllTraits().values()));
+      writer.putContext("keyTraits", memberTraitsExpr(writer, context, shape.getKey()));
+      writer.putContext("valueTraits", memberTraitsExpr(writer, context, shape.getValue()));
+      writer.putContext(
+          "keySchema",
+          shapeSchemaAccessor(
+              writer, context, context.model().expectShape(shape.getKey().getTarget())));
+      writer.write(
+          """
+          public static partial class ${schemaClass:L}
+          {
+              public static ${schema:T}<${type:L}> Schema { get; } =
+                  ${schemas:T}.Map<${type:L}, ${valueType:L}, ${builderType:L}>(${shapeId:L}, ${valueSchema:L},
+                      static value => value.Values,
+                      static () => new ${builderType:L}(${stringComparer:T}.Ordinal),
+                      static (builder, key, value) => builder[key] = value,
+                      static builder => ${type:L}.FromOwnedDictionary(builder),
+                      ${traits:L}, keyTraits: ${keyTraits:L}, valueTraits: ${valueTraits:L}, key: ${keySchema:L});
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   public static void writeSimpleSchema(CSharpWriter writer, Shape shape) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGenerator.java
@@ -82,7 +82,7 @@ public final class SchemaGenerator {
               .collect(Collectors.toList());
       return tsTraits.isEmpty()
           ? "Schemas.Timestamp"
-          : "Schemas.TimestampWithTraits(" + traitsExpr(tsTraits) + ")";
+          : "Schemas.TimestampWithTraits(" + traitsExpr(writer, tsTraits) + ")";
     }
 
     String preludeSchema =
@@ -164,17 +164,17 @@ public final class SchemaGenerator {
     return "ShapeId.Parse(" + CSharpNaming.formatString(id.toString()) + ")";
   }
 
-  public static String traitExpr(Trait trait) {
+  public static String traitExpr(CSharpWriter writer, Trait trait) {
     String idExpr = shapeIdExpr(trait.toShapeId());
     Node node = trait.toNode();
     if (node.isNullNode()) {
       return "new Trait(" + idExpr + ")";
     }
 
-    return "new Trait(" + idExpr + ", " + documentExpr(node) + ")";
+    return "new Trait(" + idExpr + ", " + documentExpr(writer, node) + ")";
   }
 
-  public static String traitsExpr(Collection<? extends Trait> traits) {
+  public static String traitsExpr(CSharpWriter writer, Collection<? extends Trait> traits) {
     if (traits.isEmpty()) {
       return "null";
     }
@@ -182,7 +182,7 @@ public final class SchemaGenerator {
     List<Trait> sorted = new ArrayList<>(traits);
     sorted.sort(java.util.Comparator.comparing(t -> t.toShapeId().toString()));
     return "["
-        + sorted.stream().map(SchemaGenerator::traitExpr).collect(Collectors.joining(", "))
+        + sorted.stream().map(value -> traitExpr(writer, value)).collect(Collectors.joining(", "))
         + "]";
   }
 
@@ -240,7 +240,7 @@ public final class SchemaGenerator {
               "Schemas.Structure<$L, Builder>($L, $L)",
               typeName,
               shapeIdExpr(shape.getId()),
-              traitsExpr(shape.getAllTraits().values()));
+              traitsExpr(writer, shape.getAllTraits().values()));
           writer.indent();
           for (MemberShape member : members) {
             String method = ShapeSupport.isRequired(member) ? "Required" : "Optional";
@@ -252,7 +252,7 @@ public final class SchemaGenerator {
             writer.write("static value => value.$L,", prop);
             writer.write("static (builder, value) => builder.$L = value,", prop);
             writer.write("$L,", memberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(context, member));
+            writer.write("$L)", memberTraitsExpr(writer, context, member));
             writer.dedent();
           }
           writer.write(".Build(");
@@ -279,7 +279,8 @@ public final class SchemaGenerator {
     String typeName = writer.typeName(sp.toSymbol(shape));
     boolean sparse = ShapeSupport.isSparse(shape);
     String memberType = writer.typeName(sp.toSymbol(memberTarget)) + (sparse ? "?" : "");
-    String builderType = "System.Collections.Generic.List<" + memberType + ">";
+    String builderType =
+        writer.frameworkType("System.Collections.Generic.List") + "<" + memberType + ">";
     String factory = shape.getType() == ShapeType.SET ? "Set" : "List";
     String elementSchema =
         elementSchemaExpr(writer, context, shape.getMember(), memberTarget, sparse);
@@ -306,8 +307,8 @@ public final class SchemaGenerator {
           writer.write("static builder => $L.FromOwnedList(builder),", typeName);
           writer.write(
               "$L, elementTraits: $L);",
-              traitsExpr(shape.getAllTraits().values()),
-              memberTraitsExpr(context, shape.getMember()));
+              traitsExpr(writer, shape.getAllTraits().values()),
+              memberTraitsExpr(writer, context, shape.getMember()));
           writer.dedent();
           writer.dedent();
           writer.write("");
@@ -322,7 +323,11 @@ public final class SchemaGenerator {
     String typeName = writer.typeName(sp.toSymbol(shape));
     boolean sparse = ShapeSupport.isSparse(shape);
     String valueType = writer.typeName(sp.toSymbol(valueTarget)) + (sparse ? "?" : "");
-    String builderType = "System.Collections.Generic.Dictionary<string, " + valueType + ">";
+    String builderType =
+        writer.frameworkType("System.Collections.Generic.Dictionary")
+            + "<string, "
+            + valueType
+            + ">";
     String valueSchema = elementSchemaExpr(writer, context, shape.getValue(), valueTarget, sparse);
 
     writer.write("public static partial class $L", localSchemaClassName(shape));
@@ -341,14 +346,16 @@ public final class SchemaGenerator {
               valueSchema);
           writer.indent();
           writer.write("static value => value.Values,");
-          writer.write("static () => new $L(System.StringComparer.Ordinal),", builderType);
+          writer.write(
+              "static () => new $L(" + writer.frameworkType("System.StringComparer") + ".Ordinal),",
+              builderType);
           writer.write("static (builder, key, value) => builder[key] = value,");
           writer.write("static builder => $L.FromOwnedDictionary(builder),", typeName);
           writer.write(
               "$L, keyTraits: $L, valueTraits: $L, key: $L);",
-              traitsExpr(shape.getAllTraits().values()),
-              memberTraitsExpr(context, shape.getKey()),
-              memberTraitsExpr(context, shape.getValue()),
+              traitsExpr(writer, shape.getAllTraits().values()),
+              memberTraitsExpr(writer, context, shape.getKey()),
+              memberTraitsExpr(writer, context, shape.getValue()),
               shapeSchemaAccessor(
                   writer, context, context.model().expectShape(shape.getKey().getTarget())));
           writer.dedent();
@@ -374,7 +381,7 @@ public final class SchemaGenerator {
                 typeName,
                 shapeIdExpr(shape.getId()),
                 stringEnumValuesExpr(shape),
-                traitsExpr(shape.getAllTraits().values()),
+                traitsExpr(writer, shape.getAllTraits().values()),
                 stringEnumInternalValuesExpr(shape));
             writer.write("");
             return;
@@ -408,7 +415,7 @@ public final class SchemaGenerator {
               "Schemas.Union<$L>($L, $L)",
               typeName,
               shapeIdExpr(shape.getId()),
-              traitsExpr(shape.getAllTraits().values()));
+              traitsExpr(writer, shape.getAllTraits().values()));
           writer.indent();
           for (MemberShape member : members) {
             String variantName = CSharpNaming.typeName(member.getMemberName());
@@ -419,7 +426,7 @@ public final class SchemaGenerator {
             writer.write("static value => (($L.$L)value).Value,", typeName, variantName);
             writer.write("static value => new $L.$L(value!),", typeName, variantName);
             writer.write("$L,", rawMemberTargetExpr(writer, context, member));
-            writer.write("$L)", memberTraitsExpr(context, member));
+            writer.write("$L)", memberTraitsExpr(writer, context, member));
             writer.dedent();
           }
           writer.write(".Build();");
@@ -536,7 +543,8 @@ public final class SchemaGenerator {
     return String.join(", ", args);
   }
 
-  private static String memberTraitsExpr(GenerationContext context, MemberShape member) {
+  private static String memberTraitsExpr(
+      CSharpWriter writer, GenerationContext context, MemberShape member) {
     List<Trait> traits = new ArrayList<>(member.getAllTraits().values());
     Shape target = context.model().expectShape(member.getTarget());
     if (shouldInlineTargetTraits(target)) {
@@ -546,7 +554,7 @@ public final class SchemaGenerator {
         }
       }
     }
-    return traitsExpr(traits);
+    return traitsExpr(writer, traits);
   }
 
   private static boolean shouldInlineTargetTraits(Shape target) {
@@ -573,7 +581,7 @@ public final class SchemaGenerator {
     };
   }
 
-  private static String documentExpr(Node node) {
+  private static String documentExpr(CSharpWriter writer, Node node) {
     return switch (node.getType()) {
       case NULL -> "NSmithy.Core.Document.Null";
       case BOOLEAN -> "NSmithy.Core.Document.From(" + node.expectBooleanNode().getValue() + ")";
@@ -583,34 +591,36 @@ public final class SchemaGenerator {
               + ")";
       case NUMBER ->
           "NSmithy.Core.Document.From((decimal)" + node.expectNumberNode().getValue() + ")";
-      case ARRAY -> arrayDocumentExpr(node.expectArrayNode());
-      case OBJECT -> objectDocumentExpr(node.expectObjectNode());
+      case ARRAY -> arrayDocumentExpr(writer, node.expectArrayNode());
+      case OBJECT -> objectDocumentExpr(writer, node.expectObjectNode());
     };
   }
 
-  private static String arrayDocumentExpr(ArrayNode node) {
+  private static String arrayDocumentExpr(CSharpWriter writer, ArrayNode node) {
     return "NSmithy.Core.Document.From(new NSmithy.Core.Document[] {"
         + node.getElements().stream()
-            .map(SchemaGenerator::documentExpr)
+            .map(value -> documentExpr(writer, value))
             .collect(Collectors.joining(", "))
         + "})";
   }
 
-  private static String objectDocumentExpr(ObjectNode node) {
+  private static String objectDocumentExpr(CSharpWriter writer, ObjectNode node) {
     return "NSmithy.Core.Document.From("
-        + "new System.Collections.Generic.Dictionary<string, NSmithy.Core.Document>"
+        + "new "
+        + writer.frameworkType("System.Collections.Generic.Dictionary")
+        + "<string, NSmithy.Core.Document>"
         + " {"
         + node.getMembers().entrySet().stream()
-            .map(SchemaGenerator::objectMemberExpr)
+            .map(value -> objectMemberExpr(writer, value))
             .collect(Collectors.joining(", "))
         + "})";
   }
 
-  private static String objectMemberExpr(Map.Entry<StringNode, Node> member) {
+  private static String objectMemberExpr(CSharpWriter writer, Map.Entry<StringNode, Node> member) {
     return "{"
         + CSharpNaming.formatString(member.getKey().getValue())
         + ", "
-        + documentExpr(member.getValue())
+        + documentExpr(writer, member.getValue())
         + "}";
   }
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -50,7 +50,6 @@ public final class ServerGenerator implements Runnable {
 
   public ServerGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -50,6 +50,7 @@ public final class ServerGenerator implements Runnable {
 
   public ServerGenerator(GenerationContext c, CSharpWriter w, ServiceShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.service = s;
   }
@@ -157,7 +158,9 @@ public final class ServerGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(services);");
                 writer.write("return CreateOperationCatalog(");
                 writer.indent();
                 for (int i = 0; i < ops.size(); i++) {
@@ -263,7 +266,9 @@ public final class ServerGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(services);");
                 writer.write(
                     "services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceDefinition,"
                         + " $LDefinition>());",
@@ -281,7 +286,9 @@ public final class ServerGenerator implements Runnable {
               "{",
               "}",
               () -> {
-                writer.write("System.ArgumentNullException.ThrowIfNull(services);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(services);");
                 writer.write("");
                 if (!serverKinds.isEmpty()) {
                   writer.write("services.AddSmithyServer();");
@@ -360,7 +367,7 @@ public final class ServerGenerator implements Runnable {
 
   private void writeProtocolEnum(String contract, List<Kind> serverKinds) {
     String enumName = protocolEnumName(contract);
-    writer.write("[System.Flags]");
+    writer.write("[" + writer.frameworkAttribute("System.FlagsAttribute") + "]");
     writer.write("public enum $L", enumName);
     writer.openBlock(
         "{",
@@ -415,20 +422,26 @@ public final class ServerGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write("System.ArgumentNullException.ThrowIfNull(endpoints);");
+          writer.write(
+              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(endpoints);");
           writer.write("if ((protocols & ~$L.All) != 0)", protocolEnum);
           writer.openBlock(
               "{",
               "}",
               () ->
                   writer.write(
-                      "throw new System.ArgumentOutOfRangeException(nameof(protocols), protocols,"
+                      "throw new "
+                          + writer.frameworkType("System.ArgumentOutOfRangeException")
+                          + "(nameof(protocols), protocols,"
                           + " \"Unknown $L value.\");",
                       protocolEnum));
           writer.write("");
           writer.write(
-              "var mappedRoutes = new System.Collections.Generic.HashSet<string>("
-                  + "System.StringComparer.Ordinal);");
+              "var mappedRoutes = new "
+                  + writer.frameworkType("System.Collections.Generic.HashSet")
+                  + "<string>("
+                  + writer.frameworkType("System.StringComparer")
+                  + ".Ordinal);");
           for (Kind kind : serverKinds) {
             writer.write("if ((protocols & $L.$L) != 0)", protocolEnum, mapSuffix(kind));
             writer.openBlock(
@@ -443,7 +456,9 @@ public final class ServerGenerator implements Runnable {
 
   private void writeRouteConflictHelper(String contract, String protocolEnum) {
     writer.write(
-        "private static void EnsureRouteAvailable(System.Collections.Generic.HashSet<string>"
+        "private static void EnsureRouteAvailable("
+            + writer.frameworkType("System.Collections.Generic.HashSet")
+            + "<string>"
             + " mappedRoutes, string method, string routePattern, $L protocol)",
         protocolEnum);
     writer.openBlock(
@@ -457,7 +472,9 @@ public final class ServerGenerator implements Runnable {
               "}",
               () -> {
                 writer.write(
-                    "throw new System.InvalidOperationException(\"Mapping \" + protocol + \" for"
+                    "throw new "
+                        + writer.frameworkType("System.InvalidOperationException")
+                        + "(\"Mapping \" + protocol + \" for"
                         + " $L would register duplicate route '\" + route + \"'. Map conflicting"
                         + " protocols on different endpoint route builders, hosts, or ports.\");",
                     contract);
@@ -469,7 +486,9 @@ public final class ServerGenerator implements Runnable {
       Kind kind, List<OperationShape> ops, String contract, String protocolEnum) {
     writer.write(
         "private static void Map$L$L(IEndpointRouteBuilder endpoints,"
-            + " System.Collections.Generic.HashSet<string> mappedRoutes)",
+            + " "
+            + writer.frameworkType("System.Collections.Generic.HashSet")
+            + "<string> mappedRoutes)",
         contract,
         mapSuffix(kind));
     writer.openBlock(
@@ -500,14 +519,19 @@ public final class ServerGenerator implements Runnable {
       writer.openBlock(
           "endpoints.MapMethods($L, [$L], async (HttpContext httpContext,"
               + " [Microsoft.AspNetCore.Mvc.FromServices] SmithyServerRuntime runtime, $L handler,"
-              + " System.Threading.CancellationToken cancellationToken) => {",
+              + " "
+              + writer.frameworkType("System.Threading.CancellationToken")
+              + " cancellationToken) => {",
           "});",
           CSharpNaming.formatString(routePattern(http)),
           CSharpNaming.formatString(http.getMethod()),
           opInterface,
           () -> {
-            writer.write("System.ArgumentNullException.ThrowIfNull(httpContext);");
-            writer.write("System.ArgumentNullException.ThrowIfNull(handler);");
+            writer.write(
+                writer.frameworkType("System.ArgumentNullException")
+                    + ".ThrowIfNull(httpContext);");
+            writer.write(
+                writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(handler);");
             writer.write("");
             writeStaticQueryValidation(http);
             writeDispatch(kind, op);
@@ -533,13 +557,17 @@ public final class ServerGenerator implements Runnable {
     writer.openBlock(
         "endpoints.MapPost($L, async (HttpContext httpContext,"
             + " [Microsoft.AspNetCore.Mvc.FromServices] SmithyServerRuntime runtime, $L handler,"
-            + " System.Threading.CancellationToken cancellationToken) => {",
+            + " "
+            + writer.frameworkType("System.Threading.CancellationToken")
+            + " cancellationToken) => {",
         "});",
         CSharpNaming.formatString(uri),
         opInterface,
         () -> {
-          writer.write("System.ArgumentNullException.ThrowIfNull(httpContext);");
-          writer.write("System.ArgumentNullException.ThrowIfNull(handler);");
+          writer.write(
+              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(httpContext);");
+          writer.write(
+              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(handler);");
           writer.write("");
           writeDispatch(kind, op);
         });
@@ -740,15 +768,16 @@ public final class ServerGenerator implements Runnable {
         hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
     String returnType =
         hasOutput
-            ? "System.Threading.Tasks.Task<" + outputType + ">"
-            : "System.Threading.Tasks.Task";
+            ? writer.frameworkType("System.Threading.Tasks.Task") + "<" + outputType + ">"
+            : writer.frameworkType("System.Threading.Tasks.Task");
     String params = hasInput ? inputType + " input, " : "";
     return returnType
         + " "
         + name
         + "("
         + params
-        + "System.Threading.CancellationToken cancellationToken = default)";
+        + writer.frameworkType("System.Threading.CancellationToken")
+        + " cancellationToken = default)";
   }
 
   private Map<String, String> operationParameterDocs(OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -15,7 +15,6 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
 import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
 import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.TraitIds;
@@ -76,6 +75,7 @@ public final class ServerGenerator implements Runnable {
         idx.getContainedOperations(service).stream()
             .sorted(Comparator.comparing(o -> o.getId().toString()))
             .collect(Collectors.toList());
+    ops.forEach(op -> writer.reserveName(operationJsonSchemasClass(op)));
 
     List<Kind> serverKinds = serverKinds();
     List<PromptDefinition> prompts = promptDefinitions(ops);
@@ -147,7 +147,7 @@ public final class ServerGenerator implements Runnable {
         () -> {
           writer.write(
               "public ServiceSchema Schema => $L;",
-              SchemaGenerator.serviceSchemaAccessor(context, service));
+              SchemaGenerator.serviceSchemaAccessor(writer, context, service));
           writer.write("");
           writePromptDefinitions(prompts);
           writer.write("");
@@ -225,19 +225,19 @@ public final class ServerGenerator implements Runnable {
         () -> {
           writer.write("return new ServiceOperationCatalog(");
           writer.indent();
-          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(context, service));
+          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
           writer.write("[");
           writer.indent();
           for (OperationShape op : ops) {
             if (isStreaming(op)) {
               writer.write(
                   "ServiceOperation.Create($L, $L),",
-                  SchemaGenerator.operationSchemaAccessor(context, op),
+                  SchemaGenerator.operationSchemaAccessor(writer, context, op),
                   unaryAdapter(op, operationHandlerVariable(op)));
             } else {
               writer.write(
                   "ServiceOperation.Create($L, $L, $L.Value),",
-                  SchemaGenerator.operationSchemaAccessor(context, op),
+                  SchemaGenerator.operationSchemaAccessor(writer, context, op),
                   unaryAdapter(op, operationHandlerVariable(op)),
                   operationJsonSchemasClass(op));
             }
@@ -385,7 +385,7 @@ public final class ServerGenerator implements Runnable {
           "private static readonly IServiceProtocol $LServiceProtocol = new $L().ForService($L);",
           mapSuffix(kind),
           ProtocolSupport.protocolType(kind),
-          SchemaGenerator.serviceSchemaAccessor(context, service));
+          SchemaGenerator.serviceSchemaAccessor(writer, context, service));
       for (OperationShape op : ops) {
         if (!canBindOperation(kind, op)) {
           continue;
@@ -393,11 +393,11 @@ public final class ServerGenerator implements Runnable {
         writer.write(
             "private static readonly IServerOperationProtocol<$L, $L> $L ="
                 + " $LServiceProtocol.ForServerOperation($L);",
-            SchemaGenerator.operationShapeType(context, op.getInputShape()),
-            SchemaGenerator.operationShapeType(context, op.getOutputShape()),
+            SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
+            SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
             operationProtocolField(kind, op),
             mapSuffix(kind),
-            SchemaGenerator.operationSchemaAccessor(context, op));
+            SchemaGenerator.operationSchemaAccessor(writer, context, op));
       }
     }
   }
@@ -735,13 +735,9 @@ public final class ServerGenerator implements Runnable {
     boolean hasOutput = !ShapeSupport.isUnit(op.getOutputShape());
     String name = CSharpNaming.typeName(op.getId().getName()) + "Async";
     String inputType =
-        hasInput
-            ? CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getInputShape())))
-            : null;
+        hasInput ? writer.typeName(sp.toSymbol(model.expectShape(op.getInputShape()))) : null;
     String outputType =
-        hasOutput
-            ? CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(op.getOutputShape())))
-            : null;
+        hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
     String returnType =
         hasOutput
             ? "System.Threading.Tasks.Task<" + outputType + ">"

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -54,18 +54,6 @@ public final class ServerGenerator implements Runnable {
     this.service = s;
   }
 
-  /** Protocols that emit an ASP.NET Core server, in declared precedence order. */
-  private List<Kind> serverKinds() {
-    return ProtocolSupport.declaredKinds(service).stream()
-        .filter(
-            kind ->
-                kind == Kind.RPC_V2_CBOR
-                    || kind == Kind.SIMPLE_REST_JSON
-                    || kind == Kind.REST_JSON_1
-                    || kind == Kind.GRPC)
-        .collect(Collectors.toList());
-  }
-
   @Override
   public void run() {
     SymbolProvider sp = context.symbolProvider();
@@ -84,20 +72,12 @@ public final class ServerGenerator implements Runnable {
     }
     boolean emitsAspNetCore = !serverKinds.isEmpty();
 
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-    writer.addImport(RuntimeTypes.NSMITHY_SERVER);
     writer.addImport(RuntimeTypes.MS_EXT_DI);
     writer.addImport(RuntimeTypes.MS_EXT_DI_EXTENSIONS);
     if (emitsAspNetCore) {
-      writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
-      writer.addImport(RuntimeTypes.NSMITHY_HTTP);
-      writer.addImport(RuntimeTypes.NSMITHY_SERVER_ASPNETCORE);
+
       writer.addImport(RuntimeTypes.MS_ASPNETCORE_BUILDER);
-      writer.addImport(RuntimeTypes.MS_ASPNETCORE_HTTP);
-      writer.addImport(RuntimeTypes.MS_ASPNETCORE_ROUTING);
-      for (Kind kind : serverKinds) {
-        writer.addImport(ProtocolSupport.runtimeProtocolNamespace(kind));
-      }
+      writer.addImport(RuntimeTypes.NSMITHY_SERVER_ASPNETCORE);
     }
 
     String serviceTypeName = CSharpNaming.typeName(service.getId().getName());
@@ -136,30 +116,43 @@ public final class ServerGenerator implements Runnable {
     writeServerExtensions(ops, contract, aggInterface, serverKinds);
   }
 
+  /** Protocols that emit an ASP.NET Core server, in declared precedence order. */
+  private List<Kind> serverKinds() {
+    return ProtocolSupport.declaredKinds(service).stream()
+        .filter(
+            kind ->
+                kind == Kind.RPC_V2_CBOR
+                    || kind == Kind.SIMPLE_REST_JSON
+                    || kind == Kind.REST_JSON_1
+                    || kind == Kind.GRPC)
+        .collect(Collectors.toList());
+  }
+
   // ---------------- DI registration ----------------
 
   private void writeServiceDefinition(
       List<OperationShape> ops, List<PromptDefinition> prompts, String contract) {
-    writer.write("public sealed class $LDefinition : IServiceDefinition", contract);
+    writer.write(
+        "public sealed class $LDefinition : $T", contract, RuntimeTypes.I_SERVICE_DEFINITION);
     writer.openBlock(
         "{",
         "}",
         () -> {
           writer.write(
-              "public ServiceSchema Schema => $L;",
+              "public $T Schema => $L;",
+              RuntimeTypes.SERVICE_SCHEMA,
               SchemaGenerator.serviceSchemaAccessor(writer, context, service));
           writer.write("");
           writePromptDefinitions(prompts);
           writer.write("");
           writer.write(
-              "public ServiceOperationCatalog CreateOperationCatalog(IServiceProvider services)");
+              "public $T CreateOperationCatalog(IServiceProvider services)",
+              RuntimeTypes.SERVICE_OPERATION_CATALOG);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(services);");
+                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write("return CreateOperationCatalog(");
                 writer.indent();
                 for (int i = 0; i < ops.size(); i++) {
@@ -183,11 +176,12 @@ public final class ServerGenerator implements Runnable {
   }
 
   private void writePromptDefinitions(List<PromptDefinition> prompts) {
-    writer.write("public IReadOnlyList<ServicePromptDefinition> Prompts { get; } =");
+    writer.write(
+        "public IReadOnlyList<$T> Prompts { get; } =", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
     writer.write("[");
     writer.indent();
     for (PromptDefinition prompt : prompts) {
-      writer.write("new ServicePromptDefinition(");
+      writer.write("new $T(", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
       writer.indent();
       writer.write("$L,", CSharpNaming.formatString(prompt.name()));
       writer.write("$L,", CSharpNaming.formatString(prompt.description()));
@@ -199,7 +193,8 @@ public final class ServerGenerator implements Runnable {
       writer.indent();
       for (PromptArgumentDefinition argument : prompt.arguments()) {
         writer.write(
-            "new ServicePromptArgumentDefinition($L, $L, $L),",
+            "new $T($L, $L, $L),",
+            RuntimeTypes.SERVICE_PROMPT_ARGUMENT_DEFINITION,
             CSharpNaming.formatString(argument.name()),
             argument.description() == null
                 ? "null"
@@ -220,12 +215,15 @@ public final class ServerGenerator implements Runnable {
         ops.stream()
             .map(op -> opHandlerName(op) + " " + operationHandlerVariable(op))
             .collect(Collectors.joining(", "));
-    writer.write("private static ServiceOperationCatalog CreateOperationCatalog($L)", parameters);
+    writer.write(
+        "private static $T CreateOperationCatalog($L)",
+        RuntimeTypes.SERVICE_OPERATION_CATALOG,
+        parameters);
     writer.openBlock(
         "{",
         "}",
         () -> {
-          writer.write("return new ServiceOperationCatalog(");
+          writer.write("return new $T(", RuntimeTypes.SERVICE_OPERATION_CATALOG);
           writer.indent();
           writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
           writer.write("[");
@@ -233,12 +231,14 @@ public final class ServerGenerator implements Runnable {
           for (OperationShape op : ops) {
             if (isStreaming(op)) {
               writer.write(
-                  "ServiceOperation.Create($L, $L),",
+                  "$T.Create($L, $L),",
+                  RuntimeTypes.SERVICE_OPERATION,
                   SchemaGenerator.operationSchemaAccessor(writer, context, op),
                   unaryAdapter(op, operationHandlerVariable(op)));
             } else {
               writer.write(
-                  "ServiceOperation.Create($L, $L, $L.Value),",
+                  "$T.Create($L, $L, $L.Value),",
+                  RuntimeTypes.SERVICE_OPERATION,
                   SchemaGenerator.operationSchemaAccessor(writer, context, op),
                   unaryAdapter(op, operationHandlerVariable(op)),
                   operationJsonSchemasClass(op));
@@ -260,34 +260,35 @@ public final class ServerGenerator implements Runnable {
         "}",
         () -> {
           writer.write(
-              "public static IServiceCollection Add$L(this IServiceCollection services)", contract);
+              "public static $T Add$L(this $T services)",
+              RuntimeTypes.I_SERVICE_COLLECTION,
+              contract,
+              RuntimeTypes.I_SERVICE_COLLECTION);
           writer.openBlock(
               "{",
               "}",
               () -> {
+                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(services);");
-                writer.write(
-                    "services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceDefinition,"
-                        + " $LDefinition>());",
+                    "services.TryAddEnumerable($T.Singleton<$T, $LDefinition>());",
+                    RuntimeTypes.SERVICE_DESCRIPTOR,
+                    RuntimeTypes.I_SERVICE_DEFINITION,
                     contract);
                 writer.write("return services;");
               });
 
           writer.write("");
           writer.write(
-              "public static IServiceCollection Add$LHandler<THandler>(this IServiceCollection"
-                  + " services)",
-              contract);
+              "public static $T Add$LHandler<THandler>(this $T services)",
+              RuntimeTypes.I_SERVICE_COLLECTION,
+              contract,
+              RuntimeTypes.I_SERVICE_COLLECTION);
           writer.write("    where THandler : class, $L", aggInterface);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(services);");
+                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write("");
                 if (!serverKinds.isEmpty()) {
                   writer.write("services.AddSmithyServer();");
@@ -336,7 +337,8 @@ public final class ServerGenerator implements Runnable {
           "{",
           "}",
           () -> {
-            writer.write("public static OperationJsonSchemas Value { get; } = new(");
+            writer.write(
+                "public static $T Value { get; } = new(", RuntimeTypes.OPERATION_JSON_SCHEMAS);
             writer.indent();
             writer.write(
                 "$L,",
@@ -366,7 +368,7 @@ public final class ServerGenerator implements Runnable {
 
   private void writeProtocolEnum(String contract, List<Kind> serverKinds) {
     String enumName = protocolEnumName(contract);
-    writer.write("[" + writer.frameworkAttribute("System.FlagsAttribute") + "]");
+    writer.write("[" + writer.attributeName(RuntimeTypes.FLAGS_ATTRIBUTE) + "]");
     writer.write("public enum $L", enumName);
     writer.openBlock(
         "{",
@@ -388,17 +390,18 @@ public final class ServerGenerator implements Runnable {
   private void writeProtocolFields(List<OperationShape> ops, List<Kind> serverKinds) {
     for (Kind kind : serverKinds) {
       writer.write(
-          "private static readonly IServiceProtocol $LServiceProtocol = new $L().ForService($L);",
+          "private static readonly $T $LServiceProtocol = new $L().ForService($L);",
+          RuntimeTypes.I_SERVICE_PROTOCOL,
           mapSuffix(kind),
-          ProtocolSupport.protocolType(kind),
+          writer.typeName(ProtocolSupport.protocolType(kind)),
           SchemaGenerator.serviceSchemaAccessor(writer, context, service));
       for (OperationShape op : ops) {
         if (!canBindOperation(kind, op)) {
           continue;
         }
         writer.write(
-            "private static readonly IServerOperationProtocol<$L, $L> $L ="
-                + " $LServiceProtocol.ForServerOperation($L);",
+            "private static readonly $T<$L, $L> $L = $LServiceProtocol.ForServerOperation($L);",
+            RuntimeTypes.I_SERVER_OPERATION_PROTOCOL,
             SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
             SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
             operationProtocolField(kind, op),
@@ -411,9 +414,10 @@ public final class ServerGenerator implements Runnable {
   private void writeSelectableMapMethod(
       String contract, List<Kind> serverKinds, String protocolEnum) {
     writer.write(
-        "public static IEndpointRouteBuilder Map$L(this IEndpointRouteBuilder endpoints,"
-            + " $L protocols = $L.$L)",
+        "public static $T Map$L(this $T endpoints, $L protocols = $L.$L)",
+        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
         contract,
+        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
         protocolEnum,
         protocolEnum,
         mapSuffix(serverKinds.get(0)));
@@ -421,26 +425,21 @@ public final class ServerGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write(
-              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(endpoints);");
+          writer.write("$T.ThrowIfNull(endpoints);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
           writer.write("if ((protocols & ~$L.All) != 0)", protocolEnum);
           writer.openBlock(
               "{",
               "}",
               () ->
                   writer.write(
-                      "throw new "
-                          + writer.frameworkType("System.ArgumentOutOfRangeException")
-                          + "(nameof(protocols), protocols,"
-                          + " \"Unknown $L value.\");",
+                      "throw new $T(nameof(protocols), protocols, \"Unknown $L value.\");",
+                      RuntimeTypes.ARGUMENT_OUT_OF_RANGE_EXCEPTION,
                       protocolEnum));
           writer.write("");
           writer.write(
-              "var mappedRoutes = new "
-                  + writer.frameworkType("System.Collections.Generic.HashSet")
-                  + "<string>("
-                  + writer.frameworkType("System.StringComparer")
-                  + ".Ordinal);");
+              "var mappedRoutes = new $T<string>($T.Ordinal);",
+              RuntimeTypes.HASH_SET,
+              RuntimeTypes.STRING_COMPARER);
           for (Kind kind : serverKinds) {
             writer.write("if ((protocols & $L.$L) != 0)", protocolEnum, mapSuffix(kind));
             writer.openBlock(
@@ -455,10 +454,9 @@ public final class ServerGenerator implements Runnable {
 
   private void writeRouteConflictHelper(String contract, String protocolEnum) {
     writer.write(
-        "private static void EnsureRouteAvailable("
-            + writer.frameworkType("System.Collections.Generic.HashSet")
-            + "<string>"
-            + " mappedRoutes, string method, string routePattern, $L protocol)",
+        "private static void EnsureRouteAvailable($T<string> mappedRoutes, string method, string"
+            + " routePattern, $L protocol)",
+        RuntimeTypes.HASH_SET,
         protocolEnum);
     writer.openBlock(
         "{",
@@ -471,11 +469,10 @@ public final class ServerGenerator implements Runnable {
               "}",
               () -> {
                 writer.write(
-                    "throw new "
-                        + writer.frameworkType("System.InvalidOperationException")
-                        + "(\"Mapping \" + protocol + \" for"
-                        + " $L would register duplicate route '\" + route + \"'. Map conflicting"
-                        + " protocols on different endpoint route builders, hosts, or ports.\");",
+                    "throw new $T(\"Mapping \" + protocol + \" for $L would register duplicate"
+                        + " route '\" + route + \"'. Map conflicting protocols on different"
+                        + " endpoint route builders, hosts, or ports.\");",
+                    RuntimeTypes.INVALID_OPERATION_EXCEPTION,
                     contract);
               });
         });
@@ -484,12 +481,11 @@ public final class ServerGenerator implements Runnable {
   private void writeProtocolMapHelper(
       Kind kind, List<OperationShape> ops, String contract, String protocolEnum) {
     writer.write(
-        "private static void Map$L$L(IEndpointRouteBuilder endpoints,"
-            + " "
-            + writer.frameworkType("System.Collections.Generic.HashSet")
-            + "<string> mappedRoutes)",
+        "private static void Map$L$L($T endpoints, $T<string> mappedRoutes)",
         contract,
-        mapSuffix(kind));
+        mapSuffix(kind),
+        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
+        RuntimeTypes.HASH_SET);
     writer.openBlock(
         "{",
         "}",
@@ -516,21 +512,20 @@ public final class ServerGenerator implements Runnable {
           protocolEnum,
           mapSuffix(kind));
       writer.openBlock(
-          "endpoints.MapMethods($L, [$L], async (HttpContext httpContext,"
-              + " [Microsoft.AspNetCore.Mvc.FromServices] SmithyServerRuntime runtime, $L handler,"
-              + " "
-              + writer.frameworkType("System.Threading.CancellationToken")
-              + " cancellationToken) => {",
+          writer.format(
+              "endpoints.MapMethods($L, [$L], async ($T httpContext, [$L] $T runtime, $L handler,"
+                  + " $T cancellationToken) => {",
+              CSharpNaming.formatString(routePattern(http)),
+              CSharpNaming.formatString(http.getMethod()),
+              RuntimeTypes.HTTP_CONTEXT,
+              writer.attributeName(RuntimeTypes.FROM_SERVICES_ATTRIBUTE),
+              RuntimeTypes.SMITHY_SERVER_RUNTIME,
+              opInterface,
+              RuntimeTypes.CANCELLATION_TOKEN),
           "});",
-          CSharpNaming.formatString(routePattern(http)),
-          CSharpNaming.formatString(http.getMethod()),
-          opInterface,
           () -> {
-            writer.write(
-                writer.frameworkType("System.ArgumentNullException")
-                    + ".ThrowIfNull(httpContext);");
-            writer.write(
-                writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(handler);");
+            writer.write("$T.ThrowIfNull(httpContext);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+            writer.write("$T.ThrowIfNull(handler);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
             writer.write("");
             writeStaticQueryValidation(http);
             writeDispatch(kind, op);
@@ -554,19 +549,19 @@ public final class ServerGenerator implements Runnable {
         protocolEnum,
         mapSuffix(kind));
     writer.openBlock(
-        "endpoints.MapPost($L, async (HttpContext httpContext,"
-            + " [Microsoft.AspNetCore.Mvc.FromServices] SmithyServerRuntime runtime, $L handler,"
-            + " "
-            + writer.frameworkType("System.Threading.CancellationToken")
-            + " cancellationToken) => {",
+        writer.format(
+            "endpoints.MapPost($L, async ($T httpContext, [$L] $T runtime, $L handler, $T"
+                + " cancellationToken) => {",
+            CSharpNaming.formatString(uri),
+            RuntimeTypes.HTTP_CONTEXT,
+            writer.attributeName(RuntimeTypes.FROM_SERVICES_ATTRIBUTE),
+            RuntimeTypes.SMITHY_SERVER_RUNTIME,
+            opInterface,
+            RuntimeTypes.CANCELLATION_TOKEN),
         "});",
-        CSharpNaming.formatString(uri),
-        opInterface,
         () -> {
-          writer.write(
-              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(httpContext);");
-          writer.write(
-              writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull(handler);");
+          writer.write("$T.ThrowIfNull(httpContext);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+          writer.write("$T.ThrowIfNull(handler);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
           writer.write("");
           writeDispatch(kind, op);
         });
@@ -579,8 +574,9 @@ public final class ServerGenerator implements Runnable {
             || ((kind == Kind.SIMPLE_REST_JSON || kind == Kind.REST_JSON_1)
                 && ShapeSupport.isStreamingBlobShape(model, op.getInputShape()));
     writer.write(
-        "await SmithyAspNetCoreHost.DispatchAsync(runtime, httpContext, $L, $L, $L,"
+        "await $T.DispatchAsync(runtime, httpContext, $L, $L, $L,"
             + " cancellationToken).ConfigureAwait(false);",
+        RuntimeTypes.SMITHY_ASP_NET_CORE_HOST,
         operationProtocolField(kind, op),
         unaryAdapter(op),
         streamRequestBody ? "true" : "false");
@@ -615,7 +611,9 @@ public final class ServerGenerator implements Runnable {
             + param
             + ", ct) => { await "
             + call
-            + ".ConfigureAwait(false); return SmithyUnit.Value; }";
+            + (".ConfigureAwait(false); return "
+                + writer.typeName(RuntimeTypes.SMITHY_UNIT)
+                + ".Value; }");
   }
 
   private String handlerMethod(OperationShape op, String handlerVariable) {
@@ -704,7 +702,8 @@ public final class ServerGenerator implements Runnable {
       String name = equalsIndex >= 0 ? segment.substring(0, equalsIndex) : segment;
       String value = equalsIndex >= 0 ? segment.substring(equalsIndex + 1) : null;
       writer.write(
-          "if (!SmithyAspNetCoreHost.HasExpectedQueryLiteral(httpContext, $L, $L))",
+          "if (!$T.HasExpectedQueryLiteral(httpContext, $L, $L))",
+          RuntimeTypes.SMITHY_ASP_NET_CORE_HOST,
           CSharpNaming.formatString(name),
           value == null ? "null" : CSharpNaming.formatString(value));
       writer.openBlock(
@@ -767,15 +766,15 @@ public final class ServerGenerator implements Runnable {
         hasOutput ? writer.typeName(sp.toSymbol(model.expectShape(op.getOutputShape()))) : null;
     String returnType =
         hasOutput
-            ? writer.frameworkType("System.Threading.Tasks.Task") + "<" + outputType + ">"
-            : writer.frameworkType("System.Threading.Tasks.Task");
+            ? writer.typeName(RuntimeTypes.TASK) + "<" + outputType + ">"
+            : writer.typeName(RuntimeTypes.TASK);
     String params = hasInput ? inputType + " input, " : "";
     return returnType
         + " "
         + name
         + "("
         + params
-        + writer.frameworkType("System.Threading.CancellationToken")
+        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
         + " cancellationToken = default)";
   }
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -75,7 +75,6 @@ public final class ServerGenerator implements Runnable {
     writer.addImport(RuntimeTypes.MS_EXT_DI);
     writer.addImport(RuntimeTypes.MS_EXT_DI_EXTENSIONS);
     if (emitsAspNetCore) {
-
       writer.addImport(RuntimeTypes.MS_ASPNETCORE_BUILDER);
       writer.addImport(RuntimeTypes.NSMITHY_SERVER_ASPNETCORE);
     }
@@ -86,16 +85,7 @@ public final class ServerGenerator implements Runnable {
 
     // Per-operation handler interfaces (streaming surface derived from the model).
     for (OperationShape op : ops) {
-      writer.writeXmlDocs(op, operationParameterDocs(op));
-      writer.write("public interface $L", opHandlerName(op));
-      writer.openBlock(
-          "{",
-          "}",
-          () -> {
-            writer.writeXmlDocs(op, operationParameterDocs(op));
-            writer.write("$L;", serverOperationSignature(sp, op));
-          });
-      writer.write("");
+      writeOperationHandler(sp, op);
     }
 
     String inherits =
@@ -116,6 +106,31 @@ public final class ServerGenerator implements Runnable {
     writeServerExtensions(ops, contract, aggInterface, serverKinds);
   }
 
+  private void writeOperationHandler(SymbolProvider sp, OperationShape op) {
+    writer.writeXmlDocs(op, operationParameterDocs(op));
+    writer.pushState();
+    try {
+      writer.putContext("handler", opHandlerName(op));
+      writer.putContext(
+          "operation",
+          writer.consumer(
+              w -> {
+                w.writeXmlDocs(op, operationParameterDocs(op));
+                w.write("$L;", serverOperationSignature(sp, op));
+              }));
+      writer.write(
+          """
+          public interface ${handler:L}
+          {
+              ${operation:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
+    writer.write("");
+  }
+
   /** Protocols that emit an ASP.NET Core server, in declared precedence order. */
   private List<Kind> serverKinds() {
     return ProtocolSupport.declaredKinds(service).stream()
@@ -132,82 +147,118 @@ public final class ServerGenerator implements Runnable {
 
   private void writeServiceDefinition(
       List<OperationShape> ops, List<PromptDefinition> prompts, String contract) {
-    writer.write(
-        "public sealed class $LDefinition : $T", contract, RuntimeTypes.I_SERVICE_DEFINITION);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write(
-              "public $T Schema => $L;",
-              RuntimeTypes.SERVICE_SCHEMA,
-              SchemaGenerator.serviceSchemaAccessor(writer, context, service));
-          writer.write("");
-          writePromptDefinitions(prompts);
-          writer.write("");
-          writer.write(
-              "public $T CreateOperationCatalog(IServiceProvider services)",
-              RuntimeTypes.SERVICE_OPERATION_CATALOG);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write("return CreateOperationCatalog(");
-                writer.indent();
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("serviceDefinition", RuntimeTypes.I_SERVICE_DEFINITION);
+      writer.putContext("serviceSchema", RuntimeTypes.SERVICE_SCHEMA);
+      writer.putContext("schema", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
+      writer.putContext("catalog", RuntimeTypes.SERVICE_OPERATION_CATALOG);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("prompts", writer.consumer(w -> writePromptDefinitions(prompts)));
+      writer.putContext(
+          "handlers",
+          writer.consumer(
+              w -> {
                 for (int i = 0; i < ops.size(); i++) {
-                  OperationShape op = ops.get(i);
-                  writer.write(
+                  w.write(
                       "services.GetRequiredService<$L>()$L",
-                      opHandlerName(op),
+                      opHandlerName(ops.get(i)),
                       i + 1 == ops.size() ? "" : ",");
                 }
-                writer.dedent();
-                writer.write(");");
-              });
-          writer.write("");
-          writeOperationCatalogFactory(ops);
+              }));
+      writer.putContext(
+          "catalogMembers",
+          writer.consumer(
+              w -> {
+                writeOperationCatalogFactory(ops);
+                if (ops.stream().anyMatch(op -> !isStreaming(op))) {
+                  w.write("");
+                  writeOperationJsonSchemas(ops);
+                }
+              }));
+      writer.write(
+          """
+          public sealed class ${contract:L}Definition : ${serviceDefinition:T}
+          {
+              public ${serviceSchema:T} Schema => ${schema:L};
 
-          if (ops.stream().anyMatch(op -> !isStreaming(op))) {
-            writer.write("");
-            writeOperationJsonSchemas(ops);
+              ${prompts:C|}
+
+              public ${catalog:T} CreateOperationCatalog(IServiceProvider services)
+              {
+                  ${argumentNullException:T}.ThrowIfNull(services);
+                  return CreateOperationCatalog(
+                      ${handlers:C|}
+                  );
+              }
+
+              ${catalogMembers:C|}
           }
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writePromptDefinitions(List<PromptDefinition> prompts) {
-    writer.write(
-        "public IReadOnlyList<$T> Prompts { get; } =", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
-    writer.write("[");
-    writer.indent();
-    for (PromptDefinition prompt : prompts) {
-      writer.write("new $T(", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
-      writer.indent();
-      writer.write("$L,", CSharpNaming.formatString(prompt.name()));
-      writer.write("$L,", CSharpNaming.formatString(prompt.description()));
-      writer.write("$L,", CSharpNaming.formatString(prompt.template()));
+    writer.pushState();
+    try {
+      writer.putContext("promptDefinition", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
+      writer.putContext(
+          "prompts", writer.consumer(w -> prompts.forEach(this::writePromptDefinition)));
       writer.write(
-          "$L,",
-          prompt.preferWhen() == null ? "null" : CSharpNaming.formatString(prompt.preferWhen()));
-      writer.write("[");
-      writer.indent();
-      for (PromptArgumentDefinition argument : prompt.arguments()) {
-        writer.write(
-            "new $T($L, $L, $L),",
-            RuntimeTypes.SERVICE_PROMPT_ARGUMENT_DEFINITION,
-            CSharpNaming.formatString(argument.name()),
-            argument.description() == null
-                ? "null"
-                : CSharpNaming.formatString(argument.description()),
-            argument.required() ? "true" : "false");
-      }
-      writer.dedent();
-      writer.write("]");
-      writer.dedent();
-      writer.write("),");
+          """
+          public IReadOnlyList<${promptDefinition:T}> Prompts { get; } =
+          [
+              ${prompts:C|}
+          ];
+          """);
+    } finally {
+      writer.popState();
     }
-    writer.dedent();
-    writer.write("];");
+  }
+
+  private void writePromptDefinition(PromptDefinition prompt) {
+    writer.pushState();
+    try {
+      writer.putContext("promptDefinition", RuntimeTypes.SERVICE_PROMPT_DEFINITION);
+      writer.putContext("name", CSharpNaming.formatString(prompt.name()));
+      writer.putContext("description", CSharpNaming.formatString(prompt.description()));
+      writer.putContext("template", CSharpNaming.formatString(prompt.template()));
+      writer.putContext(
+          "preferWhen",
+          prompt.preferWhen() == null ? "null" : CSharpNaming.formatString(prompt.preferWhen()));
+      writer.putContext(
+          "arguments",
+          writer.consumer(
+              w -> {
+                for (PromptArgumentDefinition argument : prompt.arguments()) {
+                  w.write(
+                      "new $T($L, $L, $L),",
+                      RuntimeTypes.SERVICE_PROMPT_ARGUMENT_DEFINITION,
+                      CSharpNaming.formatString(argument.name()),
+                      argument.description() == null
+                          ? "null"
+                          : CSharpNaming.formatString(argument.description()),
+                      argument.required() ? "true" : "false");
+                }
+              }));
+      writer.write(
+          """
+          new ${promptDefinition:T}(
+              ${name:L},
+              ${description:L},
+              ${template:L},
+              ${preferWhen:L},
+              [
+                  ${arguments:C|}
+              ]
+          ),
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeOperationCatalogFactory(List<OperationShape> ops) {
@@ -215,115 +266,129 @@ public final class ServerGenerator implements Runnable {
         ops.stream()
             .map(op -> opHandlerName(op) + " " + operationHandlerVariable(op))
             .collect(Collectors.joining(", "));
-    writer.write(
-        "private static $T CreateOperationCatalog($L)",
-        RuntimeTypes.SERVICE_OPERATION_CATALOG,
-        parameters);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("return new $T(", RuntimeTypes.SERVICE_OPERATION_CATALOG);
-          writer.indent();
-          writer.write("$L,", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
-          writer.write("[");
-          writer.indent();
-          for (OperationShape op : ops) {
-            if (isStreaming(op)) {
-              writer.write(
-                  "$T.Create($L, $L),",
-                  RuntimeTypes.SERVICE_OPERATION,
-                  SchemaGenerator.operationSchemaAccessor(writer, context, op),
-                  unaryAdapter(op, operationHandlerVariable(op)));
-            } else {
-              writer.write(
-                  "$T.Create($L, $L, $L.Value),",
-                  RuntimeTypes.SERVICE_OPERATION,
-                  SchemaGenerator.operationSchemaAccessor(writer, context, op),
-                  unaryAdapter(op, operationHandlerVariable(op)),
-                  operationJsonSchemasClass(op));
-            }
+    writer.pushState();
+    try {
+      writer.putContext("parameters", parameters);
+      writer.putContext("catalog", RuntimeTypes.SERVICE_OPERATION_CATALOG);
+      writer.putContext("schema", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
+      writer.putContext("operations", writer.consumer(w -> writeCatalogOperations(ops)));
+      writer.write(
+          """
+          private static ${catalog:T} CreateOperationCatalog(${parameters:L})
+          {
+              return new ${catalog:T}(
+                  ${schema:L},
+                  [
+                      ${operations:C|}
+                  ]
+              );
           }
-          writer.dedent();
-          writer.write("]");
-          writer.dedent();
-          writer.write(");");
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeCatalogOperations(List<OperationShape> ops) {
+    for (OperationShape op : ops) {
+      if (isStreaming(op)) {
+        writer.write(
+            "$T.Create($L, $L),",
+            RuntimeTypes.SERVICE_OPERATION,
+            SchemaGenerator.operationSchemaAccessor(writer, context, op),
+            unaryAdapter(op, operationHandlerVariable(op)));
+      } else {
+        writer.write(
+            "$T.Create($L, $L, $L.Value),",
+            RuntimeTypes.SERVICE_OPERATION,
+            SchemaGenerator.operationSchemaAccessor(writer, context, op),
+            unaryAdapter(op, operationHandlerVariable(op)),
+            operationJsonSchemasClass(op));
+      }
+    }
   }
 
   private void writeServerExtensions(
       List<OperationShape> ops, String contract, String aggInterface, List<Kind> serverKinds) {
-    String protocolEnum = protocolEnumName(contract);
-    writer.write("public static class $LServerExtensions", contract);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write(
-              "public static $T Add$L(this $T services)",
-              RuntimeTypes.I_SERVICE_COLLECTION,
-              contract,
-              RuntimeTypes.I_SERVICE_COLLECTION);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write(
-                    "services.TryAddEnumerable($T.Singleton<$T, $LDefinition>());",
-                    RuntimeTypes.SERVICE_DESCRIPTOR,
-                    RuntimeTypes.I_SERVICE_DEFINITION,
-                    contract);
-                writer.write("return services;");
-              });
-
-          writer.write("");
-          writer.write(
-              "public static $T Add$LHandler<THandler>(this $T services)",
-              RuntimeTypes.I_SERVICE_COLLECTION,
-              contract,
-              RuntimeTypes.I_SERVICE_COLLECTION);
-          writer.write("    where THandler : class, $L", aggInterface);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("$T.ThrowIfNull(services);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write("");
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("handler", aggInterface);
+      writer.putContext("serviceCollection", RuntimeTypes.I_SERVICE_COLLECTION);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("serviceDescriptor", RuntimeTypes.SERVICE_DESCRIPTOR);
+      writer.putContext("serviceDefinition", RuntimeTypes.I_SERVICE_DEFINITION);
+      writer.putContext(
+          "registrations",
+          writer.consumer(
+              w -> {
                 if (!serverKinds.isEmpty()) {
-                  writer.write("services.AddSmithyServer();");
+                  w.write("services.AddSmithyServer();");
                 }
-                writer.write("services.Add$L();", contract);
-                writer.write("services.AddSingleton<THandler>();");
-                writer.write(
-                    "services.AddSingleton<$L>(serviceProvider =>"
-                        + " serviceProvider.GetRequiredService<THandler>());",
-                    aggInterface);
+                w.write(
+                    """
+                    services.Add${contract:L}();
+                    services.AddSingleton<THandler>();
+                    services.AddSingleton<${handler:L}>(serviceProvider =>
+                        serviceProvider.GetRequiredService<THandler>());\
+                    """);
                 for (OperationShape op : ops) {
-                  writer.write(
+                  w.write(
                       "services.AddSingleton<$L>(serviceProvider =>"
                           + " serviceProvider.GetRequiredService<THandler>());",
                       opHandlerName(op));
                 }
-                writer.write("return services;");
-              });
+              }));
+      writer.putContext(
+          "endpointMapping",
+          writer.consumer(
+              w -> {
+                if (!serverKinds.isEmpty()) {
+                  w.write("");
+                  writeEndpointMapping(ops, contract, serverKinds);
+                }
+              }));
+      writer.write(
+          """
+          public static class ${contract:L}ServerExtensions
+          {
+              public static ${serviceCollection:T} Add${contract:L}(this ${serviceCollection:T} services)
+              {
+                  ${argumentNullException:T}.ThrowIfNull(services);
+                  services.TryAddEnumerable(
+                      ${serviceDescriptor:T}.Singleton<${serviceDefinition:T}, ${contract:L}Definition>());
+                  return services;
+              }
 
-          if (serverKinds.isEmpty()) {
-            return;
+              public static ${serviceCollection:T} Add${contract:L}Handler<THandler>(
+                  this ${serviceCollection:T} services)
+                  where THandler : class, ${handler:L}
+              {
+                  ${argumentNullException:T}.ThrowIfNull(services);
+
+                  ${registrations:C|}
+                  return services;
+              }
+              ${endpointMapping:C|}
           }
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
 
-          writer.write("");
-          writeProtocolFields(ops, serverKinds);
-          writer.write("");
-          writeSelectableMapMethod(contract, serverKinds, protocolEnum);
-          writer.write("");
-          writeRouteConflictHelper(contract, protocolEnum);
-
-          for (Kind kind : serverKinds) {
-            writer.write("");
-            writeProtocolMapHelper(kind, ops, contract, protocolEnum);
-          }
-        });
+  private void writeEndpointMapping(
+      List<OperationShape> ops, String contract, List<Kind> serverKinds) {
+    String protocolEnum = protocolEnumName(contract);
+    writeProtocolFields(ops, serverKinds);
+    writer.write("");
+    writeSelectableMapMethod(contract, serverKinds, protocolEnum);
+    writer.write("");
+    writeRouteConflictHelper(contract, protocolEnum);
+    for (Kind kind : serverKinds) {
+      writer.write("");
+      writeProtocolMapHelper(kind, ops, contract, protocolEnum);
+    }
   }
 
   private void writeOperationJsonSchemas(List<OperationShape> ops) {
@@ -331,27 +396,32 @@ public final class ServerGenerator implements Runnable {
       if (isStreaming(op)) {
         continue;
       }
-
-      writer.write("private static class $L", operationJsonSchemasClass(op));
-      writer.openBlock(
-          "{",
-          "}",
-          () -> {
-            writer.write(
-                "public static $T Value { get; } = new(", RuntimeTypes.OPERATION_JSON_SCHEMAS);
-            writer.indent();
-            writer.write(
-                "$L,",
-                CSharpNaming.formatString(
-                    JsonSchemaGenerator.generate(context.model(), op.getInputShape())));
-            writer.write(
-                "$L",
-                CSharpNaming.formatString(
-                    JsonSchemaGenerator.generate(context.model(), op.getOutputShape())));
-            writer.dedent();
-            writer.write(");");
-          });
-      writer.write("");
+      writer.pushState();
+      try {
+        writer.putContext("schemaClass", operationJsonSchemasClass(op));
+        writer.putContext("operationJsonSchemas", RuntimeTypes.OPERATION_JSON_SCHEMAS);
+        writer.putContext(
+            "inputSchema",
+            CSharpNaming.formatString(
+                JsonSchemaGenerator.generate(context.model(), op.getInputShape())));
+        writer.putContext(
+            "outputSchema",
+            CSharpNaming.formatString(
+                JsonSchemaGenerator.generate(context.model(), op.getOutputShape())));
+        writer.write(
+            """
+            private static class ${schemaClass:L}
+            {
+                public static ${operationJsonSchemas:T} Value { get; } = new(
+                    ${inputSchema:L},
+                    ${outputSchema:L}
+                );
+            }
+            """);
+        writer.write("");
+      } finally {
+        writer.popState();
+      }
     }
   }
 
@@ -367,47 +437,69 @@ public final class ServerGenerator implements Runnable {
   // ---------------- endpoint mapping ----------------
 
   private void writeProtocolEnum(String contract, List<Kind> serverKinds) {
-    String enumName = protocolEnumName(contract);
-    writer.write("[" + writer.attributeName(RuntimeTypes.FLAGS_ATTRIBUTE) + "]");
-    writer.write("public enum $L", enumName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("None = 0,");
-          for (int i = 0; i < serverKinds.size(); i++) {
-            Kind kind = serverKinds.get(i);
-            writer.write("$L = $L,", mapSuffix(kind), 1 << i);
+    writer.pushState();
+    try {
+      writer.putContext("flags", writer.attributeName(RuntimeTypes.FLAGS_ATTRIBUTE));
+      writer.putContext("enumName", protocolEnumName(contract));
+      writer.putContext(
+          "allProtocols",
+          serverKinds.stream().map(ServerGenerator::mapSuffix).collect(Collectors.joining(" | ")));
+      writer.putContext(
+          "protocols",
+          writer.consumer(
+              w -> {
+                for (int i = 0; i < serverKinds.size(); i++) {
+                  w.write("$L = $L,", mapSuffix(serverKinds.get(i)), 1 << i);
+                }
+              }));
+      writer.write(
+          """
+          [${flags:L}]
+          public enum ${enumName:L}
+          {
+              None = 0,
+              ${protocols:C|}
+              All = ${allProtocols:L},
           }
-          writer.write(
-              "All = $L,",
-              serverKinds.stream()
-                  .map(ServerGenerator::mapSuffix)
-                  .collect(Collectors.joining(" | ")));
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeProtocolFields(List<OperationShape> ops, List<Kind> serverKinds) {
-    for (Kind kind : serverKinds) {
-      writer.write(
-          "private static readonly $T $LServiceProtocol = new $L().ForService($L);",
-          RuntimeTypes.I_SERVICE_PROTOCOL,
-          mapSuffix(kind),
-          writer.typeName(ProtocolSupport.protocolType(kind)),
-          SchemaGenerator.serviceSchemaAccessor(writer, context, service));
-      for (OperationShape op : ops) {
-        if (!canBindOperation(kind, op)) {
-          continue;
-        }
+    writer.pushState();
+    try {
+      writer.putContext("serviceProtocol", RuntimeTypes.I_SERVICE_PROTOCOL);
+      writer.putContext("operationProtocol", RuntimeTypes.I_SERVER_OPERATION_PROTOCOL);
+      writer.putContext(
+          "serviceSchema", SchemaGenerator.serviceSchemaAccessor(writer, context, service));
+      for (Kind kind : serverKinds) {
+        writer.putContext("protocol", mapSuffix(kind));
+        writer.putContext("protocolType", ProtocolSupport.protocolType(kind));
         writer.write(
-            "private static readonly $T<$L, $L> $L = $LServiceProtocol.ForServerOperation($L);",
-            RuntimeTypes.I_SERVER_OPERATION_PROTOCOL,
-            SchemaGenerator.operationShapeType(writer, context, op.getInputShape()),
-            SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()),
-            operationProtocolField(kind, op),
-            mapSuffix(kind),
-            SchemaGenerator.operationSchemaAccessor(writer, context, op));
+            "private static readonly ${serviceProtocol:T} ${protocol:L}ServiceProtocol = new"
+                + " ${protocolType:T}().ForService(${serviceSchema:L});");
+        for (OperationShape op : ops) {
+          if (!canBindOperation(kind, op)) {
+            continue;
+          }
+          writer.putContext(
+              "inputType", SchemaGenerator.operationShapeType(writer, context, op.getInputShape()));
+          writer.putContext(
+              "outputType",
+              SchemaGenerator.operationShapeType(writer, context, op.getOutputShape()));
+          writer.putContext("field", operationProtocolField(kind, op));
+          writer.putContext(
+              "operationSchema", SchemaGenerator.operationSchemaAccessor(writer, context, op));
+          writer.write(
+              "private static readonly ${operationProtocol:T}<${inputType:L}, ${outputType:L}>"
+                  + " ${field:L} ="
+                  + " ${protocol:L}ServiceProtocol.ForServerOperation(${operationSchema:L});");
+        }
       }
+    } finally {
+      writer.popState();
     }
   }
 
@@ -429,12 +521,15 @@ public final class ServerGenerator implements Runnable {
           writer.consumer(w -> writeSelectedProtocolMappings(contract, serverKinds, protocolEnum)));
       writer.write(
           """
-          public static ${endpointRouteBuilder:T} Map${contract:L}(this ${endpointRouteBuilder:T} endpoints, ${protocolEnum:L} protocols = ${protocolEnum:L}.${defaultProtocol:L})
+          public static ${endpointRouteBuilder:T} Map${contract:L}(
+              this ${endpointRouteBuilder:T} endpoints,
+              ${protocolEnum:L} protocols = ${protocolEnum:L}.${defaultProtocol:L})
           {
               ${argumentNullException:T}.ThrowIfNull(endpoints);
               if ((protocols & ~${protocolEnum:L}.All) != 0)
               {
-                  throw new ${argumentOutOfRangeException:T}(nameof(protocols), protocols, "Unknown ${protocolEnum:L} value.");
+                  throw new ${argumentOutOfRangeException:T}(
+                      nameof(protocols), protocols, "Unknown ${protocolEnum:L} value.");
               }
 
               var mappedRoutes = new ${hashSet:T}<string>(${stringComparer:T}.Ordinal);
@@ -478,12 +573,18 @@ public final class ServerGenerator implements Runnable {
       writer.putContext("invalidOperationException", RuntimeTypes.INVALID_OPERATION_EXCEPTION);
       writer.write(
           """
-          private static void EnsureRouteAvailable(${hashSet:T}<string> mappedRoutes, string method, string routePattern, ${protocolEnum:L} protocol)
+          private static void EnsureRouteAvailable(
+              ${hashSet:T}<string> mappedRoutes,
+              string method,
+              string routePattern,
+              ${protocolEnum:L} protocol)
           {
               var route = method + " " + routePattern;
               if (!mappedRoutes.Add(route))
               {
-                  throw new ${invalidOperationException:T}("Mapping " + protocol + " for ${contract:L} would register duplicate route '" + route + "'. Map conflicting protocols on different endpoint route builders, hosts, or ports.");
+                  throw new ${invalidOperationException:T}(
+                      "Mapping " + protocol + " for ${contract:L} would register duplicate route '" + route
+                      + "'. Map conflicting protocols on different endpoint route builders, hosts, or ports.");
               }
           }
           """);
@@ -494,91 +595,107 @@ public final class ServerGenerator implements Runnable {
 
   private void writeProtocolMapHelper(
       Kind kind, List<OperationShape> ops, String contract, String protocolEnum) {
-    writer.write(
-        "private static void Map$L$L($T endpoints, $T<string> mappedRoutes)",
-        contract,
-        mapSuffix(kind),
-        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
-        RuntimeTypes.HASH_SET);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          for (OperationShape op : ops) {
-            if (!canBindOperation(kind, op)) {
-              continue;
-            }
-            writeOperationMap(kind, op, protocolEnum);
-            writer.write("");
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("protocol", mapSuffix(kind));
+      writer.putContext("endpointRouteBuilder", RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER);
+      writer.putContext("hashSet", RuntimeTypes.HASH_SET);
+      writer.putContext(
+          "operations",
+          writer.consumer(
+              w -> {
+                for (OperationShape op : ops) {
+                  if (canBindOperation(kind, op)) {
+                    writeOperationMap(kind, op, protocolEnum);
+                    w.write("");
+                  }
+                }
+              }));
+      writer.write(
+          """
+          private static void Map${contract:L}${protocol:L}(
+              ${endpointRouteBuilder:T} endpoints, ${hashSet:T}<string> mappedRoutes)
+          {
+              ${operations:C|}
           }
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeOperationMap(Kind kind, OperationShape op, String protocolEnum) {
-    String opInterface = opHandlerName(op);
-    boolean rest = kind == Kind.SIMPLE_REST_JSON || kind == Kind.REST_JSON_1;
-    if (rest) {
-      HttpTrait http = op.expectTrait(HttpTrait.class);
-      writer.write(
-          "EnsureRouteAvailable(mappedRoutes, $L, $L, $L.$L);",
-          CSharpNaming.formatString(http.getMethod()),
-          CSharpNaming.formatString(routePattern(http)),
-          protocolEnum,
-          mapSuffix(kind));
-      writer.openBlock(
-          writer.format(
-              "endpoints.MapMethods($L, [$L], async ($T httpContext, [$L] $T runtime, $L handler,"
-                  + " $T cancellationToken) => {",
-              CSharpNaming.formatString(routePattern(http)),
-              CSharpNaming.formatString(http.getMethod()),
-              RuntimeTypes.HTTP_CONTEXT,
-              writer.attributeName(RuntimeTypes.FROM_SERVICES_ATTRIBUTE),
-              RuntimeTypes.SMITHY_SERVER_RUNTIME,
-              opInterface,
-              RuntimeTypes.CANCELLATION_TOKEN),
-          "});",
-          () -> {
-            writer.write("$T.ThrowIfNull(httpContext);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-            writer.write("$T.ThrowIfNull(handler);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-            writer.write("");
-            writeStaticQueryValidation(http);
-            writeDispatch(kind, op);
-          });
-      return;
-    }
+    writer.pushState();
+    try {
+      writer.putContext("handler", opHandlerName(op));
+      writer.putContext("protocolEnum", protocolEnum);
+      writer.putContext("protocol", mapSuffix(kind));
+      writer.putContext("httpContext", RuntimeTypes.HTTP_CONTEXT);
+      writer.putContext("fromServices", writer.attributeName(RuntimeTypes.FROM_SERVICES_ATTRIBUTE));
+      writer.putContext("runtime", RuntimeTypes.SMITHY_SERVER_RUNTIME);
+      writer.putContext("cancellationToken", RuntimeTypes.CANCELLATION_TOKEN);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      boolean rest = kind == Kind.SIMPLE_REST_JSON || kind == Kind.REST_JSON_1;
+      if (rest) {
+        HttpTrait http = op.expectTrait(HttpTrait.class);
+        writer.putContext("method", CSharpNaming.formatString(http.getMethod()));
+        writer.putContext("route", CSharpNaming.formatString(routePattern(http)));
+        writer.putContext(
+            "dispatch",
+            writer.consumer(
+                w -> {
+                  writeStaticQueryValidation(http);
+                  writeDispatch(kind, op);
+                }));
+        writer.write(
+            """
+            EnsureRouteAvailable(mappedRoutes, ${method:L}, ${route:L}, ${protocolEnum:L}.${protocol:L});
+            endpoints.MapMethods(${route:L}, [${method:L}], async (
+                ${httpContext:T} httpContext,
+                [${fromServices:L}] ${runtime:T} runtime,
+                ${handler:L} handler,
+                ${cancellationToken:T} cancellationToken) =>
+            {
+                ${argumentNullException:T}.ThrowIfNull(httpContext);
+                ${argumentNullException:T}.ThrowIfNull(handler);
 
-    // rpcv2Cbor and gRPC use structured POST routes derived from the shape ids.
-    String uri =
-        kind == Kind.GRPC
-            ? "/"
-                + service.getId().getNamespace()
-                + "."
-                + service.getId().getName()
-                + "/"
-                + op.getId().getName()
-            : "/service/" + service.getId().getName() + "/operation/" + op.getId().getName();
-    writer.write(
-        "EnsureRouteAvailable(mappedRoutes, \"POST\", $L, $L.$L);",
-        CSharpNaming.formatString(uri),
-        protocolEnum,
-        mapSuffix(kind));
-    writer.openBlock(
-        writer.format(
-            "endpoints.MapPost($L, async ($T httpContext, [$L] $T runtime, $L handler, $T"
-                + " cancellationToken) => {",
-            CSharpNaming.formatString(uri),
-            RuntimeTypes.HTTP_CONTEXT,
-            writer.attributeName(RuntimeTypes.FROM_SERVICES_ATTRIBUTE),
-            RuntimeTypes.SMITHY_SERVER_RUNTIME,
-            opInterface,
-            RuntimeTypes.CANCELLATION_TOKEN),
-        "});",
-        () -> {
-          writer.write("$T.ThrowIfNull(httpContext);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-          writer.write("$T.ThrowIfNull(handler);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-          writer.write("");
-          writeDispatch(kind, op);
-        });
+                ${dispatch:C|}
+            });
+            """);
+        return;
+      }
+
+      // rpcv2Cbor and gRPC use structured POST routes derived from the shape ids.
+      String uri =
+          kind == Kind.GRPC
+              ? "/"
+                  + service.getId().getNamespace()
+                  + "."
+                  + service.getId().getName()
+                  + "/"
+                  + op.getId().getName()
+              : "/service/" + service.getId().getName() + "/operation/" + op.getId().getName();
+      writer.putContext("route", CSharpNaming.formatString(uri));
+      writer.putContext("dispatch", writer.consumer(w -> writeDispatch(kind, op)));
+      writer.write(
+          """
+          EnsureRouteAvailable(mappedRoutes, "POST", ${route:L}, ${protocolEnum:L}.${protocol:L});
+          endpoints.MapPost(${route:L}, async (
+              ${httpContext:T} httpContext,
+              [${fromServices:L}] ${runtime:T} runtime,
+              ${handler:L} handler,
+              ${cancellationToken:T} cancellationToken) =>
+          {
+              ${argumentNullException:T}.ThrowIfNull(httpContext);
+              ${argumentNullException:T}.ThrowIfNull(handler);
+
+              ${dispatch:C|}
+          });
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeDispatch(Kind kind, OperationShape op) {
@@ -598,12 +715,9 @@ public final class ServerGenerator implements Runnable {
 
   // ---------------- handler adapters ----------------
 
-  // Handler methods return Task<TOutput> / IAsyncEnumerable<TEvent> — the delegate shape the
-  // runtime
-  // expects — so the adapter is a bare method group whenever arity and return type line up. A
-  // lambda
-  // is emitted only for the mismatches: a unit input (the handler method takes no input) or a unit
-  // output (the handler returns Task, but the runtime expects Task<SmithyUnit>).
+  // Use a method group when the handler's arity and return type match the runtime delegate.
+  // Adapt unit input (no input parameter) and unit output (Task instead of Task<SmithyUnit>)
+  // with a lambda.
 
   private String unaryAdapter(OperationShape op) {
     return unaryAdapter(op, "handler");
@@ -620,14 +734,12 @@ public final class ServerGenerator implements Runnable {
     String call = hasInput ? method + "(input, ct)" : method + "(ct)";
     String param = hasInput ? "input" : "_";
     return hasOutput
-        ? "(" + param + ", ct) => " + call
-        : "async ("
-            + param
-            + ", ct) => { await "
-            + call
-            + (".ConfigureAwait(false); return "
-                + writer.typeName(RuntimeTypes.SMITHY_UNIT)
-                + ".Value; }");
+        ? writer.format("($L, ct) => $L", param, call)
+        : writer.format(
+            "async ($L, ct) => { await $L.ConfigureAwait(false); return $T.Value; }",
+            param,
+            call,
+            RuntimeTypes.SMITHY_UNIT);
   }
 
   private String handlerMethod(OperationShape op, String handlerVariable) {
@@ -715,18 +827,22 @@ public final class ServerGenerator implements Runnable {
       int equalsIndex = segment.indexOf('=');
       String name = equalsIndex >= 0 ? segment.substring(0, equalsIndex) : segment;
       String value = equalsIndex >= 0 ? segment.substring(equalsIndex + 1) : null;
-      writer.write(
-          "if (!$T.HasExpectedQueryLiteral(httpContext, $L, $L))",
-          RuntimeTypes.SMITHY_ASP_NET_CORE_HOST,
-          CSharpNaming.formatString(name),
-          value == null ? "null" : CSharpNaming.formatString(value));
-      writer.openBlock(
-          "{",
-          "}",
-          () -> {
-            writer.write("httpContext.Response.StatusCode = StatusCodes.Status404NotFound;");
-            writer.write("return;");
-          });
+      writer.pushState();
+      try {
+        writer.putContext("host", RuntimeTypes.SMITHY_ASP_NET_CORE_HOST);
+        writer.putContext("name", CSharpNaming.formatString(name));
+        writer.putContext("value", value == null ? "null" : CSharpNaming.formatString(value));
+        writer.write(
+            """
+            if (!${host:T}.HasExpectedQueryLiteral(httpContext, ${name:L}, ${value:L}))
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }\
+            """);
+      } finally {
+        writer.popState();
+      }
     }
 
     writer.write("");
@@ -783,13 +899,12 @@ public final class ServerGenerator implements Runnable {
             ? writer.typeName(RuntimeTypes.TASK) + "<" + outputType + ">"
             : writer.typeName(RuntimeTypes.TASK);
     String params = hasInput ? inputType + " input, " : "";
-    return returnType
-        + " "
-        + name
-        + "("
-        + params
-        + writer.typeName(RuntimeTypes.CANCELLATION_TOKEN)
-        + " cancellationToken = default)";
+    return writer.format(
+        "$L $L($L$T cancellationToken = default)",
+        returnType,
+        name,
+        params,
+        RuntimeTypes.CANCELLATION_TOKEN);
   }
 
   private Map<String, String> operationParameterDocs(OperationShape op) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGenerator.java
@@ -413,69 +413,83 @@ public final class ServerGenerator implements Runnable {
 
   private void writeSelectableMapMethod(
       String contract, List<Kind> serverKinds, String protocolEnum) {
-    writer.write(
-        "public static $T Map$L(this $T endpoints, $L protocols = $L.$L)",
-        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
-        contract,
-        RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER,
-        protocolEnum,
-        protocolEnum,
-        mapSuffix(serverKinds.get(0)));
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("$T.ThrowIfNull(endpoints);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-          writer.write("if ((protocols & ~$L.All) != 0)", protocolEnum);
-          writer.openBlock(
-              "{",
-              "}",
-              () ->
-                  writer.write(
-                      "throw new $T(nameof(protocols), protocols, \"Unknown $L value.\");",
-                      RuntimeTypes.ARGUMENT_OUT_OF_RANGE_EXCEPTION,
-                      protocolEnum));
-          writer.write("");
-          writer.write(
-              "var mappedRoutes = new $T<string>($T.Ordinal);",
-              RuntimeTypes.HASH_SET,
-              RuntimeTypes.STRING_COMPARER);
-          for (Kind kind : serverKinds) {
-            writer.write("if ((protocols & $L.$L) != 0)", protocolEnum, mapSuffix(kind));
-            writer.openBlock(
-                "{",
-                "}",
-                () -> writer.write("Map$L$L(endpoints, mappedRoutes);", contract, mapSuffix(kind)));
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("protocolEnum", protocolEnum);
+      writer.putContext("defaultProtocol", mapSuffix(serverKinds.get(0)));
+      writer.putContext("endpointRouteBuilder", RuntimeTypes.I_ENDPOINT_ROUTE_BUILDER);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext(
+          "argumentOutOfRangeException", RuntimeTypes.ARGUMENT_OUT_OF_RANGE_EXCEPTION);
+      writer.putContext("hashSet", RuntimeTypes.HASH_SET);
+      writer.putContext("stringComparer", RuntimeTypes.STRING_COMPARER);
+      writer.putContext(
+          "protocolMappings",
+          writer.consumer(w -> writeSelectedProtocolMappings(contract, serverKinds, protocolEnum)));
+      writer.write(
+          """
+          public static ${endpointRouteBuilder:T} Map${contract:L}(this ${endpointRouteBuilder:T} endpoints, ${protocolEnum:L} protocols = ${protocolEnum:L}.${defaultProtocol:L})
+          {
+              ${argumentNullException:T}.ThrowIfNull(endpoints);
+              if ((protocols & ~${protocolEnum:L}.All) != 0)
+              {
+                  throw new ${argumentOutOfRangeException:T}(nameof(protocols), protocols, "Unknown ${protocolEnum:L} value.");
+              }
+
+              var mappedRoutes = new ${hashSet:T}<string>(${stringComparer:T}.Ordinal);
+              ${protocolMappings:C|}
+
+              return endpoints;
           }
-          writer.write("");
-          writer.write("return endpoints;");
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeSelectedProtocolMappings(
+      String contract, List<Kind> serverKinds, String protocolEnum) {
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("protocolEnum", protocolEnum);
+      for (Kind kind : serverKinds) {
+        writer.putContext("protocol", mapSuffix(kind));
+        writer.write(
+            """
+            if ((protocols & ${protocolEnum:L}.${protocol:L}) != 0)
+            {
+                Map${contract:L}${protocol:L}(endpoints, mappedRoutes);
+            }
+            """);
+      }
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeRouteConflictHelper(String contract, String protocolEnum) {
-    writer.write(
-        "private static void EnsureRouteAvailable($T<string> mappedRoutes, string method, string"
-            + " routePattern, $L protocol)",
-        RuntimeTypes.HASH_SET,
-        protocolEnum);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("var route = method + \" \" + routePattern;");
-          writer.write("if (!mappedRoutes.Add(route))");
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write(
-                    "throw new $T(\"Mapping \" + protocol + \" for $L would register duplicate"
-                        + " route '\" + route + \"'. Map conflicting protocols on different"
-                        + " endpoint route builders, hosts, or ports.\");",
-                    RuntimeTypes.INVALID_OPERATION_EXCEPTION,
-                    contract);
-              });
-        });
+    writer.pushState();
+    try {
+      writer.putContext("contract", contract);
+      writer.putContext("protocolEnum", protocolEnum);
+      writer.putContext("hashSet", RuntimeTypes.HASH_SET);
+      writer.putContext("invalidOperationException", RuntimeTypes.INVALID_OPERATION_EXCEPTION);
+      writer.write(
+          """
+          private static void EnsureRouteAvailable(${hashSet:T}<string> mappedRoutes, string method, string routePattern, ${protocolEnum:L} protocol)
+          {
+              var route = method + " " + routePattern;
+              if (!mappedRoutes.Add(route))
+              {
+                  throw new ${invalidOperationException:T}("Mapping " + protocol + " for ${contract:L} would register duplicate route '" + route + "'. Map conflicting protocols on different endpoint route builders, hosts, or ports.");
+              }
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 
   private void writeProtocolMapHelper(

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
@@ -46,7 +46,7 @@ public final class ServiceSchemaGenerator implements Runnable {
               "Schemas.Service($L, $S, $L);",
               SchemaGenerator.shapeIdExpr(service.getId()),
               service.getVersion(),
-              SchemaGenerator.traitsExpr(service.getAllTraits().values()));
+              SchemaGenerator.traitsExpr(writer, service.getAllTraits().values()));
           writer.dedent();
         });
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
@@ -31,8 +31,6 @@ public final class ServiceSchemaGenerator implements Runnable {
 
   @Override
   public void run() {
-    writer.addImport(RuntimeTypes.NSMITHY_CORE);
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
 
     String typeName = CSharpNaming.typeName(service.getId().getName());
     writer.write("public static partial class $LSchema", typeName);
@@ -40,11 +38,12 @@ public final class ServiceSchemaGenerator implements Runnable {
         "{",
         "}",
         () -> {
-          writer.write("public static ServiceSchema Schema { get; } =");
+          writer.write("public static $T Schema { get; } =", RuntimeTypes.SERVICE_SCHEMA);
           writer.indent();
           writer.write(
-              "Schemas.Service($L, $S, $L);",
-              SchemaGenerator.shapeIdExpr(service.getId()),
+              "$T.Service($L, $S, $L);",
+              RuntimeTypes.SCHEMAS,
+              SchemaGenerator.shapeIdExpr(writer, service.getId()),
               service.getVersion(),
               SchemaGenerator.traitsExpr(writer, service.getAllTraits().values()));
           writer.dedent();

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServiceSchemaGenerator.java
@@ -31,22 +31,25 @@ public final class ServiceSchemaGenerator implements Runnable {
 
   @Override
   public void run() {
-
-    String typeName = CSharpNaming.typeName(service.getId().getName());
-    writer.write("public static partial class $LSchema", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static $T Schema { get; } =", RuntimeTypes.SERVICE_SCHEMA);
-          writer.indent();
-          writer.write(
-              "$T.Service($L, $S, $L);",
-              RuntimeTypes.SCHEMAS,
-              SchemaGenerator.shapeIdExpr(writer, service.getId()),
-              service.getVersion(),
-              SchemaGenerator.traitsExpr(writer, service.getAllTraits().values()));
-          writer.dedent();
-        });
+    writer.pushState();
+    try {
+      writer.putContext("typeName", CSharpNaming.typeName(service.getId().getName()));
+      writer.putContext("serviceSchema", RuntimeTypes.SERVICE_SCHEMA);
+      writer.putContext("schemas", RuntimeTypes.SCHEMAS);
+      writer.putContext("shapeId", SchemaGenerator.shapeIdExpr(writer, service.getId()));
+      writer.putContext("version", service.getVersion());
+      writer.putContext(
+          "traits", SchemaGenerator.traitsExpr(writer, service.getAllTraits().values()));
+      writer.write(
+          """
+          public static partial class ${typeName:L}Schema
+          {
+              public static ${serviceSchema:T} Schema { get; } =
+                  ${schemas:T}.Service(${shapeId:L}, ${version:S}, ${traits:L});
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
@@ -26,12 +26,13 @@ public final class StringEnumGenerator implements Runnable {
 
   @Override
   public void run() {
-    writer.addImport(RuntimeTypes.NSMITHY_CORE_SERDE);
+
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     writer.writeXmlDocs(shape);
     writer.write(
-        "public readonly partial record struct $L(string Value) : IStringEnumValue<$L>",
+        "public readonly partial record struct $L(string Value) : $T<$L>",
         typeName,
+        RuntimeTypes.I_STRING_ENUM_VALUE,
         typeName);
     writer.openBlock(
         "{",

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StringEnumGenerator.java
@@ -26,39 +26,52 @@ public final class StringEnumGenerator implements Runnable {
 
   @Override
   public void run() {
-
     String typeName = CSharpNaming.typeName(shape.getId().getName());
-    writer.writeXmlDocs(shape);
-    writer.write(
-        "public readonly partial record struct $L(string Value) : $T<$L>",
-        typeName,
-        RuntimeTypes.I_STRING_ENUM_VALUE,
-        typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("public static $L FromValue(string value)", typeName);
-          writer.openBlock("{", "}", () -> writer.write("return new $L(value);", typeName));
-          writer.write("");
-          for (MemberShape m : ShapeSupport.sortedMembers(shape)) {
-            String prop = CSharpNaming.propertyName(m.getMemberName());
-            String value =
-                m.getTrait(EnumValueTrait.class)
-                    .flatMap(t -> t.getStringValue())
-                    .orElse(m.getMemberName());
-            writer.writeXmlDocs(m);
-            writer.write(
-                "public static $L $L { get; } = new($L);",
-                typeName,
-                prop,
-                CSharpNaming.formatString(value));
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("stringEnumValue", RuntimeTypes.I_STRING_ENUM_VALUE);
+      writer.putContext("variants", writer.consumer(w -> writeVariants(typeName)));
+      writer.writeXmlDocs(shape);
+      writer.write(
+          """
+          public readonly partial record struct ${typeName:L}(string Value)
+              : ${stringEnumValue:T}<${typeName:L}>
+          {
+              public static ${typeName:L} FromValue(string value)
+              {
+                  return new ${typeName:L}(value);
+              }
+
+              ${variants:C|}
+
+              public override string ToString()
+              {
+                  return Value;
+              }
           }
-          writer.write("");
-          writer.write("public override string ToString()");
-          writer.openBlock("{", "}", () -> writer.write("return Value;"));
-        });
+          """);
+    } finally {
+      writer.popState();
+    }
     writer.write("");
     SchemaGenerator.writeSimpleSchema(writer, shape);
+  }
+
+  private void writeVariants(String typeName) {
+    for (MemberShape member : ShapeSupport.sortedMembers(shape)) {
+      String property = CSharpNaming.propertyName(member.getMemberName());
+      String value =
+          member
+              .getTrait(EnumValueTrait.class)
+              .flatMap(EnumValueTrait::getStringValue)
+              .orElse(member.getMemberName());
+      writer.writeXmlDocs(member);
+      writer.write(
+          "public static $L $L { get; } = new($L);",
+          typeName,
+          property,
+          CSharpNaming.formatString(value));
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
@@ -27,7 +27,6 @@ public final class StructureGenerator implements Runnable {
 
   public StructureGenerator(GenerationContext c, CSharpWriter w, StructureShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
@@ -27,6 +27,7 @@ public final class StructureGenerator implements Runnable {
 
   public StructureGenerator(GenerationContext c, CSharpWriter w, StructureShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/StructureGenerator.java
@@ -33,6 +33,7 @@ public final class StructureGenerator implements Runnable {
 
   @Override
   public void run() {
+    writer.reserveMemberNames(shape);
     SymbolProvider sp = context.symbolProvider();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     List<MemberShape> members = List.copyOf(shape.members());
@@ -71,7 +72,7 @@ public final class StructureGenerator implements Runnable {
     StringBuilder sig = new StringBuilder("(");
     for (int i = 0; i < ctorMembers.size(); i++) {
       MemberShape member = ctorMembers.get(i);
-      sig.append(ShapeSupport.parameterTypeExpr(context.model(), sp, member))
+      sig.append(ShapeSupport.parameterTypeExpr(writer, context.model(), sp, member))
           .append(' ')
           .append(CSharpNaming.propertyName(member.getMemberName()));
       if (ShapeSupport.isOptionalParameter(member)) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
@@ -31,6 +31,7 @@ public final class UnionGenerator implements Runnable {
 
   @Override
   public void run() {
+    writer.reserveMemberNames(shape);
     SymbolProvider sp = context.symbolProvider();
     Model model = context.model();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
@@ -45,7 +46,7 @@ public final class UnionGenerator implements Runnable {
           writer.write("");
           for (MemberShape m : members) {
             String variantName = CSharpNaming.typeName(m.getMemberName());
-            String valueType = ShapeSupport.memberTypeExpr(model, sp, m, false);
+            String valueType = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
             writer.write("public sealed partial record class $L : $L", variantName, typeName);
             writer.openBlock(
                 "{",
@@ -101,7 +102,7 @@ public final class UnionGenerator implements Runnable {
           StringBuilder header = new StringBuilder("public T Match<T>(");
           for (MemberShape m : members) {
             String pn = CSharpNaming.parameterName(m.getMemberName());
-            String vt = ShapeSupport.memberTypeExpr(model, sp, m, false);
+            String vt = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
             header.append("System.Func<").append(vt).append(", T> ").append(pn).append(", ");
           }
           header.append("System.Func<string, Document, T> unknown)");

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
@@ -25,7 +25,6 @@ public final class UnionGenerator implements Runnable {
 
   public UnionGenerator(GenerationContext c, CSharpWriter w, UnionShape s) {
     this.context = c;
-    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
@@ -59,10 +59,8 @@ public final class UnionGenerator implements Runnable {
                       () -> {
                         if (ShapeSupport.isReferenceType(model, m)) {
                           writer.write(
-                              "Value = value ?? throw new"
-                                  + " "
-                                  + writer.frameworkType("System.ArgumentNullException")
-                                  + "(nameof(value));");
+                              "Value = value ?? throw new $T(nameof(value));",
+                              RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                         } else {
                           writer.write("Value = value;");
                         }
@@ -76,29 +74,30 @@ public final class UnionGenerator implements Runnable {
             writer.write("");
           }
 
-          writer.addImport(RuntimeTypes.NSMITHY_CORE);
           writer.write("public sealed partial record class Unknown : $L", typeName);
           writer.openBlock(
               "{",
               "}",
               () -> {
-                writer.write("public Unknown(string tag, Document value)");
+                writer.write("public Unknown(string tag, $T value)", RuntimeTypes.DOCUMENT);
                 writer.openBlock(
                     "{",
                     "}",
                     () -> {
                       writer.write(
-                          "Tag = tag ?? throw new "
-                              + writer.frameworkType("System.ArgumentNullException")
-                              + "(nameof(tag));");
+                          "Tag = tag ?? throw new $T(nameof(tag));",
+                          RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                       writer.write("Value = value;");
                     });
                 writer.write("");
                 writer.write("public string Tag { get; }");
-                writer.write("public Document Value { get; }");
+                writer.write("public $T Value { get; }", RuntimeTypes.DOCUMENT);
               });
           writer.write("");
-          writer.write("public static $L FromUnknown(string tag, Document value)", typeName);
+          writer.write(
+              "public static $L FromUnknown(string tag, $T value)",
+              typeName,
+              RuntimeTypes.DOCUMENT);
           writer.openBlock("{", "}", () -> writer.write("return new Unknown(tag, value);"));
           writer.write("");
 
@@ -108,13 +107,15 @@ public final class UnionGenerator implements Runnable {
             String pn = CSharpNaming.parameterName(m.getMemberName());
             String vt = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
             header
-                .append(writer.frameworkType("System.Func") + "<")
+                .append(writer.typeName(RuntimeTypes.FUNC) + "<")
                 .append(vt)
                 .append(", T> ")
                 .append(pn)
                 .append(", ");
           }
-          header.append(writer.frameworkType("System.Func") + "<string, Document, T> unknown)");
+          header.append(
+              writer.typeName(RuntimeTypes.FUNC)
+                  + ("<string, " + writer.typeName(RuntimeTypes.DOCUMENT) + ", T> unknown)"));
           writer.write(header.toString());
           writer.openBlock(
               "{",
@@ -122,13 +123,9 @@ public final class UnionGenerator implements Runnable {
               () -> {
                 for (MemberShape m : members) {
                   String pn = CSharpNaming.parameterName(m.getMemberName());
-                  writer.write(
-                      writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull($L);",
-                      pn);
+                  writer.write("$T.ThrowIfNull($L);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION, pn);
                 }
-                writer.write(
-                    writer.frameworkType("System.ArgumentNullException")
-                        + ".ThrowIfNull(unknown);");
+                writer.write("$T.ThrowIfNull(unknown);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
                 writer.write("");
                 writer.write("return this switch {");
                 writer.indent();
@@ -139,9 +136,8 @@ public final class UnionGenerator implements Runnable {
                 }
                 writer.write("Unknown value => unknown(value.Tag, value.Value),");
                 writer.write(
-                    "_ => throw new "
-                        + writer.frameworkType("System.InvalidOperationException")
-                        + "(\"Unknown union variant.\"),");
+                    "_ => throw new $T(\"Unknown union variant.\"),",
+                    RuntimeTypes.INVALID_OPERATION_EXCEPTION);
                 writer.dedent();
                 writer.write("};");
               });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
@@ -25,6 +25,7 @@ public final class UnionGenerator implements Runnable {
 
   public UnionGenerator(GenerationContext c, CSharpWriter w, UnionShape s) {
     this.context = c;
+    w.reserveModelNames(c.model(), c.settings());
     this.writer = w;
     this.shape = s;
   }
@@ -60,7 +61,9 @@ public final class UnionGenerator implements Runnable {
                         if (ShapeSupport.isReferenceType(model, m)) {
                           writer.write(
                               "Value = value ?? throw new"
-                                  + " System.ArgumentNullException(nameof(value));");
+                                  + " "
+                                  + writer.frameworkType("System.ArgumentNullException")
+                                  + "(nameof(value));");
                         } else {
                           writer.write("Value = value;");
                         }
@@ -86,7 +89,9 @@ public final class UnionGenerator implements Runnable {
                     "}",
                     () -> {
                       writer.write(
-                          "Tag = tag ?? throw new System.ArgumentNullException(nameof(tag));");
+                          "Tag = tag ?? throw new "
+                              + writer.frameworkType("System.ArgumentNullException")
+                              + "(nameof(tag));");
                       writer.write("Value = value;");
                     });
                 writer.write("");
@@ -103,9 +108,14 @@ public final class UnionGenerator implements Runnable {
           for (MemberShape m : members) {
             String pn = CSharpNaming.parameterName(m.getMemberName());
             String vt = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
-            header.append("System.Func<").append(vt).append(", T> ").append(pn).append(", ");
+            header
+                .append(writer.frameworkType("System.Func") + "<")
+                .append(vt)
+                .append(", T> ")
+                .append(pn)
+                .append(", ");
           }
-          header.append("System.Func<string, Document, T> unknown)");
+          header.append(writer.frameworkType("System.Func") + "<string, Document, T> unknown)");
           writer.write(header.toString());
           writer.openBlock(
               "{",
@@ -113,9 +123,13 @@ public final class UnionGenerator implements Runnable {
               () -> {
                 for (MemberShape m : members) {
                   String pn = CSharpNaming.parameterName(m.getMemberName());
-                  writer.write("System.ArgumentNullException.ThrowIfNull($L);", pn);
+                  writer.write(
+                      writer.frameworkType("System.ArgumentNullException") + ".ThrowIfNull($L);",
+                      pn);
                 }
-                writer.write("System.ArgumentNullException.ThrowIfNull(unknown);");
+                writer.write(
+                    writer.frameworkType("System.ArgumentNullException")
+                        + ".ThrowIfNull(unknown);");
                 writer.write("");
                 writer.write("return this switch {");
                 writer.indent();
@@ -126,7 +140,9 @@ public final class UnionGenerator implements Runnable {
                 }
                 writer.write("Unknown value => unknown(value.Tag, value.Value),");
                 writer.write(
-                    "_ => throw new System.InvalidOperationException(\"Unknown union variant.\"),");
+                    "_ => throw new "
+                        + writer.frameworkType("System.InvalidOperationException")
+                        + "(\"Unknown union variant.\"),");
                 writer.dedent();
                 writer.write("};");
               });

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/UnionGenerator.java
@@ -10,7 +10,6 @@ import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.support.ShapeSupport;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.List;
-import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.UnionShape;
@@ -32,117 +31,156 @@ public final class UnionGenerator implements Runnable {
   @Override
   public void run() {
     writer.reserveMemberNames(shape);
-    SymbolProvider sp = context.symbolProvider();
-    Model model = context.model();
     String typeName = CSharpNaming.typeName(shape.getId().getName());
     List<MemberShape> members = ShapeSupport.sortedMembers(shape);
 
-    writer.write("public abstract partial record class $L", typeName);
-    writer.openBlock(
-        "{",
-        "}",
-        () -> {
-          writer.write("private protected $L() { }", typeName);
-          writer.write("");
-          for (MemberShape m : members) {
-            String variantName = CSharpNaming.typeName(m.getMemberName());
-            String valueType = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
-            writer.write("public sealed partial record class $L : $L", variantName, typeName);
-            writer.openBlock(
-                "{",
-                "}",
-                () -> {
-                  writer.write("public $L($L value)", variantName, valueType);
-                  writer.openBlock(
-                      "{",
-                      "}",
-                      () -> {
-                        if (ShapeSupport.isReferenceType(model, m)) {
-                          writer.write(
-                              "Value = value ?? throw new $T(nameof(value));",
-                              RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                        } else {
-                          writer.write("Value = value;");
-                        }
-                      });
-                  writer.write("");
-                  writer.write("public $L Value { get; }", valueType);
-                });
-            writer.write("");
-            writer.write("public static $L From$L($L value)", typeName, variantName, valueType);
-            writer.openBlock("{", "}", () -> writer.write("return new $L(value);", variantName));
-            writer.write("");
-          }
-
-          writer.write("public sealed partial record class Unknown : $L", typeName);
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                writer.write("public Unknown(string tag, $T value)", RuntimeTypes.DOCUMENT);
-                writer.openBlock(
-                    "{",
-                    "}",
-                    () -> {
-                      writer.write(
-                          "Tag = tag ?? throw new $T(nameof(tag));",
-                          RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                      writer.write("Value = value;");
-                    });
-                writer.write("");
-                writer.write("public string Tag { get; }");
-                writer.write("public $T Value { get; }", RuntimeTypes.DOCUMENT);
-              });
-          writer.write("");
-          writer.write(
-              "public static $L FromUnknown(string tag, $T value)",
-              typeName,
-              RuntimeTypes.DOCUMENT);
-          writer.openBlock("{", "}", () -> writer.write("return new Unknown(tag, value);"));
-          writer.write("");
-
-          // Match method
-          StringBuilder header = new StringBuilder("public T Match<T>(");
-          for (MemberShape m : members) {
-            String pn = CSharpNaming.parameterName(m.getMemberName());
-            String vt = ShapeSupport.memberTypeExpr(writer, model, sp, m, false);
-            header
-                .append(writer.typeName(RuntimeTypes.FUNC) + "<")
-                .append(vt)
-                .append(", T> ")
-                .append(pn)
-                .append(", ");
-          }
-          header.append(
-              writer.typeName(RuntimeTypes.FUNC)
-                  + ("<string, " + writer.typeName(RuntimeTypes.DOCUMENT) + ", T> unknown)"));
-          writer.write(header.toString());
-          writer.openBlock(
-              "{",
-              "}",
-              () -> {
-                for (MemberShape m : members) {
-                  String pn = CSharpNaming.parameterName(m.getMemberName());
-                  writer.write("$T.ThrowIfNull($L);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION, pn);
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("document", RuntimeTypes.DOCUMENT);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext(
+          "variants",
+          writer.consumer(
+              w -> {
+                for (MemberShape member : members) {
+                  writeVariant(typeName, member);
+                  w.write("");
                 }
-                writer.write("$T.ThrowIfNull(unknown);", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
-                writer.write("");
-                writer.write("return this switch {");
-                writer.indent();
-                for (MemberShape m : members) {
-                  String variantName = CSharpNaming.typeName(m.getMemberName());
-                  String pn = CSharpNaming.parameterName(m.getMemberName());
-                  writer.write("$L value => $L(value.Value),", variantName, pn);
-                }
-                writer.write("Unknown value => unknown(value.Tag, value.Value),");
-                writer.write(
-                    "_ => throw new $T(\"Unknown union variant.\"),",
-                    RuntimeTypes.INVALID_OPERATION_EXCEPTION);
-                writer.dedent();
-                writer.write("};");
-              });
-        });
+              }));
+      writer.putContext("match", writer.consumer(w -> writeMatch(members)));
+      writer.write(
+          """
+          public abstract partial record class ${typeName:L}
+          {
+              private protected ${typeName:L}() { }
+
+              ${variants:C|}
+              public sealed partial record class Unknown : ${typeName:L}
+              {
+                  public Unknown(string tag, ${document:T} value)
+                  {
+                      Tag = tag ?? throw new ${argumentNullException:T}(nameof(tag));
+                      Value = value;
+                  }
+
+                  public string Tag { get; }
+                  public ${document:T} Value { get; }
+              }
+
+              public static ${typeName:L} FromUnknown(string tag, ${document:T} value)
+              {
+                  return new Unknown(tag, value);
+              }
+
+              ${match:C|}
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
     writer.write("");
     SchemaGenerator.writeUnionSchema(writer, context, shape, members);
+  }
+
+  private void writeVariant(String typeName, MemberShape member) {
+    Model model = context.model();
+    String valueType =
+        ShapeSupport.memberTypeExpr(writer, model, context.symbolProvider(), member, false);
+    String valueExpression =
+        ShapeSupport.isReferenceType(model, member)
+            ? writer.format(
+                "value ?? throw new $T(nameof(value))", RuntimeTypes.ARGUMENT_NULL_EXCEPTION)
+            : "value";
+    writer.pushState();
+    try {
+      writer.putContext("typeName", typeName);
+      writer.putContext("variantName", CSharpNaming.typeName(member.getMemberName()));
+      writer.putContext("valueType", valueType);
+      writer.putContext("valueExpression", valueExpression);
+      writer.write(
+          """
+          public sealed partial record class ${variantName:L} : ${typeName:L}
+          {
+              public ${variantName:L}(${valueType:L} value)
+              {
+                  Value = ${valueExpression:L};
+              }
+
+              public ${valueType:L} Value { get; }
+          }
+
+          public static ${typeName:L} From${variantName:L}(${valueType:L} value)
+          {
+              return new ${variantName:L}(value);
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
+  }
+
+  private void writeMatch(List<MemberShape> members) {
+    writer.pushState();
+    try {
+      writer.putContext("func", RuntimeTypes.FUNC);
+      writer.putContext("document", RuntimeTypes.DOCUMENT);
+      writer.putContext("argumentNullException", RuntimeTypes.ARGUMENT_NULL_EXCEPTION);
+      writer.putContext("invalidOperationException", RuntimeTypes.INVALID_OPERATION_EXCEPTION);
+      writer.putContext(
+          "parameters",
+          writer.consumer(
+              w -> {
+                for (MemberShape member : members) {
+                  w.write(
+                      "$T<$L, T> $L,",
+                      RuntimeTypes.FUNC,
+                      ShapeSupport.memberTypeExpr(
+                          w, context.model(), context.symbolProvider(), member, false),
+                      CSharpNaming.parameterName(member.getMemberName()));
+                }
+              }));
+      writer.putContext(
+          "nullChecks",
+          writer.consumer(
+              w -> {
+                for (MemberShape member : members) {
+                  w.write(
+                      "$T.ThrowIfNull($L);",
+                      RuntimeTypes.ARGUMENT_NULL_EXCEPTION,
+                      CSharpNaming.parameterName(member.getMemberName()));
+                }
+              }));
+      writer.putContext(
+          "cases",
+          writer.consumer(
+              w -> {
+                for (MemberShape member : members) {
+                  w.write(
+                      "$L value => $L(value.Value),",
+                      CSharpNaming.typeName(member.getMemberName()),
+                      CSharpNaming.parameterName(member.getMemberName()));
+                }
+              }));
+      writer.write(
+          """
+          public T Match<T>(
+              ${parameters:C|}
+              ${func:T}<string, ${document:T}, T> unknown)
+          {
+              ${nullChecks:C|}
+              ${argumentNullException:T}.ThrowIfNull(unknown);
+
+              return this switch
+              {
+                  ${cases:C|}
+                  Unknown value => unknown(value.Tag, value.Value),
+                  _ => throw new ${invalidOperationException:T}("Unknown union variant."),
+              };
+          }
+          """);
+    } finally {
+      writer.popState();
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ProtocolSupport.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -39,8 +40,6 @@ public final class ProtocolSupport {
   }
 
   public record HttpVersionPreference(String alpnId, boolean allowDowngrade) {}
-
-  private ProtocolSupport() {}
 
   public static boolean isRestJson1Service(ServiceShape s) {
     return s.findTrait(TraitIds.REST_JSON_1).isPresent();
@@ -195,15 +194,6 @@ public final class ProtocolSupport {
                     || ShapeSupport.isEventStreamShape(model, operation.getOutputShape()));
   }
 
-  private static int httpVersionRank(String alpnId) {
-    return switch (alpnId) {
-      case "http/1.1" -> 1;
-      case "h2" -> 2;
-      case "h3" -> 3;
-      default -> -1;
-    };
-  }
-
   /** The default protocol for the client: the first declared kind by precedence. */
   public static Kind primaryKind(ServiceShape s) {
     List<Kind> kinds = declaredKinds(s);
@@ -229,17 +219,17 @@ public final class ProtocolSupport {
   }
 
   /** Protocol helper class for the given protocol. */
-  public static String protocolType(Kind kind) {
+  public static Symbol protocolType(Kind kind) {
     return switch (kind) {
-      case AWS_JSON_1_0 -> "AwsJson10Protocol";
-      case AWS_JSON_1_1 -> "AwsJson11Protocol";
-      case AWS_QUERY -> "AwsQueryProtocol";
-      case EC2_QUERY -> "Ec2QueryProtocol";
-      case SIMPLE_REST_JSON -> "SimpleRestJsonProtocol";
-      case REST_JSON_1 -> "RestJson1Protocol";
-      case REST_XML -> "RestXmlProtocol";
-      case RPC_V2_CBOR -> "RpcV2CborProtocol";
-      case GRPC -> "GrpcProtocol";
+      case AWS_JSON_1_0 -> RuntimeTypes.AWS_JSON10_PROTOCOL;
+      case AWS_JSON_1_1 -> RuntimeTypes.AWS_JSON11_PROTOCOL;
+      case AWS_QUERY -> RuntimeTypes.AWS_QUERY_PROTOCOL;
+      case EC2_QUERY -> RuntimeTypes.EC2_QUERY_PROTOCOL;
+      case SIMPLE_REST_JSON -> RuntimeTypes.SIMPLE_REST_JSON_PROTOCOL;
+      case REST_JSON_1 -> RuntimeTypes.REST_JSON1_PROTOCOL;
+      case REST_XML -> RuntimeTypes.REST_XML_PROTOCOL;
+      case RPC_V2_CBOR -> RuntimeTypes.RPC_V2_CBOR_PROTOCOL;
+      case GRPC -> RuntimeTypes.GRPC_PROTOCOL;
     };
   }
 
@@ -255,18 +245,6 @@ public final class ProtocolSupport {
     };
   }
 
-  /** Runtime namespace housing the protocol class. */
-  public static String runtimeProtocolNamespace(Kind kind) {
-    return switch (kind) {
-      case AWS_JSON_1_0, AWS_JSON_1_1 -> RuntimeTypes.NSMITHY_PROTOCOLS_AWSJSON;
-      case AWS_QUERY, EC2_QUERY -> RuntimeTypes.NSMITHY_PROTOCOLS_AWSQUERY;
-      case SIMPLE_REST_JSON, REST_JSON_1 -> RuntimeTypes.NSMITHY_PROTOCOLS_RESTJSON;
-      case REST_XML -> RuntimeTypes.NSMITHY_PROTOCOLS_RESTXML;
-      case RPC_V2_CBOR -> RuntimeTypes.NSMITHY_PROTOCOLS_RPCV2CBOR;
-      case GRPC -> RuntimeTypes.NSMITHY_PROTOCOLS_GRPC;
-    };
-  }
-
   /** True when the runtime protocol can bind Smithy event-stream operation inputs/outputs. */
   public static boolean supportsEventStreams(Kind kind) {
     return switch (kind) {
@@ -275,14 +253,14 @@ public final class ProtocolSupport {
     };
   }
 
-  /** Runtime namespace housing the codec singleton. */
-  public static String codecNamespace(Kind kind) {
-    return switch (kind) {
-      case AWS_JSON_1_0, AWS_JSON_1_1, SIMPLE_REST_JSON, REST_JSON_1 ->
-          RuntimeTypes.NSMITHY_CODECS_JSON;
-      case AWS_QUERY, EC2_QUERY, REST_XML -> RuntimeTypes.NSMITHY_CODECS_XML;
-      case RPC_V2_CBOR -> RuntimeTypes.NSMITHY_CODECS_CBOR;
-      case GRPC -> RuntimeTypes.NSMITHY_CODECS_PROTO;
+  private ProtocolSupport() {}
+
+  private static int httpVersionRank(String alpnId) {
+    return switch (alpnId) {
+      case "http/1.1" -> 1;
+      case "h2" -> 2;
+      case "h3" -> 3;
+      default -> -1;
     };
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
@@ -93,16 +93,20 @@ public final class ShapeSupport {
       Shape target,
       software.amazon.smithy.model.node.Node node,
       String typeName) {
-    if (target.getType() == ShapeType.DOCUMENT) return documentLiteral(node);
+    if (target.getType() == ShapeType.DOCUMENT) return documentLiteral(writer, node);
     if (node.isNullNode()) return null;
     return switch (target.getType()) {
       case BLOB ->
           node.isStringNode()
-              ? "System.Convert.FromBase64String(\"" + node.expectStringNode().getValue() + "\")"
+              ? writer.frameworkType("System.Convert")
+                  + ".FromBase64String(\""
+                  + node.expectStringNode().getValue()
+                  + "\")"
               : null;
       case TIMESTAMP ->
           node.isNumberNode()
-              ? "System.DateTimeOffset.FromUnixTimeSeconds("
+              ? writer.frameworkType("System.DateTimeOffset")
+                  + ".FromUnixTimeSeconds("
                   + node.expectNumberNode().getValue().longValue()
                   + ")"
               : null;
@@ -183,7 +187,7 @@ public final class ShapeSupport {
     StringBuilder sb =
         new StringBuilder("new ")
             .append(typeName)
-            .append("(new System.Collections.Generic.Dictionary<")
+            .append("(new " + writer.frameworkType("System.Collections.Generic.Dictionary") + "<")
             .append(keyType)
             .append(", ")
             .append(valueType)
@@ -202,7 +206,8 @@ public final class ShapeSupport {
     return sb.append("})").toString();
   }
 
-  public static String documentLiteral(software.amazon.smithy.model.node.Node node) {
+  public static String documentLiteral(
+      CSharpWriter writer, software.amazon.smithy.model.node.Node node) {
     if (node.isNullNode()) return "NSmithy.Core.Document.Null";
     if (node.isBooleanNode())
       return "NSmithy.Core.Document.From(" + node.expectBooleanNode().getValue() + ")";
@@ -220,14 +225,16 @@ public final class ShapeSupport {
       for (var el : node.expectArrayNode().getElements()) {
         if (!first) sb.append(", ");
         first = false;
-        sb.append(documentLiteral(el));
+        sb.append(documentLiteral(writer, el));
       }
       return sb.append("})").toString();
     }
     if (node.isObjectNode()) {
       StringBuilder sb =
           new StringBuilder(
-              "NSmithy.Core.Document.From(new System.Collections.Generic.Dictionary<string,"
+              "NSmithy.Core.Document.From(new "
+                  + writer.frameworkType("System.Collections.Generic.Dictionary")
+                  + "<string,"
                   + " NSmithy.Core.Document> {");
       boolean first = true;
       for (var entry : node.expectObjectNode().getStringMap().entrySet()) {
@@ -236,7 +243,7 @@ public final class ShapeSupport {
         sb.append("{ \"")
             .append(entry.getKey().replace("\\", "\\\\").replace("\"", "\\\""))
             .append("\", ")
-            .append(documentLiteral(entry.getValue()))
+            .append(documentLiteral(writer, entry.getValue()))
             .append(" }");
       }
       return sb.append("})").toString();
@@ -347,10 +354,11 @@ public final class ShapeSupport {
       CSharpWriter writer, Model model, SymbolProvider sp, MemberShape member, boolean nullable) {
     String base;
     if (isStreamingBlobMember(model, member)) {
-      base = "System.IO.Stream";
+      base = writer.frameworkType("System.IO.Stream");
     } else if (isEventStreamMember(model, member)) {
       base =
-          "System.Collections.Generic.IAsyncEnumerable<"
+          writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
+              + "<"
               + writer.typeName(sp.toSymbol(model.expectShape(member.getTarget())))
               + ">";
     } else {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
@@ -1,6 +1,7 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.support;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -34,8 +35,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class ShapeSupport {
 
   private static final ShapeId UNIT = ShapeId.from("smithy.api#Unit");
-
-  private ShapeSupport() {}
 
   /** smithy.framework#ValidationException, the error the server runtime itself returns. */
   public static final ShapeId VALIDATION_EXCEPTION =
@@ -86,141 +85,31 @@ public final class ShapeSupport {
     return literalForShape(writer, model, sp, target, node, typeName);
   }
 
-  private static String literalForShape(
-      CSharpWriter writer,
-      Model model,
-      SymbolProvider sp,
-      Shape target,
-      software.amazon.smithy.model.node.Node node,
-      String typeName) {
-    if (target.getType() == ShapeType.DOCUMENT) return documentLiteral(writer, node);
-    if (node.isNullNode()) return null;
-    return switch (target.getType()) {
-      case BLOB ->
-          node.isStringNode()
-              ? writer.frameworkType("System.Convert")
-                  + ".FromBase64String(\""
-                  + node.expectStringNode().getValue()
-                  + "\")"
-              : null;
-      case TIMESTAMP ->
-          node.isNumberNode()
-              ? writer.frameworkType("System.DateTimeOffset")
-                  + ".FromUnixTimeSeconds("
-                  + node.expectNumberNode().getValue().longValue()
-                  + ")"
-              : null;
-      case FLOAT ->
-          node.isNumberNode() ? node.expectNumberNode().getValue().floatValue() + "f" : null;
-      case ENUM ->
-          node.isStringNode()
-              ? "new "
-                  + typeName
-                  + "(\""
-                  + node.expectStringNode().getValue().replace("\\", "\\\\").replace("\"", "\\\"")
-                  + "\")"
-              : null;
-      case INT_ENUM ->
-          node.isNumberNode()
-              ? "(" + typeName + ")" + node.expectNumberNode().getValue().longValue()
-              : null;
-      case LIST, SET -> listLiteral(writer, model, sp, target, node, typeName);
-      case MAP -> mapLiteral(writer, model, sp, target, node, typeName);
-      default -> defaultLiteral(node);
-    };
-  }
-
-  private static String listLiteral(
-      CSharpWriter writer,
-      Model model,
-      SymbolProvider sp,
-      Shape target,
-      software.amazon.smithy.model.node.Node node,
-      String typeName) {
-    if (!node.isArrayNode()) return null;
-    Shape memberTarget =
-        model.expectShape(
-            switch (target.getType()) {
-              case LIST -> target.asListShape().orElseThrow().getMember().getTarget();
-              case SET -> target.asSetShape().orElseThrow().getMember().getTarget();
-              default ->
-                  throw new CodegenException(
-                      "Expected list or set shape while rendering @default for "
-                          + target.getId()
-                          + ", but found "
-                          + target.getType()
-                          + ".");
-            });
-    String elementType = writer.typeName(sp.toSymbol(memberTarget));
-    List<String> elements = new ArrayList<>();
-    for (var element : node.expectArrayNode().getElements()) {
-      String literal = literalForShape(writer, model, sp, memberTarget, element, elementType);
-      if (literal == null) return null;
-      elements.add(literal);
-    }
-    return "new " + typeName + "(new " + elementType + "[] {" + String.join(", ", elements) + "})";
-  }
-
-  private static String mapLiteral(
-      CSharpWriter writer,
-      Model model,
-      SymbolProvider sp,
-      Shape target,
-      software.amazon.smithy.model.node.Node node,
-      String typeName) {
-    if (!node.isObjectNode()) return null;
-    var mapShape =
-        target
-            .asMapShape()
-            .orElseThrow(
-                () ->
-                    new CodegenException(
-                        "Expected map shape while rendering @default for "
-                            + target.getId()
-                            + ", but found "
-                            + target.getType()
-                            + "."));
-    Shape keyTarget = model.expectShape(mapShape.getKey().getTarget());
-    Shape valueTarget = model.expectShape(mapShape.getValue().getTarget());
-    String keyType = writer.typeName(sp.toSymbol(keyTarget));
-    String valueType = writer.typeName(sp.toSymbol(valueTarget));
-    StringBuilder sb =
-        new StringBuilder("new ")
-            .append(typeName)
-            .append("(new " + writer.frameworkType("System.Collections.Generic.Dictionary") + "<")
-            .append(keyType)
-            .append(", ")
-            .append(valueType)
-            .append("> {");
-    boolean first = true;
-    for (var entry : node.expectObjectNode().getStringMap().entrySet()) {
-      String keyLiteral =
-          defaultLiteral(software.amazon.smithy.model.node.Node.from(entry.getKey()));
-      String valueLiteral =
-          literalForShape(writer, model, sp, valueTarget, entry.getValue(), valueType);
-      if (keyLiteral == null || valueLiteral == null) return null;
-      if (!first) sb.append(", ");
-      first = false;
-      sb.append("{ ").append(keyLiteral).append(", ").append(valueLiteral).append(" }");
-    }
-    return sb.append("})").toString();
-  }
-
   public static String documentLiteral(
       CSharpWriter writer, software.amazon.smithy.model.node.Node node) {
-    if (node.isNullNode()) return "NSmithy.Core.Document.Null";
+    if (node.isNullNode()) return writer.typeName(RuntimeTypes.DOCUMENT) + ".Null";
     if (node.isBooleanNode())
-      return "NSmithy.Core.Document.From(" + node.expectBooleanNode().getValue() + ")";
+      return writer.typeName(RuntimeTypes.DOCUMENT)
+          + ".From("
+          + node.expectBooleanNode().getValue()
+          + ")";
     if (node.isStringNode()) {
       String s = node.expectStringNode().getValue().replace("\\", "\\\\").replace("\"", "\\\"");
-      return "NSmithy.Core.Document.From(\"" + s + "\")";
+      return writer.typeName(RuntimeTypes.DOCUMENT) + ".From(\"" + s + "\")";
     }
     if (node.isNumberNode()) {
-      return "NSmithy.Core.Document.From((decimal)" + node.expectNumberNode().getValue() + ")";
+      return writer.typeName(RuntimeTypes.DOCUMENT)
+          + ".From((decimal)"
+          + node.expectNumberNode().getValue()
+          + ")";
     }
     if (node.isArrayNode()) {
       StringBuilder sb =
-          new StringBuilder("NSmithy.Core.Document.From(new NSmithy.Core.Document[] {");
+          new StringBuilder(
+              writer.typeName(RuntimeTypes.DOCUMENT)
+                  + ".From(new "
+                  + writer.typeName(RuntimeTypes.DOCUMENT)
+                  + "[] {");
       boolean first = true;
       for (var el : node.expectArrayNode().getElements()) {
         if (!first) sb.append(", ");
@@ -232,10 +121,13 @@ public final class ShapeSupport {
     if (node.isObjectNode()) {
       StringBuilder sb =
           new StringBuilder(
-              "NSmithy.Core.Document.From(new "
-                  + writer.frameworkType("System.Collections.Generic.Dictionary")
+              writer.typeName(RuntimeTypes.DOCUMENT)
+                  + ".From(new "
+                  + writer.typeName(RuntimeTypes.DICTIONARY)
                   + "<string,"
-                  + " NSmithy.Core.Document> {");
+                  + " "
+                  + writer.typeName(RuntimeTypes.DOCUMENT)
+                  + "> {");
       boolean first = true;
       for (var entry : node.expectObjectNode().getStringMap().entrySet()) {
         if (!first) sb.append(", ");
@@ -248,22 +140,7 @@ public final class ShapeSupport {
       }
       return sb.append("})").toString();
     }
-    return "NSmithy.Core.Document.Null";
-  }
-
-  private static String defaultLiteral(software.amazon.smithy.model.node.Node node) {
-    if (node.isStringNode()) {
-      String s = node.expectStringNode().getValue();
-      return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
-    }
-    if (node.isBooleanNode()) {
-      return node.expectBooleanNode().getValue() ? "true" : "false";
-    }
-    if (node.isNumberNode()) {
-      var num = node.expectNumberNode().getValue();
-      return num.toString();
-    }
-    return null;
+    return writer.typeName(RuntimeTypes.DOCUMENT) + ".Null";
   }
 
   /** A member is nullable iff not @required AND either has no @default or is @clientOptional. */
@@ -354,10 +231,10 @@ public final class ShapeSupport {
       CSharpWriter writer, Model model, SymbolProvider sp, MemberShape member, boolean nullable) {
     String base;
     if (isStreamingBlobMember(model, member)) {
-      base = writer.frameworkType("System.IO.Stream");
+      base = writer.typeName(RuntimeTypes.STREAM);
     } else if (isEventStreamMember(model, member)) {
       base =
-          writer.frameworkType("System.Collections.Generic.IAsyncEnumerable")
+          writer.typeName(RuntimeTypes.I_ASYNC_ENUMERABLE)
               + "<"
               + writer.typeName(sp.toSymbol(model.expectShape(member.getTarget())))
               + ">";
@@ -469,6 +346,173 @@ public final class ShapeSupport {
     requireGrpcEventStreamWrapperIsFlattenable(model, op, op.getOutputShape(), "output");
   }
 
+  public static boolean isStreamingBlobMember(Model model, MemberShape member) {
+    Shape target = model.expectShape(member.getTarget());
+    return target.getType() == ShapeType.BLOB
+        && (member.hasTrait(StreamingTrait.class) || target.hasTrait(StreamingTrait.class));
+  }
+
+  public static boolean isEventStreamMember(Model model, MemberShape member) {
+    Shape target = model.expectShape(member.getTarget());
+    return target.getType() == ShapeType.UNION
+        && (member.hasTrait(StreamingTrait.class) || target.hasTrait(StreamingTrait.class));
+  }
+
+  public static boolean isStreamingBlobShape(Model model, ShapeId shapeId) {
+    Shape shape = model.expectShape(shapeId);
+    if (shape.getType() == ShapeType.BLOB && shape.hasTrait(StreamingTrait.class)) {
+      return true;
+    }
+
+    return shape.members().stream().anyMatch(member -> isStreamingBlobMember(model, member));
+  }
+
+  public static boolean isEventStreamShape(Model model, ShapeId shapeId) {
+    return isStreamingShape(model, shapeId) && !isStreamingBlobShape(model, shapeId);
+  }
+
+  /** "Foo" -> "FooAsync". Convenience for generated method names. */
+  public static String asyncMethodName(String operationName) {
+    return CSharpNaming.propertyName(operationName) + "Async";
+  }
+
+  private ShapeSupport() {}
+
+  private static String literalForShape(
+      CSharpWriter writer,
+      Model model,
+      SymbolProvider sp,
+      Shape target,
+      software.amazon.smithy.model.node.Node node,
+      String typeName) {
+    if (target.getType() == ShapeType.DOCUMENT) return documentLiteral(writer, node);
+    if (node.isNullNode()) return null;
+    return switch (target.getType()) {
+      case BLOB ->
+          node.isStringNode()
+              ? writer.typeName(RuntimeTypes.CONVERT)
+                  + ".FromBase64String(\""
+                  + node.expectStringNode().getValue()
+                  + "\")"
+              : null;
+      case TIMESTAMP ->
+          node.isNumberNode()
+              ? writer.typeName(RuntimeTypes.DATE_TIME_OFFSET)
+                  + ".FromUnixTimeSeconds("
+                  + node.expectNumberNode().getValue().longValue()
+                  + ")"
+              : null;
+      case FLOAT ->
+          node.isNumberNode() ? node.expectNumberNode().getValue().floatValue() + "f" : null;
+      case ENUM ->
+          node.isStringNode()
+              ? "new "
+                  + typeName
+                  + "(\""
+                  + node.expectStringNode().getValue().replace("\\", "\\\\").replace("\"", "\\\"")
+                  + "\")"
+              : null;
+      case INT_ENUM ->
+          node.isNumberNode()
+              ? "(" + typeName + ")" + node.expectNumberNode().getValue().longValue()
+              : null;
+      case LIST, SET -> listLiteral(writer, model, sp, target, node, typeName);
+      case MAP -> mapLiteral(writer, model, sp, target, node, typeName);
+      default -> defaultLiteral(node);
+    };
+  }
+
+  private static String listLiteral(
+      CSharpWriter writer,
+      Model model,
+      SymbolProvider sp,
+      Shape target,
+      software.amazon.smithy.model.node.Node node,
+      String typeName) {
+    if (!node.isArrayNode()) return null;
+    Shape memberTarget =
+        model.expectShape(
+            switch (target.getType()) {
+              case LIST -> target.asListShape().orElseThrow().getMember().getTarget();
+              case SET -> target.asSetShape().orElseThrow().getMember().getTarget();
+              default ->
+                  throw new CodegenException(
+                      "Expected list or set shape while rendering @default for "
+                          + target.getId()
+                          + ", but found "
+                          + target.getType()
+                          + ".");
+            });
+    String elementType = writer.typeName(sp.toSymbol(memberTarget));
+    List<String> elements = new ArrayList<>();
+    for (var element : node.expectArrayNode().getElements()) {
+      String literal = literalForShape(writer, model, sp, memberTarget, element, elementType);
+      if (literal == null) return null;
+      elements.add(literal);
+    }
+    return "new " + typeName + "(new " + elementType + "[] {" + String.join(", ", elements) + "})";
+  }
+
+  private static String mapLiteral(
+      CSharpWriter writer,
+      Model model,
+      SymbolProvider sp,
+      Shape target,
+      software.amazon.smithy.model.node.Node node,
+      String typeName) {
+    if (!node.isObjectNode()) return null;
+    var mapShape =
+        target
+            .asMapShape()
+            .orElseThrow(
+                () ->
+                    new CodegenException(
+                        "Expected map shape while rendering @default for "
+                            + target.getId()
+                            + ", but found "
+                            + target.getType()
+                            + "."));
+    Shape keyTarget = model.expectShape(mapShape.getKey().getTarget());
+    Shape valueTarget = model.expectShape(mapShape.getValue().getTarget());
+    String keyType = writer.typeName(sp.toSymbol(keyTarget));
+    String valueType = writer.typeName(sp.toSymbol(valueTarget));
+    StringBuilder sb =
+        new StringBuilder("new ")
+            .append(typeName)
+            .append("(new " + writer.typeName(RuntimeTypes.DICTIONARY) + "<")
+            .append(keyType)
+            .append(", ")
+            .append(valueType)
+            .append("> {");
+    boolean first = true;
+    for (var entry : node.expectObjectNode().getStringMap().entrySet()) {
+      String keyLiteral =
+          defaultLiteral(software.amazon.smithy.model.node.Node.from(entry.getKey()));
+      String valueLiteral =
+          literalForShape(writer, model, sp, valueTarget, entry.getValue(), valueType);
+      if (keyLiteral == null || valueLiteral == null) return null;
+      if (!first) sb.append(", ");
+      first = false;
+      sb.append("{ ").append(keyLiteral).append(", ").append(valueLiteral).append(" }");
+    }
+    return sb.append("})").toString();
+  }
+
+  private static String defaultLiteral(software.amazon.smithy.model.node.Node node) {
+    if (node.isStringNode()) {
+      String s = node.expectStringNode().getValue();
+      return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+    if (node.isBooleanNode()) {
+      return node.expectBooleanNode().getValue() ? "true" : "false";
+    }
+    if (node.isNumberNode()) {
+      var num = node.expectNumberNode().getValue();
+      return num.toString();
+    }
+    return null;
+  }
+
   private static void requireGrpcEventStreamWrapperIsFlattenable(
       Model model, OperationShape op, ShapeId shapeId, String direction) {
     Shape shape = model.expectShape(shapeId);
@@ -504,35 +548,5 @@ public final class ShapeSupport {
             + " wrapper to 'stream <Event>', so sibling members cannot be represented. Members: "
             + members
             + ".");
-  }
-
-  public static boolean isStreamingBlobMember(Model model, MemberShape member) {
-    Shape target = model.expectShape(member.getTarget());
-    return target.getType() == ShapeType.BLOB
-        && (member.hasTrait(StreamingTrait.class) || target.hasTrait(StreamingTrait.class));
-  }
-
-  public static boolean isEventStreamMember(Model model, MemberShape member) {
-    Shape target = model.expectShape(member.getTarget());
-    return target.getType() == ShapeType.UNION
-        && (member.hasTrait(StreamingTrait.class) || target.hasTrait(StreamingTrait.class));
-  }
-
-  public static boolean isStreamingBlobShape(Model model, ShapeId shapeId) {
-    Shape shape = model.expectShape(shapeId);
-    if (shape.getType() == ShapeType.BLOB && shape.hasTrait(StreamingTrait.class)) {
-      return true;
-    }
-
-    return shape.members().stream().anyMatch(member -> isStreamingBlobMember(model, member));
-  }
-
-  public static boolean isEventStreamShape(Model model, ShapeId shapeId) {
-    return isStreamingShape(model, shapeId) && !isStreamingBlobShape(model, shapeId);
-  }
-
-  /** "Foo" -> "FooAsync". Convenience for generated method names. */
-  public static String asyncMethodName(String operationName) {
-    return CSharpNaming.propertyName(operationName) + "Async";
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/support/ShapeSupport.java
@@ -1,7 +1,7 @@
 package io.github.thomaslaich.nsmithy.csharp.codegen.support;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
-import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -75,17 +75,19 @@ public final class ShapeSupport {
    * integer to the generated enum type. Anything else falls through to a plain literal
    * (string/bool/numeric).
    */
-  public static String defaultValueExpression(Model model, SymbolProvider sp, MemberShape member) {
+  public static String defaultValueExpression(
+      CSharpWriter writer, Model model, SymbolProvider sp, MemberShape member) {
     var trait = member.getTrait(DefaultTrait.class).orElse(null);
     if (trait == null) return null;
     if (hasClientOptional(member)) return null;
     var node = trait.toNode();
     Shape target = model.expectShape(member.getTarget());
-    String typeName = CSharpSymbolProvider.qualified(sp.toSymbol(member));
-    return literalForShape(model, sp, target, node, typeName);
+    String typeName = writer.typeName(sp.toSymbol(member));
+    return literalForShape(writer, model, sp, target, node, typeName);
   }
 
   private static String literalForShape(
+      CSharpWriter writer,
       Model model,
       SymbolProvider sp,
       Shape target,
@@ -118,13 +120,14 @@ public final class ShapeSupport {
           node.isNumberNode()
               ? "(" + typeName + ")" + node.expectNumberNode().getValue().longValue()
               : null;
-      case LIST, SET -> listLiteral(model, sp, target, node, typeName);
-      case MAP -> mapLiteral(model, sp, target, node, typeName);
+      case LIST, SET -> listLiteral(writer, model, sp, target, node, typeName);
+      case MAP -> mapLiteral(writer, model, sp, target, node, typeName);
       default -> defaultLiteral(node);
     };
   }
 
   private static String listLiteral(
+      CSharpWriter writer,
       Model model,
       SymbolProvider sp,
       Shape target,
@@ -144,10 +147,10 @@ public final class ShapeSupport {
                           + target.getType()
                           + ".");
             });
-    String elementType = CSharpSymbolProvider.qualified(sp.toSymbol(memberTarget));
+    String elementType = writer.typeName(sp.toSymbol(memberTarget));
     List<String> elements = new ArrayList<>();
     for (var element : node.expectArrayNode().getElements()) {
-      String literal = literalForShape(model, sp, memberTarget, element, elementType);
+      String literal = literalForShape(writer, model, sp, memberTarget, element, elementType);
       if (literal == null) return null;
       elements.add(literal);
     }
@@ -155,6 +158,7 @@ public final class ShapeSupport {
   }
 
   private static String mapLiteral(
+      CSharpWriter writer,
       Model model,
       SymbolProvider sp,
       Shape target,
@@ -174,8 +178,8 @@ public final class ShapeSupport {
                             + "."));
     Shape keyTarget = model.expectShape(mapShape.getKey().getTarget());
     Shape valueTarget = model.expectShape(mapShape.getValue().getTarget());
-    String keyType = CSharpSymbolProvider.qualified(sp.toSymbol(keyTarget));
-    String valueType = CSharpSymbolProvider.qualified(sp.toSymbol(valueTarget));
+    String keyType = writer.typeName(sp.toSymbol(keyTarget));
+    String valueType = writer.typeName(sp.toSymbol(valueTarget));
     StringBuilder sb =
         new StringBuilder("new ")
             .append(typeName)
@@ -188,7 +192,8 @@ public final class ShapeSupport {
     for (var entry : node.expectObjectNode().getStringMap().entrySet()) {
       String keyLiteral =
           defaultLiteral(software.amazon.smithy.model.node.Node.from(entry.getKey()));
-      String valueLiteral = literalForShape(model, sp, valueTarget, entry.getValue(), valueType);
+      String valueLiteral =
+          literalForShape(writer, model, sp, valueTarget, entry.getValue(), valueType);
       if (keyLiteral == null || valueLiteral == null) return null;
       if (!first) sb.append(", ");
       first = false;
@@ -331,35 +336,38 @@ public final class ShapeSupport {
   }
 
   /** Member type for property emission: type symbol + optional `?` suffix. */
-  public static String memberTypeExpr(SymbolProvider sp, MemberShape member, boolean nullable) {
+  public static String memberTypeExpr(
+      CSharpWriter writer, SymbolProvider sp, MemberShape member, boolean nullable) {
     Symbol s = sp.toSymbol(member);
-    String base = CSharpSymbolProvider.qualified(s);
+    String base = writer.typeName(s);
     return nullable ? base + "?" : base;
   }
 
   public static String memberTypeExpr(
-      Model model, SymbolProvider sp, MemberShape member, boolean nullable) {
+      CSharpWriter writer, Model model, SymbolProvider sp, MemberShape member, boolean nullable) {
     String base;
     if (isStreamingBlobMember(model, member)) {
       base = "System.IO.Stream";
     } else if (isEventStreamMember(model, member)) {
       base =
           "System.Collections.Generic.IAsyncEnumerable<"
-              + CSharpSymbolProvider.qualified(sp.toSymbol(model.expectShape(member.getTarget())))
+              + writer.typeName(sp.toSymbol(model.expectShape(member.getTarget())))
               + ">";
     } else {
-      base = CSharpSymbolProvider.qualified(sp.toSymbol(member));
+      base = writer.typeName(sp.toSymbol(member));
     }
     return nullable ? base + "?" : base;
   }
 
   /** Parameter type: nullable if member is nullable OR has a default. */
-  public static String parameterTypeExpr(SymbolProvider sp, MemberShape member) {
-    return memberTypeExpr(sp, member, isNullable(member) || hasDefault(member));
+  public static String parameterTypeExpr(
+      CSharpWriter writer, SymbolProvider sp, MemberShape member) {
+    return memberTypeExpr(writer, sp, member, isNullable(member) || hasDefault(member));
   }
 
-  public static String parameterTypeExpr(Model model, SymbolProvider sp, MemberShape member) {
-    return memberTypeExpr(model, sp, member, isNullable(member) || hasDefault(member));
+  public static String parameterTypeExpr(
+      CSharpWriter writer, Model model, SymbolProvider sp, MemberShape member) {
+    return memberTypeExpr(writer, model, sp, member, isNullable(member) || hasDefault(member));
   }
 
   public static boolean isHttpLabel(MemberShape m) {

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpDelegator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpDelegator.java
@@ -4,9 +4,11 @@
  */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -14,5 +16,20 @@ public final class CSharpDelegator extends WriterDelegator<CSharpWriter> {
 
   public CSharpDelegator(FileManifest fileManifest, SymbolProvider symbolProvider) {
     super(fileManifest, symbolProvider, new CSharpWriter.CSharpWriterFactory());
+  }
+
+  public CSharpDelegator(
+      FileManifest fileManifest,
+      SymbolProvider symbolProvider,
+      Model model,
+      CSharpSettings settings) {
+    super(
+        fileManifest,
+        symbolProvider,
+        (filename, namespace) -> {
+          var writer = new CSharpWriter(namespace);
+          writer.reserveModelNames(model, settings);
+          return writer;
+        });
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpDelegator.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpDelegator.java
@@ -14,22 +14,11 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class CSharpDelegator extends WriterDelegator<CSharpWriter> {
 
-  public CSharpDelegator(FileManifest fileManifest, SymbolProvider symbolProvider) {
-    super(fileManifest, symbolProvider, new CSharpWriter.CSharpWriterFactory());
-  }
-
   public CSharpDelegator(
       FileManifest fileManifest,
       SymbolProvider symbolProvider,
       Model model,
       CSharpSettings settings) {
-    super(
-        fileManifest,
-        symbolProvider,
-        (filename, namespace) -> {
-          var writer = new CSharpWriter(namespace);
-          writer.reserveModelNames(model, settings);
-          return writer;
-        });
+    super(fileManifest, symbolProvider, new CSharpWriter.CSharpWriterFactory(model, settings));
   }
 }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -33,7 +33,10 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclarations> {
 
   private final String namespace;
-  private final Set<String> modelNames = new HashSet<>();
+  // Shape names and generated companions visible in the current or a parent namespace.
+  private final Set<String> modelTypeNames = new HashSet<>();
+  // Conservatively reserve segments from every model namespace, including unrelated ones.
+  private final Set<String> namespaceSegments = new HashSet<>();
   private final Map<FrameworkReference, String> frameworkReferences = new LinkedHashMap<>();
 
   private record FrameworkReference(String qualifiedName, boolean attribute) {}
@@ -72,14 +75,14 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
             shape -> {
               String ns = settings.csharpNamespace(shape.getId().getNamespace());
               // Namespace segments can also hide imported types during C# name lookup.
-              modelNames.addAll(java.util.List.of(ns.split("\\.")));
+              namespaceSegments.addAll(java.util.List.of(ns.split("\\.")));
               if (ns.equals(namespace) || namespace.startsWith(ns + ".")) {
                 String name = CSharpNaming.typeName(shape.getId().getName());
-                modelNames.add(name);
-                modelNames.add(name + "Schema");
+                modelTypeNames.add(name);
+                modelTypeNames.add(name + "Schema");
                 if (shape.isServiceShape()) {
-                  modelNames.add(name + "Client");
-                  modelNames.add(name + "ClientConfig");
+                  modelTypeNames.add(name + "Client");
+                  modelTypeNames.add(name + "ClientConfig");
                 }
               }
             });
@@ -115,16 +118,7 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
           reference.getKey().attribute() && name.endsWith("Attribute")
               ? name.substring(0, name.length() - 9)
               : name;
-      boolean collision =
-          reservedNames.contains(name)
-              || modelNames.contains(name)
-              || reservedNames.contains(shortName)
-              || modelNames.contains(shortName)
-              || frameworkReferences.keySet().stream()
-                  .anyMatch(
-                      other ->
-                          !other.qualifiedName().equals(qualified)
-                              && other.qualifiedName().endsWith("." + name));
+      boolean collision = hasFrameworkNameCollision(qualified, name, shortName);
       String rendered = "global::" + qualified;
       if (!collision) {
         imports.add(ns);
@@ -133,6 +127,22 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
       body = body.replace(reference.getValue(), rendered);
     }
     return body;
+  }
+
+  /** Check each source of shadowing for both the full name and attribute shorthand. */
+  private boolean hasFrameworkNameCollision(String qualifiedName, String name, String shortName) {
+    // Generated members, nested types, or type parameters can hide the reference.
+    if (reservedNames.contains(name) || reservedNames.contains(shortName)) return true;
+    // Model types and their generated companions can take precedence over imported types.
+    if (modelTypeNames.contains(name) || modelTypeNames.contains(shortName)) return true;
+    // Preserve the existing conservative policy for namespace segments.
+    if (namespaceSegments.contains(name) || namespaceSegments.contains(shortName)) return true;
+    // Distinct framework types sharing a simple name would make the imports ambiguous.
+    return frameworkReferences.keySet().stream()
+        .anyMatch(
+            other ->
+                !other.qualifiedName().equals(qualifiedName)
+                    && other.qualifiedName().endsWith("." + name));
   }
 
   /** Reserve model member names before rendering references in the containing file. */

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -7,13 +7,15 @@
  * $T behaviour:
  *  - Symbol with empty namespace: bare name (used for C# keyword primitives
  *    like `string`, `int`, etc.).
- *  - Symbol with non-empty namespace: name only; the namespace is added to the
- *    file imports. (System.* is also imported as a `using` to keep generated
- *    code uncluttered.)
+ *  - Local, unshadowed types use their short name. Other types use global:: qualification.
+ *  - Explicit SymbolReference aliases are preserved.
  */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -27,6 +29,11 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclarations> {
 
   private final String namespace;
+  // These generated nested types, members, and type parameters can hide model types.
+  private final Set<String> reservedNames =
+      new HashSet<>(
+          Set.of(
+              "Builder", "ValueSerializer", "Schema", "Unknown", "Value", "Tag", "T", "TWriter"));
 
   public CSharpWriter(String namespace) {
     super(new ImportDeclarations(namespace));
@@ -40,6 +47,36 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
   public CSharpWriter addImport(String csharpNamespace) {
     getImportContainer().importNamespace(csharpNamespace);
     return this;
+  }
+
+  /** Reserve a generated identifier that can hide a type reference in this file. */
+  public void reserveName(String name) {
+    reservedNames.add(name);
+  }
+
+  /** Reserve model member names before rendering references in the containing file. */
+  public void reserveMemberNames(Shape shape) {
+    shape
+        .members()
+        .forEach(
+            member -> {
+              reservedNames.add(CSharpNaming.propertyName(member.getMemberName()));
+              reservedNames.add(CSharpNaming.typeName(member.getMemberName()));
+            });
+  }
+
+  /** Render a type reference without importing potentially ambiguous model namespaces. */
+  public String typeName(Symbol symbol) {
+    return typeName(symbol, "");
+  }
+
+  /** The suffix refers to a generated companion type, such as a shape's schema class. */
+  public String typeName(Symbol symbol, String suffix) {
+    String name = symbol.getName() + suffix;
+    String ns = symbol.getNamespace();
+    if (ns.isEmpty()) return name;
+    if (ns.equals(namespace) && !reservedNames.contains(name)) return name;
+    return "global::" + ns + "." + name;
   }
 
   /** Emits a C# XML documentation summary from a Smithy shape's documentation trait. */
@@ -128,8 +165,7 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
     @Override
     public String apply(Object type, String indent) {
       if (type instanceof Symbol s) {
-        addImport(s, null);
-        return s.getName();
+        return typeName(s);
       }
       if (type instanceof SymbolReference ref) {
         addImport(ref.getSymbol(), ref.getAlias(), SymbolReference.ContextOption.USE);

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -7,13 +7,16 @@
  * $T behaviour:
  *  - Symbol with empty namespace: bare name (used for C# keyword primitives
  *    like `string`, `int`, etc.).
- *  - Local, unshadowed types use their short name. Other types use global:: qualification.
+ *  - Local, unshadowed model types use their short name; other model types are qualified.
+ *  - Framework references collect imports and fall back to global:: qualification on collision.
  *  - Explicit SymbolReference aliases are preserved.
  */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -21,6 +24,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -29,6 +33,12 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclarations> {
 
   private final String namespace;
+  private final Set<String> modelNames = new HashSet<>();
+  private final Map<FrameworkReference, String> frameworkReferences = new LinkedHashMap<>();
+  private boolean modelNamesCollected;
+
+  private record FrameworkReference(String qualifiedName, boolean attribute) {}
+
   // These generated nested types, members, and type parameters can hide model types.
   private final Set<String> reservedNames =
       new HashSet<>(
@@ -54,6 +64,80 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
     reservedNames.add(name);
   }
 
+  /** Include declarations that can shadow framework types even when this file never uses them. */
+  public void reserveModelNames(Model model, CSharpSettings settings) {
+    if (modelNamesCollected) return;
+    modelNamesCollected = true;
+    model
+        .shapes()
+        .filter(shape -> !shape.isMemberShape())
+        .forEach(
+            shape -> {
+              String ns = settings.csharpNamespace(shape.getId().getNamespace());
+              // Namespace segments can also hide imported types during C# name lookup.
+              modelNames.addAll(java.util.List.of(ns.split("\\.")));
+              if (ns.equals(namespace) || namespace.startsWith(ns + ".")) {
+                String name = CSharpNaming.typeName(shape.getId().getName());
+                modelNames.add(name);
+                modelNames.add(name + "Schema");
+                if (shape.isServiceShape()) {
+                  modelNames.add(name + "Client");
+                  modelNames.add(name + "ClientConfig");
+                }
+              }
+            });
+  }
+
+  /**
+   * Return a stable reference token. Resolve it after the whole file has registered its names, so
+   * import decisions do not depend on emission order. Only explicit tokens are substituted;
+   * documentation and model string literals are never simplified.
+   */
+  public String frameworkType(String qualifiedName) {
+    return frameworkReference(qualifiedName, false);
+  }
+
+  /** Render an attribute with its conventional short form when that form is unambiguous. */
+  public String frameworkAttribute(String qualifiedName) {
+    return frameworkReference(qualifiedName, true);
+  }
+
+  private String frameworkReference(String qualifiedName, boolean attribute) {
+    return frameworkReferences.computeIfAbsent(
+        new FrameworkReference(qualifiedName, attribute),
+        ignored -> "\u0001framework" + frameworkReferences.size() + "\u0002");
+  }
+
+  private String renderFrameworkReferences(String body, Set<String> imports) {
+    for (var reference : frameworkReferences.entrySet()) {
+      String qualified = reference.getKey().qualifiedName();
+      int separator = qualified.lastIndexOf('.');
+      String ns = qualified.substring(0, separator);
+      String name = qualified.substring(separator + 1);
+      String shortName =
+          reference.getKey().attribute() && name.endsWith("Attribute")
+              ? name.substring(0, name.length() - 9)
+              : name;
+      boolean collision =
+          reservedNames.contains(name)
+              || modelNames.contains(name)
+              || reservedNames.contains(shortName)
+              || modelNames.contains(shortName)
+              || frameworkReferences.keySet().stream()
+                  .anyMatch(
+                      other ->
+                          !other.qualifiedName().equals(qualified)
+                              && other.qualifiedName().endsWith("." + name));
+      String rendered = "global::" + qualified;
+      if (!collision) {
+        imports.add(ns);
+        rendered = shortName;
+      }
+      body = body.replace(reference.getValue(), rendered);
+    }
+    return body;
+  }
+
   /** Reserve model member names before rendering references in the containing file. */
   public void reserveMemberNames(Shape shape) {
     shape
@@ -74,6 +158,9 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
   public String typeName(Symbol symbol, String suffix) {
     String name = symbol.getName() + suffix;
     String ns = symbol.getNamespace();
+    if (symbol.getDefinitionFile().isEmpty() && (ns.equals("System") || ns.startsWith("System."))) {
+      return frameworkType(ns + "." + name);
+    }
     if (ns.isEmpty()) return name;
     if (ns.equals(namespace) && !reservedNames.contains(name)) return name;
     return "global::" + ns + "." + name;
@@ -151,13 +238,15 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
 
   @Override
   public String toString() {
+    Set<String> frameworkImports = new HashSet<>();
+    String body = renderFrameworkReferences(super.toString(), frameworkImports);
     StringBuilder sb = new StringBuilder();
     sb.append("// <auto-generated />\n");
     sb.append("// Generated by smithy-csharp-codegen. DO NOT EDIT.\n");
     sb.append("#nullable enable\n\n");
-    sb.append(getImportContainer().toString());
+    sb.append(getImportContainer().render(frameworkImports));
     sb.append("namespace ").append(namespace).append(";\n\n");
-    sb.append(super.toString());
+    sb.append(body);
     return sb.toString();
   }
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -35,7 +35,6 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
   private final String namespace;
   private final Set<String> modelNames = new HashSet<>();
   private final Map<FrameworkReference, String> frameworkReferences = new LinkedHashMap<>();
-  private boolean modelNamesCollected;
 
   private record FrameworkReference(String qualifiedName, boolean attribute) {}
 
@@ -65,9 +64,7 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
   }
 
   /** Include declarations that can shadow framework types even when this file never uses them. */
-  public void reserveModelNames(Model model, CSharpSettings settings) {
-    if (modelNamesCollected) return;
-    modelNamesCollected = true;
+  private void reserveModelNames(Model model, CSharpSettings settings) {
     model
         .shapes()
         .filter(shape -> !shape.isMemberShape())
@@ -230,9 +227,19 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
 
   /** Factory used by WriterDelegator. */
   public static final class CSharpWriterFactory implements SymbolWriter.Factory<CSharpWriter> {
+    private final Model model;
+    private final CSharpSettings settings;
+
+    public CSharpWriterFactory(Model model, CSharpSettings settings) {
+      this.model = model;
+      this.settings = settings;
+    }
+
     @Override
     public CSharpWriter apply(String filename, String namespace) {
-      return new CSharpWriter(namespace);
+      var writer = new CSharpWriter(namespace);
+      writer.reserveModelNames(model, settings);
+      return writer;
     }
   }
 

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriter.java
@@ -8,17 +8,15 @@
  *  - Symbol with empty namespace: bare name (used for C# keyword primitives
  *    like `string`, `int`, etc.).
  *  - Local, unshadowed model types use their short name; other model types are qualified.
- *  - Framework references collect imports and fall back to global:: qualification on collision.
+ *  - External references collect imports and fall back to global:: qualification on collision.
  *  - Explicit SymbolReference aliases are preserved.
  */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
+import io.github.thomaslaich.nsmithy.csharp.codegen.SymbolProperties;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -33,19 +31,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclarations> {
 
   private final String namespace;
-  // Shape names and generated companions visible in the current or a parent namespace.
-  private final Set<String> modelTypeNames = new HashSet<>();
-  // Conservatively reserve segments from every model namespace, including unrelated ones.
-  private final Set<String> namespaceSegments = new HashSet<>();
-  private final Map<FrameworkReference, String> frameworkReferences = new LinkedHashMap<>();
-
-  private record FrameworkReference(String qualifiedName, boolean attribute) {}
-
-  // These generated nested types, members, and type parameters can hide model types.
-  private final Set<String> reservedNames =
-      new HashSet<>(
-          Set.of(
-              "Builder", "ValueSerializer", "Schema", "Unknown", "Value", "Tag", "T", "TWriter"));
 
   public CSharpWriter(String namespace) {
     super(new ImportDeclarations(namespace));
@@ -63,86 +48,12 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
 
   /** Reserve a generated identifier that can hide a type reference in this file. */
   public void reserveName(String name) {
-    reservedNames.add(name);
+    getImportContainer().reserveName(name);
   }
 
-  /** Include declarations that can shadow framework types even when this file never uses them. */
-  private void reserveModelNames(Model model, CSharpSettings settings) {
-    model
-        .shapes()
-        .filter(shape -> !shape.isMemberShape())
-        .forEach(
-            shape -> {
-              String ns = settings.csharpNamespace(shape.getId().getNamespace());
-              // Namespace segments can also hide imported types during C# name lookup.
-              namespaceSegments.addAll(java.util.List.of(ns.split("\\.")));
-              if (ns.equals(namespace) || namespace.startsWith(ns + ".")) {
-                String name = CSharpNaming.typeName(shape.getId().getName());
-                modelTypeNames.add(name);
-                modelTypeNames.add(name + "Schema");
-                if (shape.isServiceShape()) {
-                  modelTypeNames.add(name + "Client");
-                  modelTypeNames.add(name + "ClientConfig");
-                }
-              }
-            });
-  }
-
-  /**
-   * Return a stable reference token. Resolve it after the whole file has registered its names, so
-   * import decisions do not depend on emission order. Only explicit tokens are substituted;
-   * documentation and model string literals are never simplified.
-   */
-  public String frameworkType(String qualifiedName) {
-    return frameworkReference(qualifiedName, false);
-  }
-
-  /** Render an attribute with its conventional short form when that form is unambiguous. */
-  public String frameworkAttribute(String qualifiedName) {
-    return frameworkReference(qualifiedName, true);
-  }
-
-  private String frameworkReference(String qualifiedName, boolean attribute) {
-    return frameworkReferences.computeIfAbsent(
-        new FrameworkReference(qualifiedName, attribute),
-        ignored -> "\u0001framework" + frameworkReferences.size() + "\u0002");
-  }
-
-  private String renderFrameworkReferences(String body, Set<String> imports) {
-    for (var reference : frameworkReferences.entrySet()) {
-      String qualified = reference.getKey().qualifiedName();
-      int separator = qualified.lastIndexOf('.');
-      String ns = qualified.substring(0, separator);
-      String name = qualified.substring(separator + 1);
-      String shortName =
-          reference.getKey().attribute() && name.endsWith("Attribute")
-              ? name.substring(0, name.length() - 9)
-              : name;
-      boolean collision = hasFrameworkNameCollision(qualified, name, shortName);
-      String rendered = "global::" + qualified;
-      if (!collision) {
-        imports.add(ns);
-        rendered = shortName;
-      }
-      body = body.replace(reference.getValue(), rendered);
-    }
-    return body;
-  }
-
-  /** Check each source of shadowing for both the full name and attribute shorthand. */
-  private boolean hasFrameworkNameCollision(String qualifiedName, String name, String shortName) {
-    // Generated members, nested types, or type parameters can hide the reference.
-    if (reservedNames.contains(name) || reservedNames.contains(shortName)) return true;
-    // Model types and their generated companions can take precedence over imported types.
-    if (modelTypeNames.contains(name) || modelTypeNames.contains(shortName)) return true;
-    // Preserve the existing conservative policy for namespace segments.
-    if (namespaceSegments.contains(name) || namespaceSegments.contains(shortName)) return true;
-    // Distinct framework types sharing a simple name would make the imports ambiguous.
-    return frameworkReferences.keySet().stream()
-        .anyMatch(
-            other ->
-                !other.qualifiedName().equals(qualifiedName)
-                    && other.qualifiedName().endsWith("." + name));
+  /** Render an attribute symbol using its conventional shorthand when safe. */
+  public String attributeName(Symbol symbol) {
+    return typeName(symbol.toBuilder().putProperty(SymbolProperties.IS_ATTRIBUTE, true).build());
   }
 
   /** Reserve model member names before rendering references in the containing file. */
@@ -151,8 +62,8 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
         .members()
         .forEach(
             member -> {
-              reservedNames.add(CSharpNaming.propertyName(member.getMemberName()));
-              reservedNames.add(CSharpNaming.typeName(member.getMemberName()));
+              getImportContainer().reserveName(CSharpNaming.propertyName(member.getMemberName()));
+              getImportContainer().reserveName(CSharpNaming.typeName(member.getMemberName()));
             });
   }
 
@@ -163,14 +74,10 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
 
   /** The suffix refers to a generated companion type, such as a shape's schema class. */
   public String typeName(Symbol symbol, String suffix) {
-    String name = symbol.getName() + suffix;
-    String ns = symbol.getNamespace();
-    if (symbol.getDefinitionFile().isEmpty() && (ns.equals("System") || ns.startsWith("System."))) {
-      return frameworkType(ns + "." + name);
-    }
-    if (ns.isEmpty()) return name;
-    if (ns.equals(namespace) && !reservedNames.contains(name)) return name;
-    return "global::" + ns + "." + name;
+    Symbol reference =
+        suffix.isEmpty() ? symbol : symbol.toBuilder().name(symbol.getName() + suffix).build();
+    addUseImports(reference);
+    return getImportContainer().reference(reference, reference.getName());
   }
 
   /** Emits a C# XML documentation summary from a Smithy shape's documentation trait. */
@@ -195,10 +102,6 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
     writeXmlDocs((String) null, parameterDocs);
   }
 
-  private void writeXmlDocs(String summary) {
-    writeXmlDocs(summary, Map.of());
-  }
-
   public void writeXmlDocs(String summary, Map<String, String> parameterDocs) {
     boolean hasSummary = summary != null && !summary.isBlank();
     if (hasSummary) {
@@ -215,24 +118,6 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
           writeXmlText(documentation);
           write("/// </param>");
         });
-  }
-
-  private void writeXmlText(String text) {
-    for (String line : text.strip().split("\\R", -1)) {
-      if (line.isBlank()) {
-        write("///");
-      } else {
-        write("/// $L", escapeXml(line.strip()));
-      }
-    }
-  }
-
-  private static String escapeXml(String value) {
-    return value
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace("\"", "&quot;");
   }
 
   /** Factory used by WriterDelegator. */
@@ -255,16 +140,61 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
 
   @Override
   public String toString() {
-    Set<String> frameworkImports = new HashSet<>();
-    String body = renderFrameworkReferences(super.toString(), frameworkImports);
+    String body = getImportContainer().renderReferences(super.toString());
     StringBuilder sb = new StringBuilder();
     sb.append("// <auto-generated />\n");
     sb.append("// Generated by smithy-csharp-codegen. DO NOT EDIT.\n");
     sb.append("#nullable enable\n\n");
-    sb.append(getImportContainer().render(frameworkImports));
+    sb.append(getImportContainer().toString());
     sb.append("namespace ").append(namespace).append(";\n\n");
     sb.append(body);
     return sb.toString();
+  }
+
+  /** Include declarations that can shadow framework types even when this file never uses them. */
+  private void reserveModelNames(Model model, CSharpSettings settings) {
+    model
+        .shapes()
+        .filter(shape -> !shape.isMemberShape())
+        .forEach(
+            shape -> {
+              String ns = settings.csharpNamespace(shape.getId().getNamespace());
+              // Namespace segments can also hide imported types during C# name lookup.
+              for (String segment : ns.split("\\.")) {
+                getImportContainer().reserveNamespaceSegment(segment);
+              }
+              if (ns.equals(namespace) || namespace.startsWith(ns + ".")) {
+                String name = CSharpNaming.typeName(shape.getId().getName());
+                getImportContainer().reserveModelTypeName(name);
+                getImportContainer().reserveModelTypeName(name + "Schema");
+                if (shape.isServiceShape()) {
+                  getImportContainer().reserveModelTypeName(name + "Client");
+                  getImportContainer().reserveModelTypeName(name + "ClientConfig");
+                }
+              }
+            });
+  }
+
+  private void writeXmlDocs(String summary) {
+    writeXmlDocs(summary, Map.of());
+  }
+
+  private void writeXmlText(String text) {
+    for (String line : text.strip().split("\\R", -1)) {
+      if (line.isBlank()) {
+        write("///");
+      } else {
+        write("/// $L", escapeXml(line.strip()));
+      }
+    }
+  }
+
+  private static String escapeXml(String value) {
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;");
   }
 
   private final class CSharpSymbolFormatter implements BiFunction<Object, String, String> {
@@ -275,7 +205,7 @@ public final class CSharpWriter extends SymbolWriter<CSharpWriter, ImportDeclara
       }
       if (type instanceof SymbolReference ref) {
         addImport(ref.getSymbol(), ref.getAlias(), SymbolReference.ContextOption.USE);
-        return ref.getAlias();
+        return getImportContainer().reference(ref.getSymbol(), ref.getAlias());
       }
       throw new CodegenException("Invalid type for $T: " + type);
     }

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/ImportDeclarations.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/ImportDeclarations.java
@@ -40,11 +40,19 @@ public final class ImportDeclarations implements ImportContainer {
 
   @Override
   public String toString() {
-    if (imports.isEmpty()) {
+    return render(Set.of());
+  }
+
+  /** Combine explicit imports with the framework imports needed for this rendering. */
+  public String render(Set<String> additionalImports) {
+    Set<String> allImports = new TreeSet<>(imports);
+    allImports.addAll(additionalImports);
+    allImports.remove(currentNamespace);
+    if (allImports.isEmpty()) {
       return "";
     }
     StringBuilder sb = new StringBuilder();
-    for (String ns : imports) {
+    for (String ns : allImports) {
       sb.append("using ").append(ns).append(";\n");
     }
     sb.append('\n');

--- a/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/ImportDeclarations.java
+++ b/codegen/smithy-csharp-codegen/src/main/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/ImportDeclarations.java
@@ -1,14 +1,10 @@
-/*
- * Tracks `using` directives for a generated C# file. Implements ImportContainer
- * so it composes with SymbolWriter the same way ImportDeclarations does in
- * smithy-python / smithy-typescript.
- *
- * In addition to symbol-driven imports it also accepts raw namespace strings,
- * which generators use for runtime namespaces that have no Smithy symbol
- * (e.g. NSmithy.Server.AspNetCore, Microsoft.AspNetCore.Builder).
- */
+/* Tracks C# symbol references and their using directives. */
 package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
 
+import io.github.thomaslaich.nsmithy.csharp.codegen.SymbolProperties;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.ImportContainer;
@@ -17,9 +13,17 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
 public final class ImportDeclarations implements ImportContainer {
-
   private final String currentNamespace;
   private final Set<String> imports = new TreeSet<>();
+  private final Map<Reference, String> references = new LinkedHashMap<>();
+  // Shape names and generated companions visible in the current or a parent namespace.
+  private final Set<String> modelTypeNames = new HashSet<>();
+  // Conservatively reserve segments from every model namespace, including unrelated ones.
+  private final Set<String> namespaceSegments = new HashSet<>();
+  private final Set<String> reservedNames =
+      new HashSet<>(
+          Set.of(
+              "Builder", "ValueSerializer", "Schema", "Unknown", "Value", "Tag", "T", "TWriter"));
 
   public ImportDeclarations(String currentNamespace) {
     this.currentNamespace = currentNamespace;
@@ -27,35 +31,110 @@ public final class ImportDeclarations implements ImportContainer {
 
   @Override
   public void importSymbol(Symbol symbol, String alias) {
-    importNamespace(symbol.getNamespace());
+    references.computeIfAbsent(
+        new Reference(symbol, alias), ignored -> "\u0001symbol" + references.size() + "\u0002");
   }
 
-  /** Import a raw C# namespace (no symbol). */
+  /** Register a symbol now; decide its spelling once all file names are known. */
+  String reference(Symbol symbol, String alias) {
+    importSymbol(symbol, alias);
+    return references.get(new Reference(symbol, alias));
+  }
+
+  void reserveName(String name) {
+    reservedNames.add(name);
+  }
+
+  void reserveModelTypeName(String name) {
+    modelTypeNames.add(name);
+  }
+
+  void reserveNamespaceSegment(String name) {
+    namespaceSegments.add(name);
+  }
+
+  /** Import a raw C# namespace, including extension methods with no type reference. */
   public void importNamespace(String namespace) {
-    if (namespace == null || namespace.isEmpty() || namespace.equals(currentNamespace)) {
-      return;
+    if (namespace != null && !namespace.isEmpty() && !namespace.equals(currentNamespace)) {
+      imports.add(namespace);
     }
-    imports.add(namespace);
+  }
+
+  String renderReferences(String body) {
+    for (var entry : references.entrySet()) {
+      Reference reference = entry.getKey();
+      String rendered = reference.shortName();
+      if (usesQualifiedName(reference)) {
+        rendered = "global::" + reference.symbol().getFullName();
+      }
+      body = body.replace(entry.getValue(), rendered);
+    }
+    return body;
   }
 
   @Override
   public String toString() {
-    return render(Set.of());
+    Set<String> declarations = new TreeSet<>();
+    for (String namespace : imports) {
+      declarations.add(namespace);
+    }
+    for (Reference reference : references.keySet()) {
+      Symbol symbol = reference.symbol();
+      if (symbol.getNamespace().isEmpty() || usesQualifiedName(reference)) continue;
+      if (reference.isAlias()) {
+        declarations.add(reference.alias() + " = global::" + symbol.getFullName());
+      } else if (!symbol.getNamespace().equals(currentNamespace)) {
+        declarations.add(symbol.getNamespace());
+      }
+    }
+    return declarations.isEmpty()
+        ? ""
+        : "using " + String.join(";\nusing ", declarations) + ";\n\n";
   }
 
-  /** Combine explicit imports with the framework imports needed for this rendering. */
-  public String render(Set<String> additionalImports) {
-    Set<String> allImports = new TreeSet<>(imports);
-    allImports.addAll(additionalImports);
-    allImports.remove(currentNamespace);
-    if (allImports.isEmpty()) {
-      return "";
+  private boolean isReservedName(String name) {
+    return reservedNames.contains(name);
+  }
+
+  /** Check each source of shadowing for both the full name and attribute shorthand. */
+  private boolean hasNameCollision(Reference reference) {
+    String name = reference.alias();
+    String shortName = reference.shortName();
+    if (reservedNames.contains(name) || reservedNames.contains(shortName)) return true;
+    if (modelTypeNames.contains(name) || modelTypeNames.contains(shortName)) return true;
+    if (namespaceSegments.contains(name) || namespaceSegments.contains(shortName)) return true;
+    return references.keySet().stream()
+        .anyMatch(
+            other ->
+                !other.symbol().getFullName().equals(reference.symbol().getFullName())
+                    && (other.alias().equals(name) || other.shortName().equals(shortName)));
+  }
+
+  private boolean usesQualifiedName(Reference reference) {
+    Symbol symbol = reference.symbol();
+    String namespace = symbol.getNamespace();
+    if (namespace.isEmpty()) return false;
+    if (reference.isAlias()) return hasNameCollision(reference);
+    // Keep model references qualified outside their own namespace.
+    // External symbols can use namespace imports when their names are unambiguous.
+    if (!symbol.getDefinitionFile().isEmpty()) {
+      return !namespace.equals(currentNamespace) || isReservedName(symbol.getName());
     }
-    StringBuilder sb = new StringBuilder();
-    for (String ns : allImports) {
-      sb.append("using ").append(ns).append(";\n");
+    return hasNameCollision(reference);
+  }
+
+  private record Reference(Symbol symbol, String alias) {
+    boolean isAlias() {
+      return !alias.equals(symbol.getName());
     }
-    sb.append('\n');
-    return sb.toString();
+
+    String shortName() {
+      if (!isAlias()
+          && symbol.getProperty(SymbolProperties.IS_ATTRIBUTE, Boolean.class).orElse(false)
+          && alias.endsWith("Attribute")) {
+        return alias.substring(0, alias.length() - 9);
+      }
+      return alias;
+    }
   }
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/AiTraitsGeneratorTest.java
@@ -106,9 +106,11 @@ final class AiTraitsGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
 
     new OperationSchemaGenerator(context, writer, operation).run();
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -127,21 +127,21 @@ final class ClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.WatchOutput>"
+            "Task<global::Example.Example.Streaming.WatchOutput>"
                 + " WatchAsync(global::Example.Example.Streaming.WatchInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.UploadOutput>"
+            "Task<global::Example.Example.Streaming.UploadOutput>"
                 + " UploadAsync(global::Example.Example.Streaming.UploadInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.ChatOutput>"
+            "Task<global::Example.Example.Streaming.ChatOutput>"
                 + " ChatAsync(global::Example.Example.Streaming.ChatInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertFalse(generated.contains("ForOutputEventStreamOperation"), generated);
     assertFalse(generated.contains("Streaming operations are not wired"), generated);
@@ -435,7 +435,7 @@ final class ClientGeneratorTest {
     assertTrue(
         generated.contains(
             "new"
-                + " SmithyHttpVersionPreference(System.Net.HttpVersion.Version20,"
+                + " SmithyHttpVersionPreference(HttpVersion.Version20,"
                 + " allowDowngrade: true)"),
         generated);
   }
@@ -451,8 +451,7 @@ final class ClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "new SmithyHttpVersionPreference(System.Net.HttpVersion.Version20,"
-                + " allowDowngrade: true));"),
+            "new SmithyHttpVersionPreference(HttpVersion.Version20," + " allowDowngrade: true));"),
         generated);
     assertTrue(
         generated.indexOf("SmithyHttpClientEnvironment.ConfigureHttpClient(client,")
@@ -472,7 +471,7 @@ final class ClientGeneratorTest {
     assertTrue(
         generated.contains(
             "new"
-                + " SmithyHttpVersionPreference(System.Net.HttpVersion.Version20,"
+                + " SmithyHttpVersionPreference(HttpVersion.Version20,"
                 + " allowDowngrade: false)"),
         generated);
   }
@@ -567,9 +566,9 @@ final class ClientGeneratorTest {
     // Pages paginator: repeats the call while the response carries a token.
     assertTrue(
         generated.contains(
-            "System.Collections.Generic.IAsyncEnumerable<global::Example.Example.Pages.ListThingsOutput>"
+            "IAsyncEnumerable<global::Example.Example.Pages.ListThingsOutput>"
                 + " ListThingsPagesAsync(global::Example.Example.Pages.ListThingsInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(generated.contains("input = input with { NextToken = token };"), generated);
     assertTrue(generated.contains("while (token is not null)"), generated);
@@ -577,11 +576,20 @@ final class ClientGeneratorTest {
     // Items paginator: flattens the pages' list member.
     assertTrue(
         generated.contains(
-            "System.Collections.Generic.IAsyncEnumerable<global::Example.Example.Pages.Thing>"
+            "IAsyncEnumerable<global::Example.Example.Pages.Thing>"
                 + " ListThingsItemsAsync(global::Example.Example.Pages.ListThingsInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(generated.contains("foreach (var item in items.Values)"), generated);
+    assertTrue(generated.contains("using System.Collections.Generic;"), generated);
+    assertTrue(generated.contains("using System.Threading;"), generated);
+    assertTrue(generated.contains("using System.Runtime.CompilerServices;"), generated);
+    assertTrue(
+        generated.contains("[EnumeratorCancellation] CancellationToken cancellationToken"),
+        generated);
+    assertFalse(generated.contains("System.Collections.Generic.IAsyncEnumerable<"), generated);
+    assertFalse(
+        generated.contains("System.Threading.CancellationToken cancellationToken"), generated);
 
     // Unpaginated operations get no paginators.
     assertFalse(generated.contains("GetThingPagesAsync"), generated);

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -655,9 +655,11 @@ final class ClientGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter(writerNamespace);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", writerNamespace);
     var service = model.expectShape(ShapeId.from(serviceId), ServiceShape.class);
 
     new ClientGenerator(context, writer, service).run();
@@ -690,9 +692,11 @@ final class ClientGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter(writerNamespace);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", writerNamespace);
     var service = model.expectShape(ShapeId.from(serviceId), ServiceShape.class);
 
     new ClientDependencyInjectionGenerator(context, writer, service).run();

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -127,20 +127,20 @@ final class ClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.WatchOutput>"
-                + " WatchAsync(Example.Example.Streaming.WatchInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.WatchOutput>"
+                + " WatchAsync(global::Example.Example.Streaming.WatchInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.UploadOutput>"
-                + " UploadAsync(Example.Example.Streaming.UploadInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.UploadOutput>"
+                + " UploadAsync(global::Example.Example.Streaming.UploadInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.ChatOutput>"
-                + " ChatAsync(Example.Example.Streaming.ChatInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.ChatOutput>"
+                + " ChatAsync(global::Example.Example.Streaming.ChatInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertFalse(generated.contains("ForOutputEventStreamOperation"), generated);
@@ -148,8 +148,8 @@ final class ClientGeneratorTest {
     assertTrue(
         generated.contains(
             "private readonly"
-                + " SmithyOperationBinding<Example.Example.Streaming.WatchInput,"
-                + " Example.Example.Streaming.WatchOutput> WatchBinding;"));
+                + " SmithyOperationBinding<global::Example.Example.Streaming.WatchInput,"
+                + " global::Example.Example.Streaming.WatchOutput> WatchBinding;"));
     assertTrue(generated.contains("runtime.InvokeAsync(WatchBinding"), generated);
     assertFalse(generated.contains("SmithyEventStreamOperationInvoker"), generated);
   }
@@ -396,12 +396,12 @@ final class ClientGeneratorTest {
     assertTrue(
         generated.contains(
             "private readonly"
-                + " SmithyOperationBinding<Example.Example.Reststreaming.WatchInput,"
-                + " Example.Example.Reststreaming.WatchOutput> WatchBinding;"),
+                + " SmithyOperationBinding<global::Example.Example.Reststreaming.WatchInput,"
+                + " global::Example.Example.Reststreaming.WatchOutput> WatchBinding;"),
         generated);
     assertTrue(
         generated.contains(
-            "serviceProtocol.ForClientOperation(Example.Example.Reststreaming.WatchSchema.Schema)"),
+            "serviceProtocol.ForClientOperation(global::Example.Example.Reststreaming.WatchSchema.Schema)"),
         generated);
     assertTrue(generated.contains("runtime.InvokeAsync(WatchBinding"), generated);
     assertFalse(generated.contains("Event-stream operations are not supported"), generated);
@@ -490,14 +490,14 @@ final class ClientGeneratorTest {
     // ReadThing inherits the service's explicitly selected default.
     assertTrue(
         generated.contains(
-            "serviceProtocol.ForClientOperation(Example.Example.Auth.ReadThingSchema.Schema), new"
-                + " string[] { \"smithy.api#httpBearerAuth\" }, null);"),
+            "serviceProtocol.ForClientOperation(global::Example.Example.Auth.ReadThingSchema.Schema),"
+                + " new string[] { \"smithy.api#httpBearerAuth\" }, null);"),
         generated);
     // AdminThing's @auth trait overrides the service default.
     assertTrue(
         generated.contains(
-            "serviceProtocol.ForClientOperation(Example.Example.Auth.AdminThingSchema.Schema), new"
-                + " string[] { \"smithy.api#httpApiKeyAuth\" }, null);"),
+            "serviceProtocol.ForClientOperation(global::Example.Example.Auth.AdminThingSchema.Schema),"
+                + " new string[] { \"smithy.api#httpApiKeyAuth\" }, null);"),
         generated);
   }
 
@@ -567,8 +567,8 @@ final class ClientGeneratorTest {
     // Pages paginator: repeats the call while the response carries a token.
     assertTrue(
         generated.contains(
-            "System.Collections.Generic.IAsyncEnumerable<Example.Example.Pages.ListThingsOutput>"
-                + " ListThingsPagesAsync(Example.Example.Pages.ListThingsInput input,"
+            "System.Collections.Generic.IAsyncEnumerable<global::Example.Example.Pages.ListThingsOutput>"
+                + " ListThingsPagesAsync(global::Example.Example.Pages.ListThingsInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(generated.contains("input = input with { NextToken = token };"), generated);
@@ -577,8 +577,8 @@ final class ClientGeneratorTest {
     // Items paginator: flattens the pages' list member.
     assertTrue(
         generated.contains(
-            "System.Collections.Generic.IAsyncEnumerable<Example.Example.Pages.Thing>"
-                + " ListThingsItemsAsync(Example.Example.Pages.ListThingsInput input,"
+            "System.Collections.Generic.IAsyncEnumerable<global::Example.Example.Pages.Thing>"
+                + " ListThingsItemsAsync(global::Example.Example.Pages.ListThingsInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(generated.contains("foreach (var item in items.Values)"), generated);

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -621,8 +621,7 @@ final class ClientGeneratorTest {
             "com.amazonaws.glacier#Glacier",
             "Auxiliary.Com.Amazonaws.Glacier");
 
-    assertTrue(
-        generated.contains("Interceptors.Add(new NSmithy.Aws.GlacierInterceptor());"), generated);
+    assertTrue(generated.contains("Interceptors.Add(new GlacierInterceptor());"), generated);
   }
 
   private String renderClient() throws Exception {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ClientGeneratorTest.java
@@ -488,13 +488,15 @@ final class ClientGeneratorTest {
         generated);
     // ReadThing inherits the service's explicitly selected default.
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "serviceProtocol.ForClientOperation(global::Example.Example.Auth.ReadThingSchema.Schema),"
                 + " new string[] { \"smithy.api#httpBearerAuth\" }, null);"),
         generated);
     // AdminThing's @auth trait overrides the service default.
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "serviceProtocol.ForClientOperation(global::Example.Example.Auth.AdminThingSchema.Schema),"
                 + " new string[] { \"smithy.api#httpApiKeyAuth\" }, null);"),
         generated);
@@ -622,6 +624,10 @@ final class ClientGeneratorTest {
             "Auxiliary.Com.Amazonaws.Glacier");
 
     assertTrue(generated.contains("Interceptors.Add(new GlacierInterceptor());"), generated);
+  }
+
+  private static boolean containsIgnoringWhitespace(String actual, String expected) {
+    return actual.replaceAll("\\s+", "").contains(expected.replaceAll("\\s+", ""));
   }
 
   private String renderClient() throws Exception {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/DocumentationGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/DocumentationGeneratorTest.java
@@ -161,7 +161,9 @@ final class DocumentationGeneratorTest {
   private String renderStructure(String shapeId) throws Exception {
     var model = model();
     var context = context(model);
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new StructureGenerator(
             context, writer, model.expectShape(ShapeId.from(shapeId), StructureShape.class))
         .run();
@@ -170,7 +172,10 @@ final class DocumentationGeneratorTest {
 
   private String renderStringEnum(String shapeId) throws Exception {
     var model = model();
-    var writer = new CSharpWriter("Example.Weather");
+    var context = context(model);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new StringEnumGenerator(writer, model.expectShape(ShapeId.from(shapeId), EnumShape.class))
         .run();
     return writer.toString();
@@ -178,7 +183,10 @@ final class DocumentationGeneratorTest {
 
   private String renderIntEnum(String shapeId) throws Exception {
     var model = model();
-    var writer = new CSharpWriter("Example.Weather");
+    var context = context(model);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new IntEnumGenerator(writer, model.expectShape(ShapeId.from(shapeId), IntEnumShape.class))
         .run();
     return writer.toString();
@@ -187,7 +195,9 @@ final class DocumentationGeneratorTest {
   private String renderError(String shapeId) throws Exception {
     var model = model();
     var context = context(model);
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new ErrorGenerator(
             context, writer, model.expectShape(ShapeId.from(shapeId), StructureShape.class))
         .run();
@@ -197,7 +207,9 @@ final class DocumentationGeneratorTest {
   private String renderClient() throws Exception {
     var model = model();
     var context = context(model);
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new ClientGenerator(
             context,
             writer,
@@ -209,7 +221,9 @@ final class DocumentationGeneratorTest {
   private String renderServer() throws Exception {
     var model = model();
     var context = context(model);
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     new ServerGenerator(
             context,
             writer,
@@ -240,7 +254,7 @@ final class DocumentationGeneratorTest {
         .settings(settings)
         .symbolProvider(symbolProvider)
         .fileManifest(manifest)
-        .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+        .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
         .build();
   }
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
@@ -115,9 +115,11 @@ final class ErrorGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter("Example.Weather");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Weather");
     var shape = model.expectShape(ShapeId.from(shapeId), StructureShape.class);
 
     new ErrorGenerator(context, writer, shape).run();

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
@@ -64,7 +64,7 @@ final class ErrorGeneratorTest {
 
     assertTrue(
         throttling.contains(
-            "public sealed partial class ThrottlingError : System.Exception,"
+            "public sealed partial class ThrottlingError : Exception,"
                 + " NSmithy.Core.ISmithyRetryableError"),
         throttling);
     assertTrue(
@@ -81,8 +81,7 @@ final class ErrorGeneratorTest {
     String generated = renderError("example.weather#ValidationError");
 
     assertTrue(
-        generated.contains("public sealed partial class ValidationError : System.Exception"),
-        generated);
+        generated.contains("public sealed partial class ValidationError : Exception"), generated);
     assertFalse(generated.contains("ISmithyRetryableError"), generated);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
@@ -64,15 +64,12 @@ final class ErrorGeneratorTest {
 
     assertTrue(
         throttling.contains(
-            "public sealed partial class ThrottlingError : Exception,"
-                + " NSmithy.Core.ISmithyRetryableError"),
+            "public sealed partial class ThrottlingError : Exception," + " ISmithyRetryableError"),
         throttling);
     assertTrue(
-        throttling.contains("bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => true;"),
-        throttling);
+        throttling.contains("bool ISmithyRetryableError.IsThrottlingError => true;"), throttling);
     assertTrue(
-        transientError.contains(
-            "bool NSmithy.Core.ISmithyRetryableError.IsThrottlingError => false;"),
+        transientError.contains("bool ISmithyRetryableError.IsThrottlingError => false;"),
         transientError);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ErrorGeneratorTest.java
@@ -93,7 +93,7 @@ final class ErrorGeneratorTest {
     assertTrue(
         generated.contains(
             "private sealed class ValueSerializer :"
-                + " IStructValueSerializer<Example.Example.Weather.ValidationError>"),
+                + " IStructValueSerializer<global::Example.Example.Weather.ValidationError>"),
         generated);
     assertTrue(generated.contains("writer.WriteMember<string?>(0, value.Message);"), generated);
     assertTrue(generated.contains("new ValueSerializer())"), generated);

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
@@ -229,9 +229,11 @@ final class FakeClientGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter("Example.Example.Fake");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Example.Fake");
     var service = model.expectShape(ShapeId.from("example.fake#Fakeable"), ServiceShape.class);
 
     new FakeClientGenerator(context, writer, service).run();

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
@@ -114,8 +114,8 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual"
-                + " System.Threading.Tasks.Task<Example.Example.Fake.GetCityOutput>"
-                + " GetCityAsync(Example.Example.Fake.GetCityInput input,"
+                + " System.Threading.Tasks.Task<GetCityOutput>"
+                + " GetCityAsync(GetCityInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default)"),
         generated);
     assertTrue(generated.contains("public virtual void Dispose() { }"), generated);
@@ -127,8 +127,9 @@ final class FakeClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new Example.Example.Fake.GetCityOutput("
-                + "Name: \"Zurich\", Population: 400000));"),
+            "return System.Threading.Tasks.Task.FromResult(new"
+                + " GetCityOutput(Name: \"Zurich\", Population:"
+                + " 400000));"),
         generated);
   }
 
@@ -138,14 +139,14 @@ final class FakeClientGeneratorTest {
 
     assertTrue(generated.contains("if (MatchesGetCityExample0(input))"), generated);
     assertTrue(
-        generated.contains(
-            "private static bool MatchesGetCityExample1(Example.Example.Fake.GetCityInput input)"),
+        generated.contains("private static bool MatchesGetCityExample1(GetCityInput" + " input)"),
         generated);
     assertTrue(generated.contains("if (!(input.Id == \"nope\"))"), generated);
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromException<Example.Example.Fake.GetCityOutput>("
-                + "new Example.Example.Fake.NoSuchCity(message: \"unknown city\"));"),
+            "return"
+                + " System.Threading.Tasks.Task.FromException<GetCityOutput>(new"
+                + " NoSuchCity(message: \"unknown city\"));"),
         generated);
   }
 
@@ -156,8 +157,8 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual async"
-                + " System.Collections.Generic.IAsyncEnumerable<Example.Example.Fake.ListCitiesOutput>"
-                + " ListCitiesPagesAsync(Example.Example.Fake.ListCitiesInput input,"
+                + " System.Collections.Generic.IAsyncEnumerable<ListCitiesOutput>"
+                + " ListCitiesPagesAsync(ListCitiesInput input,"
                 + " [System.Runtime.CompilerServices.EnumeratorCancellation]"
                 + " System.Threading.CancellationToken cancellationToken = default)"),
         generated);
@@ -176,8 +177,8 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual async"
-                + " System.Collections.Generic.IAsyncEnumerable<Example.Example.Fake.CitySummary>"
-                + " ListCitiesItemsAsync(Example.Example.Fake.ListCitiesInput input,"
+                + " System.Collections.Generic.IAsyncEnumerable<CitySummary>"
+                + " ListCitiesItemsAsync(ListCitiesInput input,"
                 + " [System.Runtime.CompilerServices.EnumeratorCancellation]"
                 + " System.Threading.CancellationToken cancellationToken = default)"),
         generated);
@@ -206,13 +207,11 @@ final class FakeClientGeneratorTest {
   void eventStreamOutputsYieldFromGeneratedAsyncIterator() throws Exception {
     String generated = renderFake();
 
-    assertTrue(
-        generated.contains("new Example.Example.Fake.WatchOutput(Events: FakeWatchEventsEvents())"),
-        generated);
+    assertTrue(generated.contains("new WatchOutput(Events: FakeWatchEventsEvents())"), generated);
     assertTrue(
         generated.contains(
             "private static async"
-                + " System.Collections.Generic.IAsyncEnumerable<Example.Example.Fake.ChatEvent>"
+                + " System.Collections.Generic.IAsyncEnumerable<ChatEvent>"
                 + " FakeWatchEventsEvents()"),
         generated);
   }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
@@ -114,9 +114,9 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual"
-                + " System.Threading.Tasks.Task<GetCityOutput>"
+                + " Task<GetCityOutput>"
                 + " GetCityAsync(GetCityInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default)"),
+                + " CancellationToken cancellationToken = default)"),
         generated);
     assertTrue(generated.contains("public virtual void Dispose() { }"), generated);
   }
@@ -127,7 +127,7 @@ final class FakeClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new"
+            "return Task.FromResult(new"
                 + " GetCityOutput(Name: \"Zurich\", Population:"
                 + " 400000));"),
         generated);
@@ -145,7 +145,7 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "return"
-                + " System.Threading.Tasks.Task.FromException<GetCityOutput>(new"
+                + " Task.FromException<GetCityOutput>(new"
                 + " NoSuchCity(message: \"unknown city\"));"),
         generated);
   }
@@ -157,10 +157,10 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual async"
-                + " System.Collections.Generic.IAsyncEnumerable<ListCitiesOutput>"
+                + " IAsyncEnumerable<ListCitiesOutput>"
                 + " ListCitiesPagesAsync(ListCitiesInput input,"
-                + " [System.Runtime.CompilerServices.EnumeratorCancellation]"
-                + " System.Threading.CancellationToken cancellationToken = default)"),
+                + " [EnumeratorCancellation]"
+                + " CancellationToken cancellationToken = default)"),
         generated);
     assertTrue(
         generated.contains(
@@ -177,10 +177,10 @@ final class FakeClientGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual async"
-                + " System.Collections.Generic.IAsyncEnumerable<CitySummary>"
+                + " IAsyncEnumerable<CitySummary>"
                 + " ListCitiesItemsAsync(ListCitiesInput input,"
-                + " [System.Runtime.CompilerServices.EnumeratorCancellation]"
-                + " System.Threading.CancellationToken cancellationToken = default)"),
+                + " [EnumeratorCancellation]"
+                + " CancellationToken cancellationToken = default)"),
         generated);
     assertTrue(
         generated.contains(
@@ -197,10 +197,9 @@ final class FakeClientGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "public virtual System.Threading.Tasks.Task"
-                + " PingAsync(System.Threading.CancellationToken cancellationToken = default)"),
+            "public virtual Task" + " PingAsync(CancellationToken cancellationToken = default)"),
         generated);
-    assertTrue(generated.contains("return System.Threading.Tasks.Task.CompletedTask;"), generated);
+    assertTrue(generated.contains("return Task.CompletedTask;"), generated);
   }
 
   @Test
@@ -210,9 +209,7 @@ final class FakeClientGeneratorTest {
     assertTrue(generated.contains("new WatchOutput(Events: FakeWatchEventsEvents())"), generated);
     assertTrue(
         generated.contains(
-            "private static async"
-                + " System.Collections.Generic.IAsyncEnumerable<ChatEvent>"
-                + " FakeWatchEventsEvents()"),
+            "private static async" + " IAsyncEnumerable<ChatEvent>" + " FakeWatchEventsEvents()"),
         generated);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeClientGeneratorTest.java
@@ -183,7 +183,8 @@ final class FakeClientGeneratorTest {
                 + " CancellationToken cancellationToken = default)"),
         generated);
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "await foreach (var page in ListCitiesPagesAsync(input,"
                 + " cancellationToken).ConfigureAwait(false))"),
         generated);
@@ -211,6 +212,10 @@ final class FakeClientGeneratorTest {
         generated.contains(
             "private static async" + " IAsyncEnumerable<ChatEvent>" + " FakeWatchEventsEvents()"),
         generated);
+  }
+
+  private static boolean containsIgnoringWhitespace(String actual, String expected) {
+    return actual.replaceAll("\\s+", "").contains(expected.replaceAll("\\s+", ""));
   }
 
   private String renderFake() throws Exception {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
@@ -323,9 +323,11 @@ final class FakeHandlerGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter("Example.Example.Fake");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Example.Fake");
     var service = model.expectShape(ShapeId.from("example.fake#Fakeable"), ServiceShape.class);
 
     new FakeHandlerGenerator(context, writer, service).run();

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
@@ -179,8 +179,8 @@ final class FakeHandlerGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual"
-                + " System.Threading.Tasks.Task<Example.Example.Fake.GetCityOutput>"
-                + " GetCityAsync(Example.Example.Fake.GetCityInput input,"
+                + " System.Threading.Tasks.Task<GetCityOutput>"
+                + " GetCityAsync(GetCityInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default)"),
         generated);
     assertFalse(generated.contains("AddFakeFakeableServiceHandler"), generated);
@@ -192,9 +192,10 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new Example.Example.Fake.GetCityOutput("
-                + "Name: \"Zurich\", Population: 400000, Tags: new Example.Example.Fake.TagList("
-                + "new string[] { \"alpine\" })));"),
+            "return System.Threading.Tasks.Task.FromResult(new"
+                + " GetCityOutput(Name: \"Zurich\", Population:"
+                + " 400000, Tags: new TagList(new string[] {"
+                + " \"alpine\" })));"),
         generated);
     assertFalse(generated.contains("GetCityOutput(Name: \"Zurich\", Mood:"), generated);
   }
@@ -205,11 +206,11 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "new Example.Example.Fake.GetStatusOutput(Label: \"label\","
-                + " Attrs: new Example.Example.Fake.AttrMap(new"
+            "new GetStatusOutput(Label: \"label\","
+                + " Attrs: new AttrMap(new"
                 + " System.Collections.Generic.Dictionary<string, string> { { \"key\", \"value\" }"
-                + " }), Choice: Example.Example.Fake.Choice.FromNum(0), Code: \"codexx\","
-                + " Count: 5, Mood: Example.Example.Fake.Mood.HAPPY,"
+                + " }), Choice: Choice.FromNum(0), Code: \"codexx\","
+                + " Count: 5, Mood: Mood.HAPPY,"
                 + " When: System.DateTimeOffset.FromUnixTimeSeconds(1704067200))"),
         generated);
   }
@@ -220,11 +221,12 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "new Example.Example.Fake.GetTreeOutput(Root: new Example.Example.Fake.TreeNode("
-                + "Id: \"id\", Children: new Example.Example.Fake.TreeList("
-                + "System.Array.Empty<Example.Example.Fake.TreeNode>())))"),
+            "new GetTreeOutput(Root: new"
+                + " TreeNode(Id: \"id\", Children: new"
+                + " TreeList("
+                + "System.Array.Empty<TreeNode>())))"),
         generated);
-    assertFalse(generated.contains("Child: new Example.Example.Fake.TreeNode"), generated);
+    assertFalse(generated.contains("Child: new TreeNode"), generated);
   }
 
   @Test
@@ -243,19 +245,16 @@ final class FakeHandlerGeneratorTest {
   void eventStreamOutputsYieldFromGeneratedAsyncIterator() throws Exception {
     String generated = renderFake();
 
-    assertTrue(
-        generated.contains("new Example.Example.Fake.WatchOutput(Events: FakeWatchEventsEvents())"),
-        generated);
+    assertTrue(generated.contains("new WatchOutput(Events: FakeWatchEventsEvents())"), generated);
     assertTrue(
         generated.contains(
             "private static async"
-                + " System.Collections.Generic.IAsyncEnumerable<Example.Example.Fake.ChatEvent>"
+                + " System.Collections.Generic.IAsyncEnumerable<ChatEvent>"
                 + " FakeWatchEventsEvents()"),
         generated);
     assertTrue(
         generated.contains(
-            "yield return Example.Example.Fake.ChatEvent.FromMessage(new"
-                + " Example.Example.Fake.MessageEvent(Text: \"text\"));"),
+            "yield return ChatEvent.FromMessage(new" + " MessageEvent(Text: \"text\"));"),
         generated);
   }
 
@@ -267,21 +266,20 @@ final class FakeHandlerGeneratorTest {
     assertTrue(generated.contains("if (MatchesLookupExample1(input))"), generated);
     assertTrue(generated.contains("if (MatchesLookupExample2(input))"), generated);
     assertTrue(
-        generated.contains(
-            "private static bool MatchesLookupExample0(Example.Example.Fake.LookupInput input)"),
+        generated.contains("private static bool MatchesLookupExample0(LookupInput" + " input)"),
         generated);
     assertTrue(generated.contains("if (!(input.Query == \"zrh\"))"), generated);
     assertTrue(generated.contains("if (!(input.Limit == 1))"), generated);
     assertTrue(
         generated.contains(
             "return System.Threading.Tasks.Task.FromResult(new"
-                + " Example.Example.Fake.LookupOutput(Label: \"Filtered\"));"),
+                + " LookupOutput(Label: \"Filtered\"));"),
         generated);
     // The fallback stays the first non-error example output.
     assertTrue(
         generated.contains(
             "return System.Threading.Tasks.Task.FromResult(new"
-                + " Example.Example.Fake.LookupOutput(Label: \"Zurich\"));"),
+                + " LookupOutput(Label: \"Zurich\"));"),
         generated);
   }
 
@@ -302,9 +300,10 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromException<Example.Example.Fake.LookupOutput>("
-                + "new Example.Example.Fake.LookupError(message: \"no such city\","
-                + " hint: \"try zrh\"));"),
+            "return"
+                + " System.Threading.Tasks.Task.FromException<LookupOutput>(new"
+                + " LookupError(message: \"no such city\", hint: \"try"
+                + " zrh\"));"),
         generated);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/FakeHandlerGeneratorTest.java
@@ -179,9 +179,9 @@ final class FakeHandlerGeneratorTest {
     assertTrue(
         generated.contains(
             "public virtual"
-                + " System.Threading.Tasks.Task<GetCityOutput>"
+                + " Task<GetCityOutput>"
                 + " GetCityAsync(GetCityInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default)"),
+                + " CancellationToken cancellationToken = default)"),
         generated);
     assertFalse(generated.contains("AddFakeFakeableServiceHandler"), generated);
   }
@@ -192,7 +192,7 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new"
+            "return Task.FromResult(new"
                 + " GetCityOutput(Name: \"Zurich\", Population:"
                 + " 400000, Tags: new TagList(new string[] {"
                 + " \"alpine\" })));"),
@@ -208,10 +208,10 @@ final class FakeHandlerGeneratorTest {
         generated.contains(
             "new GetStatusOutput(Label: \"label\","
                 + " Attrs: new AttrMap(new"
-                + " System.Collections.Generic.Dictionary<string, string> { { \"key\", \"value\" }"
+                + " Dictionary<string, string> { { \"key\", \"value\" }"
                 + " }), Choice: Choice.FromNum(0), Code: \"codexx\","
                 + " Count: 5, Mood: Mood.HAPPY,"
-                + " When: System.DateTimeOffset.FromUnixTimeSeconds(1704067200))"),
+                + " When: DateTimeOffset.FromUnixTimeSeconds(1704067200))"),
         generated);
   }
 
@@ -224,7 +224,7 @@ final class FakeHandlerGeneratorTest {
             "new GetTreeOutput(Root: new"
                 + " TreeNode(Id: \"id\", Children: new"
                 + " TreeList("
-                + "System.Array.Empty<TreeNode>())))"),
+                + "Array.Empty<TreeNode>())))"),
         generated);
     assertFalse(generated.contains("Child: new TreeNode"), generated);
   }
@@ -235,10 +235,9 @@ final class FakeHandlerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "public virtual System.Threading.Tasks.Task"
-                + " PingAsync(System.Threading.CancellationToken cancellationToken = default)"),
+            "public virtual Task" + " PingAsync(CancellationToken cancellationToken = default)"),
         generated);
-    assertTrue(generated.contains("return System.Threading.Tasks.Task.CompletedTask;"), generated);
+    assertTrue(generated.contains("return Task.CompletedTask;"), generated);
   }
 
   @Test
@@ -248,9 +247,7 @@ final class FakeHandlerGeneratorTest {
     assertTrue(generated.contains("new WatchOutput(Events: FakeWatchEventsEvents())"), generated);
     assertTrue(
         generated.contains(
-            "private static async"
-                + " System.Collections.Generic.IAsyncEnumerable<ChatEvent>"
-                + " FakeWatchEventsEvents()"),
+            "private static async" + " IAsyncEnumerable<ChatEvent>" + " FakeWatchEventsEvents()"),
         generated);
     assertTrue(
         generated.contains(
@@ -271,15 +268,11 @@ final class FakeHandlerGeneratorTest {
     assertTrue(generated.contains("if (!(input.Query == \"zrh\"))"), generated);
     assertTrue(generated.contains("if (!(input.Limit == 1))"), generated);
     assertTrue(
-        generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new"
-                + " LookupOutput(Label: \"Filtered\"));"),
+        generated.contains("return Task.FromResult(new" + " LookupOutput(Label: \"Filtered\"));"),
         generated);
     // The fallback stays the first non-error example output.
     assertTrue(
-        generated.contains(
-            "return System.Threading.Tasks.Task.FromResult(new"
-                + " LookupOutput(Label: \"Zurich\"));"),
+        generated.contains("return Task.FromResult(new" + " LookupOutput(Label: \"Zurich\"));"),
         generated);
   }
 
@@ -301,7 +294,7 @@ final class FakeHandlerGeneratorTest {
     assertTrue(
         generated.contains(
             "return"
-                + " System.Threading.Tasks.Task.FromException<LookupOutput>(new"
+                + " Task.FromException<LookupOutput>(new"
                 + " LookupError(message: \"no such city\", hint: \"try"
                 + " zrh\"));"),
         generated);

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/SchemaGeneratorTest.java
@@ -16,7 +16,7 @@ final class SchemaGeneratorTest {
 
     CodegenException ex =
         assertThrows(
-            CodegenException.class, () -> SchemaGenerator.shapeSchemaAccessor(null, shape));
+            CodegenException.class, () -> SchemaGenerator.shapeSchemaAccessor(null, null, shape));
 
     assertTrue(
         ex.getMessage().contains("Unsupported Smithy prelude schema shape smithy.api#Unsupported"),

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -534,9 +534,11 @@ final class ServerGeneratorTest {
             .settings(settings)
             .symbolProvider(symbolProvider)
             .fileManifest(manifest)
-            .writerDelegator(new CSharpDelegator(manifest, symbolProvider))
+            .writerDelegator(new CSharpDelegator(manifest, symbolProvider, model, settings))
             .build();
-    var writer = new CSharpWriter(writerNamespace);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", writerNamespace);
     var service = model.expectShape(ShapeId.from(serviceId), ServiceShape.class);
 
     new ServerGenerator(context, writer, service).run();

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -321,21 +321,21 @@ final class ServerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.WatchOutput>"
+            "Task<global::Example.Example.Streaming.WatchOutput>"
                 + " WatchAsync(global::Example.Example.Streaming.WatchInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.UploadOutput>"
+            "Task<global::Example.Example.Streaming.UploadOutput>"
                 + " UploadAsync(global::Example.Example.Streaming.UploadInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<global::Example.Example.Streaming.ChatOutput>"
+            "Task<global::Example.Example.Streaming.ChatOutput>"
                 + " ChatAsync(global::Example.Example.Streaming.ChatInput input,"
-                + " System.Threading.CancellationToken cancellationToken = default);"),
+                + " CancellationToken cancellationToken = default);"),
         generated);
     assertFalse(generated.contains("IEventStreamServiceProtocol"));
     // Streaming endpoints delegate to the shared runtime path; only request-body streaming is

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -321,20 +321,20 @@ final class ServerGeneratorTest {
 
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.WatchOutput>"
-                + " WatchAsync(Example.Example.Streaming.WatchInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.WatchOutput>"
+                + " WatchAsync(global::Example.Example.Streaming.WatchInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.UploadOutput>"
-                + " UploadAsync(Example.Example.Streaming.UploadInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.UploadOutput>"
+                + " UploadAsync(global::Example.Example.Streaming.UploadInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertTrue(
         generated.contains(
-            "System.Threading.Tasks.Task<Example.Example.Streaming.ChatOutput>"
-                + " ChatAsync(Example.Example.Streaming.ChatInput input,"
+            "System.Threading.Tasks.Task<global::Example.Example.Streaming.ChatOutput>"
+                + " ChatAsync(global::Example.Example.Streaming.ChatInput input,"
                 + " System.Threading.CancellationToken cancellationToken = default);"),
         generated);
     assertFalse(generated.contains("IEventStreamServiceProtocol"));
@@ -466,13 +466,14 @@ final class ServerGeneratorTest {
     assertTrue(generated.contains("draft/2020-12/schema"), generated);
     assertTrue(
         generated.contains(
-            "ServiceOperation.Create(Example.Example.Catalog.NotifySchema.Schema, async (input, ct)"
-                + " => { await notifyHandler.NotifyAsync(input, ct).ConfigureAwait(false); return"
-                + " SmithyUnit.Value; }, NotifyJsonSchemas.Value),"),
+            "ServiceOperation.Create(global::Example.Example.Catalog.NotifySchema.Schema, async"
+                + " (input, ct) => { await notifyHandler.NotifyAsync(input,"
+                + " ct).ConfigureAwait(false); return SmithyUnit.Value; },"
+                + " NotifyJsonSchemas.Value),"),
         generated);
     assertTrue(
         generated.contains(
-            "ServiceOperation.Create(Example.Example.Catalog.PingSchema.Schema, "
+            "ServiceOperation.Create(global::Example.Example.Catalog.PingSchema.Schema, "
                 + "(_, ct) => pingHandler.PingAsync(ct), PingJsonSchemas.Value),"),
         generated);
   }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/ServerGeneratorTest.java
@@ -344,7 +344,8 @@ final class ServerGeneratorTest {
     assertTrue(generated.contains("UploadGrpcProtocol, handler.UploadAsync, true"), generated);
     assertTrue(generated.contains("ChatGrpcProtocol, handler.ChatAsync, true"), generated);
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "public static IEndpointRouteBuilder MapStreamingService(this IEndpointRouteBuilder"
                 + " endpoints, StreamingServiceProtocols protocols ="
                 + " StreamingServiceProtocols.Grpc)"),
@@ -381,7 +382,8 @@ final class ServerGeneratorTest {
     assertTrue(generated.contains("RestJson1 = 1,"), generated);
     assertTrue(generated.contains("All = RestJson1,"), generated);
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "public static IEndpointRouteBuilder MapStreamingService(this IEndpointRouteBuilder"
                 + " endpoints, StreamingServiceProtocols protocols ="
                 + " StreamingServiceProtocols.RestJson1)"),
@@ -410,7 +412,8 @@ final class ServerGeneratorTest {
     assertTrue(generated.contains("RestJson1 = 4,"), generated);
     assertTrue(generated.contains("All = RpcV2Cbor | SimpleRestJson | RestJson1,"), generated);
     assertTrue(
-        generated.contains(
+        containsIgnoringWhitespace(
+            generated,
             "public static IEndpointRouteBuilder MapMultiService(this IEndpointRouteBuilder"
                 + " endpoints, MultiServiceProtocols protocols = MultiServiceProtocols.RpcV2Cbor)"),
         generated);
@@ -497,6 +500,10 @@ final class ServerGeneratorTest {
         generated.contains("new ServicePromptArgumentDefinition(\"second\", null, false)"),
         generated);
     assertTrue(generated.contains("\"operation_brief\""), generated);
+  }
+
+  private static boolean containsIgnoringWhitespace(String actual, String expected) {
+    return actual.replaceAll("\\s+", "").contains(expected.replaceAll("\\s+", ""));
   }
 
   private String renderServer() throws Exception {

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
@@ -46,7 +46,9 @@ final class TypeNameGeneratorTest {
   @Test
   void shortensLocalTypesAndSchemaAccessorsWithoutChangingDocumentation() {
     var context = context();
-    var writer = new CSharpWriter("Example.Library");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Library");
     new StructureGenerator(
             context,
             writer,
@@ -74,7 +76,9 @@ final class TypeNameGeneratorTest {
   @Test
   void qualifiesTypesHiddenByUnionVariantsAndTypeParameters() {
     var context = context();
-    var writer = new CSharpWriter("Example.Library");
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(context.model(), context.settings())
+            .apply("test.g.cs", "Example.Library");
     new UnionGenerator(
             context,
             writer,
@@ -112,7 +116,7 @@ final class TypeNameGeneratorTest {
         .settings(settings)
         .symbolProvider(symbols)
         .fileManifest(manifest)
-        .writerDelegator(new CSharpDelegator(manifest, symbols))
+        .writerDelegator(new CSharpDelegator(manifest, symbols, model, settings))
         .build();
   }
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
@@ -1,0 +1,118 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.generators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSymbolProvider;
+import io.github.thomaslaich.nsmithy.csharp.codegen.GenerationContext;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpDelegator;
+import io.github.thomaslaich.nsmithy.csharp.codegen.writer.CSharpWriter;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+final class TypeNameGeneratorTest {
+  @TempDir Path tempDir;
+
+  private static final String MODEL =
+      """
+      $version: "2"
+      namespace example.library
+
+      /// Example.Library.DeleteBookInput stays qualified in documentation.
+      structure DeleteBookInput {
+          item: Book
+          other: example.other#Book
+          helper: Builder
+          serializer: ValueSerializer
+      }
+      structure Book {}
+      structure Builder {}
+      structure ValueSerializer {}
+      structure T {}
+      union Choice {
+          book: Book
+          generic: T
+      }
+      """;
+
+  @Test
+  void shortensLocalTypesAndSchemaAccessorsWithoutChangingDocumentation() {
+    var context = context();
+    var writer = new CSharpWriter("Example.Library");
+    new StructureGenerator(
+            context,
+            writer,
+            context
+                .model()
+                .expectShape(ShapeId.from("example.library#DeleteBookInput"), StructureShape.class))
+        .run();
+    String generated = writer.toString();
+    assertTrue(generated.contains("Schema<DeleteBookInput> Schema"), generated);
+    assertTrue(generated.contains("Book? Item"), generated);
+    assertTrue(generated.contains("BookSchema.Schema!"), generated);
+    assertTrue(generated.contains("global::Example.Other.Book? Other"), generated);
+    assertTrue(generated.contains("global::Example.Other.BookSchema.Schema!"), generated);
+    assertTrue(generated.contains("global::Example.Library.Builder? Helper"), generated);
+    assertTrue(
+        generated.contains("global::Example.Library.ValueSerializer? Serializer"), generated);
+    assertTrue(
+        generated.contains("/// Example.Library.DeleteBookInput stays qualified in documentation."),
+        generated);
+    assertFalse(generated.contains("global::Example.Library.Book"), generated);
+    assertFalse(generated.contains("Example.Library.DeleteBookInput>"), generated);
+    assertFalse(generated.contains("using Example.Other;"), generated);
+  }
+
+  @Test
+  void qualifiesTypesHiddenByUnionVariantsAndTypeParameters() {
+    var context = context();
+    var writer = new CSharpWriter("Example.Library");
+    new UnionGenerator(
+            context,
+            writer,
+            context.model().expectShape(ShapeId.from("example.library#Choice"), UnionShape.class))
+        .run();
+    String generated = writer.toString();
+    assertTrue(generated.contains("public Book(global::Example.Library.Book value)"), generated);
+    assertTrue(generated.contains("System.Func<global::Example.Library.T, T>"), generated);
+    assertTrue(generated.contains("Schema<Choice> Schema"), generated);
+  }
+
+  private GenerationContext context() {
+    var model =
+        Model.assembler()
+            .addUnparsedModel("local.smithy", MODEL)
+            .addUnparsedModel(
+                "other.smithy",
+                """
+                $version: "2"
+                namespace example.other
+                structure Book {}
+                """)
+            .assemble()
+            .unwrap();
+    var settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder()
+                .withMember("service", "example.library#Library")
+                .withMember("baseNamespace", "")
+                .build());
+    var symbols = new CSharpSymbolProvider(model, settings);
+    var manifest = FileManifest.create(tempDir);
+    return GenerationContext.builder()
+        .model(model)
+        .settings(settings)
+        .symbolProvider(symbols)
+        .fileManifest(manifest)
+        .writerDelegator(new CSharpDelegator(manifest, symbols))
+        .build();
+  }
+}

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/generators/TypeNameGeneratorTest.java
@@ -82,7 +82,7 @@ final class TypeNameGeneratorTest {
         .run();
     String generated = writer.toString();
     assertTrue(generated.contains("public Book(global::Example.Library.Book value)"), generated);
-    assertTrue(generated.contains("System.Func<global::Example.Library.T, T>"), generated);
+    assertTrue(generated.contains("Func<global::Example.Library.T, T>"), generated);
     assertTrue(generated.contains("Schema<Choice> Schema"), generated);
   }
 

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
@@ -100,8 +100,8 @@ final class CSharpWriterTest {
     var settings =
         CSharpSettings.fromNode(
             ObjectNode.builder().withMember("service", "example.library#Http").build());
-    var writer = new CSharpWriter("Example.Library");
-    writer.reserveModelNames(model, settings);
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(model, settings).apply("test.g.cs", "Example.Library");
     writer.write(
         "public $L Read($L token, $L client);",
         writer.frameworkType("System.Threading.Tasks.Task"),

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
@@ -112,4 +112,48 @@ final class CSharpWriterTest {
     assertTrue(generated.contains("global::System.Threading.CancellationToken token"), generated);
     assertTrue(generated.contains("global::System.Net.Http.HttpClient client"), generated);
   }
+
+  @Test
+  void unrelatedNamespaceSegmentsRemainReservedButUnrelatedTypeNamesDoNot() {
+    var model =
+        Model.assembler()
+            .addUnparsedModel(
+                "task.smithy",
+                """
+                $version: "2"
+                namespace unrelated.task
+                structure CancellationToken {}
+                """)
+            .addUnparsedModel(
+                "attribute.smithy",
+                """
+                $version: "2"
+                namespace unrelated.enumeratorCancellation
+                structure Placeholder {}
+                """)
+            .assemble()
+            .unwrap();
+    var settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder().withMember("service", "example.library#Library").build());
+    var writer =
+        new CSharpWriter.CSharpWriterFactory(model, settings).apply("test.g.cs", "Example.Library");
+    writer.write(
+        "public $L Read([$L] $L token);",
+        writer.frameworkType("System.Threading.Tasks.Task"),
+        writer.frameworkAttribute(
+            "System.Runtime.CompilerServices.EnumeratorCancellationAttribute"),
+        writer.frameworkType("System.Threading.CancellationToken"));
+    String generated = writer.toString();
+    assertTrue(generated.contains("global::System.Threading.Tasks.Task Read("), generated);
+    assertTrue(
+        generated.contains(
+            "[global::System.Runtime.CompilerServices.EnumeratorCancellationAttribute]"),
+        generated);
+    assertTrue(generated.contains("CancellationToken token"), generated);
+    assertTrue(generated.contains("using System.Threading;"), generated);
+    assertFalse(generated.contains("global::System.Threading.CancellationToken"), generated);
+    assertFalse(generated.contains("using System.Threading.Tasks;"), generated);
+    assertFalse(generated.contains("using System.Runtime.CompilerServices;"), generated);
+  }
 }

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
@@ -1,0 +1,115 @@
+package io.github.thomaslaich.nsmithy.csharp.codegen.writer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
+import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+
+final class CSharpWriterTest {
+  @Test
+  void importsFrameworkTypesWithoutRewritingLiteralText() {
+    var writer = new CSharpWriter("Example.Library");
+    writer.write("// System.Threading.CancellationToken remains in comments.");
+    writer.write(
+        "public const string Name = $L;",
+        CSharpNaming.formatString("System.Threading.CancellationToken"));
+    writer.write(
+        "public $L<int> Read($L cancellationToken);",
+        writer.frameworkType("System.Threading.Tasks.Task"),
+        writer.frameworkType("System.Threading.CancellationToken"));
+    String generated = writer.toString();
+    assertTrue(
+        generated.contains("using System.Threading;\nusing System.Threading.Tasks;"), generated);
+    assertTrue(
+        generated.contains("Task<int> Read(CancellationToken cancellationToken)"), generated);
+    assertTrue(
+        generated.contains("// System.Threading.CancellationToken remains in comments."),
+        generated);
+    assertTrue(generated.contains("Name = \"System.Threading.CancellationToken\";"), generated);
+    assertEquals(generated, writer.toString());
+  }
+
+  @Test
+  void lateReservationsQualifyEarlierReferencesAndDoNotLeaveStaleImports() {
+    var writer = new CSharpWriter("Example.Library");
+    writer.write("public $L Read();", writer.frameworkType("System.Threading.Tasks.Task"));
+    assertTrue(writer.toString().contains("using System.Threading.Tasks;"));
+    writer.reserveName("Task");
+    String generated = writer.toString();
+    assertTrue(generated.contains("public global::System.Threading.Tasks.Task Read();"), generated);
+    assertFalse(generated.contains("using System.Threading.Tasks;"), generated);
+  }
+
+  @Test
+  void conflictingFrameworkImportsAreQualifiedRegardlessOfReferenceOrder() {
+    var writer = new CSharpWriter("Example.Library");
+    writer.write("public $L First;", writer.frameworkType("System.Threading.Timer"));
+    writer.write("public $L Second;", writer.frameworkType("System.Timers.Timer"));
+    String generated = writer.toString();
+    assertTrue(generated.contains("global::System.Threading.Timer First"), generated);
+    assertTrue(generated.contains("global::System.Timers.Timer Second"), generated);
+    assertFalse(generated.contains("using System.Threading;"), generated);
+    assertFalse(generated.contains("using System.Timers;"), generated);
+  }
+
+  @Test
+  void attributesUseShortNamesUnlessEitherAttributeSpellingIsHidden() {
+    for (String collision :
+        new String[] {"EnumeratorCancellation", "EnumeratorCancellationAttribute"}) {
+      var writer = new CSharpWriter("Example.Library");
+      writer.write(
+          "[$L]",
+          writer.frameworkAttribute(
+              "System.Runtime.CompilerServices.EnumeratorCancellationAttribute"));
+      assertTrue(writer.toString().contains("[EnumeratorCancellation]"));
+      writer.reserveName(collision);
+      assertTrue(
+          writer
+              .toString()
+              .contains(
+                  "[global::System.Runtime.CompilerServices.EnumeratorCancellationAttribute]"));
+    }
+  }
+
+  @Test
+  void unreferencedDeclarationsInCurrentAndParentNamespacesAlsoPreventFrameworkImports() {
+    var model =
+        Model.assembler()
+            .addUnparsedModel(
+                "local.smithy",
+                """
+                $version: "2"
+                namespace example.library
+                structure CancellationToken {}
+                service Http { version: "1" }
+                """)
+            .addUnparsedModel(
+                "parent.smithy",
+                """
+                $version: "2"
+                namespace example
+                structure Task {}
+                """)
+            .assemble()
+            .unwrap();
+    var settings =
+        CSharpSettings.fromNode(
+            ObjectNode.builder().withMember("service", "example.library#Http").build());
+    var writer = new CSharpWriter("Example.Library");
+    writer.reserveModelNames(model, settings);
+    writer.write(
+        "public $L Read($L token, $L client);",
+        writer.frameworkType("System.Threading.Tasks.Task"),
+        writer.frameworkType("System.Threading.CancellationToken"),
+        writer.frameworkType("System.Net.Http.HttpClient"));
+    String generated = writer.toString();
+    assertTrue(generated.contains("global::System.Threading.Tasks.Task Read"), generated);
+    assertTrue(generated.contains("global::System.Threading.CancellationToken token"), generated);
+    assertTrue(generated.contains("global::System.Net.Http.HttpClient client"), generated);
+  }
+}

--- a/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
+++ b/codegen/smithy-csharp-codegen/src/test/java/io/github/thomaslaich/nsmithy/csharp/codegen/writer/CSharpWriterTest.java
@@ -6,11 +6,64 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpNaming;
 import io.github.thomaslaich.nsmithy.csharp.codegen.CSharpSettings;
+import io.github.thomaslaich.nsmithy.csharp.codegen.RuntimeTypes;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ObjectNode;
 
 final class CSharpWriterTest {
+  @Test
+  void runtimeSymbolsUseImportsAndQualifyLateCollisions() {
+    var writer = new CSharpWriter("Example.Library");
+    writer.write("public $T Read();", RuntimeTypes.DOCUMENT);
+    assertTrue(writer.toString().contains("using NSmithy.Core;"));
+    assertTrue(writer.toString().contains("public Document Read();"));
+    writer.reserveName("Document");
+    assertTrue(writer.toString().contains("public global::NSmithy.Core.Document Read();"));
+    assertFalse(writer.toString().contains("using NSmithy.Core;"));
+  }
+
+  @Test
+  void symbolFormatterRegistersImportsAndResolvesLateCollisions() {
+    var writer = new CSharpWriter("Example.Library");
+    var task = Symbol.builder().name("Task").namespace("System.Threading.Tasks", ".").build();
+    writer.write("public $T Read();", task);
+    assertTrue(writer.getImportContainer().toString().contains("using System.Threading.Tasks;"));
+    writer.reserveName("Task");
+    assertTrue(writer.toString().contains("public global::System.Threading.Tasks.Task Read();"));
+    assertFalse(writer.getImportContainer().toString().contains("using System.Threading.Tasks;"));
+  }
+
+  @Test
+  void symbolReferenceAliasesProduceAliasDirectives() {
+    var writer = new CSharpWriter("Example.Library");
+    var symbol = Symbol.builder().name("Timer").namespace("System.Threading", ".").build();
+    var alias = SymbolReference.builder().symbol(symbol).alias("ThreadTimer").build();
+    writer.write("public $T Timer;", alias);
+    String generated = writer.toString();
+    assertTrue(
+        generated.contains("using ThreadTimer = global::System.Threading.Timer;"), generated);
+    assertTrue(generated.contains("public ThreadTimer Timer;"), generated);
+    writer.reserveName("ThreadTimer");
+    generated = writer.toString();
+    assertFalse(generated.contains("using ThreadTimer ="), generated);
+    assertTrue(generated.contains("public global::System.Threading.Timer Timer;"), generated);
+  }
+
+  @Test
+  void symbolImportsOmitCurrentNamespaceAndDeduplicateExplicitImports() {
+    var imports = new ImportDeclarations("System.Threading");
+    imports.importSymbol(
+        Symbol.builder().name("CancellationToken").namespace("System.Threading", ".").build());
+    assertEquals("", imports.toString());
+    imports.importSymbol(
+        Symbol.builder().name("Task").namespace("System.Threading.Tasks", ".").build());
+    imports.importNamespace("System.Threading.Tasks");
+    assertEquals("using System.Threading.Tasks;\n\n", imports.toString());
+  }
+
   @Test
   void importsFrameworkTypesWithoutRewritingLiteralText() {
     var writer = new CSharpWriter("Example.Library");
@@ -20,8 +73,8 @@ final class CSharpWriterTest {
         CSharpNaming.formatString("System.Threading.CancellationToken"));
     writer.write(
         "public $L<int> Read($L cancellationToken);",
-        writer.frameworkType("System.Threading.Tasks.Task"),
-        writer.frameworkType("System.Threading.CancellationToken"));
+        writer.typeName(RuntimeTypes.TASK),
+        writer.typeName(RuntimeTypes.CANCELLATION_TOKEN));
     String generated = writer.toString();
     assertTrue(
         generated.contains("using System.Threading;\nusing System.Threading.Tasks;"), generated);
@@ -37,7 +90,7 @@ final class CSharpWriterTest {
   @Test
   void lateReservationsQualifyEarlierReferencesAndDoNotLeaveStaleImports() {
     var writer = new CSharpWriter("Example.Library");
-    writer.write("public $L Read();", writer.frameworkType("System.Threading.Tasks.Task"));
+    writer.write("public $L Read();", writer.typeName(RuntimeTypes.TASK));
     assertTrue(writer.toString().contains("using System.Threading.Tasks;"));
     writer.reserveName("Task");
     String generated = writer.toString();
@@ -48,8 +101,12 @@ final class CSharpWriterTest {
   @Test
   void conflictingFrameworkImportsAreQualifiedRegardlessOfReferenceOrder() {
     var writer = new CSharpWriter("Example.Library");
-    writer.write("public $L First;", writer.frameworkType("System.Threading.Timer"));
-    writer.write("public $L Second;", writer.frameworkType("System.Timers.Timer"));
+    writer.write(
+        "public $L First;",
+        writer.typeName(Symbol.builder().name("Timer").namespace("System.Threading", ".").build()));
+    writer.write(
+        "public $L Second;",
+        writer.typeName(Symbol.builder().name("Timer").namespace("System.Timers", ".").build()));
     String generated = writer.toString();
     assertTrue(generated.contains("global::System.Threading.Timer First"), generated);
     assertTrue(generated.contains("global::System.Timers.Timer Second"), generated);
@@ -62,10 +119,7 @@ final class CSharpWriterTest {
     for (String collision :
         new String[] {"EnumeratorCancellation", "EnumeratorCancellationAttribute"}) {
       var writer = new CSharpWriter("Example.Library");
-      writer.write(
-          "[$L]",
-          writer.frameworkAttribute(
-              "System.Runtime.CompilerServices.EnumeratorCancellationAttribute"));
+      writer.write("[$L]", writer.attributeName(RuntimeTypes.ENUMERATOR_CANCELLATION_ATTRIBUTE));
       assertTrue(writer.toString().contains("[EnumeratorCancellation]"));
       writer.reserveName(collision);
       assertTrue(
@@ -104,9 +158,9 @@ final class CSharpWriterTest {
         new CSharpWriter.CSharpWriterFactory(model, settings).apply("test.g.cs", "Example.Library");
     writer.write(
         "public $L Read($L token, $L client);",
-        writer.frameworkType("System.Threading.Tasks.Task"),
-        writer.frameworkType("System.Threading.CancellationToken"),
-        writer.frameworkType("System.Net.Http.HttpClient"));
+        writer.typeName(RuntimeTypes.TASK),
+        writer.typeName(RuntimeTypes.CANCELLATION_TOKEN),
+        writer.typeName(RuntimeTypes.HTTP_CLIENT));
     String generated = writer.toString();
     assertTrue(generated.contains("global::System.Threading.Tasks.Task Read"), generated);
     assertTrue(generated.contains("global::System.Threading.CancellationToken token"), generated);
@@ -140,10 +194,9 @@ final class CSharpWriterTest {
         new CSharpWriter.CSharpWriterFactory(model, settings).apply("test.g.cs", "Example.Library");
     writer.write(
         "public $L Read([$L] $L token);",
-        writer.frameworkType("System.Threading.Tasks.Task"),
-        writer.frameworkAttribute(
-            "System.Runtime.CompilerServices.EnumeratorCancellationAttribute"),
-        writer.frameworkType("System.Threading.CancellationToken"));
+        writer.typeName(RuntimeTypes.TASK),
+        writer.attributeName(RuntimeTypes.ENUMERATOR_CANCELLATION_ATTRIBUTE),
+        writer.typeName(RuntimeTypes.CANCELLATION_TOKEN));
     String generated = writer.toString();
     assertTrue(generated.contains("global::System.Threading.Tasks.Task Read("), generated);
     assertTrue(

--- a/tests/Fakes/TypeNameTests.cs
+++ b/tests/Fakes/TypeNameTests.cs
@@ -1,0 +1,23 @@
+using Example.Names;
+using NSmithy.Core.Serde;
+
+namespace NSmithy.Fakes.Tests;
+
+public class TypeNameTests
+{
+    [Fact]
+    public void GeneratedSchemasKeepTheIntendedTypesWhenNamesCollide()
+    {
+        Assert.IsAssignableFrom<Schema<Builder>>(BuilderSchema.Schema);
+        Assert.IsAssignableFrom<Schema<ValueSerializer>>(ValueSerializerSchema.Schema);
+        Assert.IsAssignableFrom<Schema<RoundTripInput>>(RoundTripInputSchema.Schema);
+        var local = new Widget("local");
+        var foreign = new global::Example.Other.Widget(42);
+        var payload = new RoundTripInput(LocalWidget: local, ForeignWidget: foreign);
+        Assert.Same(local, payload.LocalWidget);
+        Assert.Same(foreign, payload.ForeignWidget);
+        Assert.Same(local, new Choice.Widget(local).Value);
+        Assert.IsType<T>(new Choice.Generic(new T()).Value);
+        Assert.IsType<Unknown>(new Choice.UnknownValue(new Unknown()).Value);
+    }
+}

--- a/tests/Fakes/model/type-names-other.smithy
+++ b/tests/Fakes/model/type-names-other.smithy
@@ -1,0 +1,7 @@
+$version: "2"
+
+namespace example.other
+
+structure Widget {
+    count: Integer
+}

--- a/tests/Fakes/model/type-names.smithy
+++ b/tests/Fakes/model/type-names.smithy
@@ -1,0 +1,60 @@
+$version: "2"
+
+namespace example.names
+
+use aws.protocols#restJson1
+
+// Compile regression coverage for references hidden by generated nested types,
+// union variants, generic parameters, and a type named after a namespace root.
+@restJson1
+service Names {
+    version: "1"
+    operations: [RoundTrip]
+    rename: { "example.other#Widget": "ForeignWidget" }
+}
+
+@http(method: "POST", uri: "/names")
+operation RoundTrip {
+    input: Payload
+    output: Payload
+}
+
+structure Payload {
+    helper: Builder
+    serializer: ValueSerializer
+    choice: Choice
+    widgets: Widgets
+    widgetMap: WidgetMap
+    localWidget: Widget
+    foreignWidget: example.other#Widget
+    namespaceRoot: Example
+    genericWriter: TWriter
+    serverHelper: RoundTripJsonSchemas
+}
+
+structure Builder {}
+structure ValueSerializer {}
+structure Example {}
+structure TWriter {}
+structure RoundTripJsonSchemas {}
+structure Widget {
+    label: String
+}
+
+union Choice {
+    widget: Widget
+    generic: T
+    unknownValue: Unknown
+}
+
+structure T {}
+structure Unknown {}
+
+list Widgets {
+    member: Widget
+}
+
+map WidgetMap {
+    key: String
+    value: Widget
+}

--- a/tests/Fakes/model/type-names.smithy
+++ b/tests/Fakes/model/type-names.smithy
@@ -23,6 +23,7 @@ operation RoundTrip {
 structure Payload {
     nextToken: String
     frameworkNames: FrameworkNames
+    runtimeNames: RuntimeNames
     helper: Builder
     serializer: ValueSerializer
     choice: Choice
@@ -87,3 +88,20 @@ structure Dictionary {}
 structure List {}
 structure Exception {}
 structure Uri {}
+
+// Runtime symbol imports must be as collision-safe as framework symbol imports.
+structure RuntimeNames {
+    documentType: Document
+    schemaType: Schema
+    schemasType: Schemas
+    shapeIdType: ShapeId
+    traitType: Trait
+    runtimeType: SmithyServerRuntime
+}
+
+structure Document {}
+structure Schema {}
+structure Schemas {}
+structure ShapeId {}
+structure Trait {}
+structure SmithyServerRuntime {}

--- a/tests/Fakes/model/type-names.smithy
+++ b/tests/Fakes/model/type-names.smithy
@@ -13,6 +13,7 @@ service Names {
     rename: { "example.other#Widget": "ForeignWidget" }
 }
 
+@paginated(inputToken: "nextToken", outputToken: "nextToken", items: "widgets")
 @http(method: "POST", uri: "/names")
 operation RoundTrip {
     input: Payload
@@ -20,6 +21,8 @@ operation RoundTrip {
 }
 
 structure Payload {
+    nextToken: String
+    frameworkNames: FrameworkNames
     helper: Builder
     serializer: ValueSerializer
     choice: Choice
@@ -58,3 +61,29 @@ map WidgetMap {
     key: String
     value: Widget
 }
+
+// These model types must not capture imported framework references, including
+// static calls, paginator parameters, and the EnumeratorCancellation attribute.
+structure FrameworkNames {
+    task: Task
+    cancellation: CancellationToken
+    enumerable: IAsyncEnumerable
+    attributeName: EnumeratorCancellation
+    client: HttpClient
+    array: Array
+    dictionary: Dictionary
+    list: List
+    exception: Exception
+    uri: Uri
+}
+
+structure Task {}
+structure CancellationToken {}
+structure IAsyncEnumerable {}
+structure EnumeratorCancellation {}
+structure HttpClient {}
+structure Array {}
+structure Dictionary {}
+structure List {}
+structure Exception {}
+structure Uri {}

--- a/tests/Fakes/smithy-build.json
+++ b/tests/Fakes/smithy-build.json
@@ -1,6 +1,8 @@
 {
   "version": "1.0",
-  "sources": ["model/weather.smithy"],
+  "sources": [
+    "model"
+  ],
   "maven": {
     "repositories": [
       {
@@ -19,6 +21,14 @@
           "service": "example.weather#Weather",
           "baseNamespace": "",
           "generateFakes": true
+        }
+      }
+    },
+    "type-names": {
+      "plugins": {
+        "csharp-codegen": {
+          "service": "example.names#Names",
+          "baseNamespace": ""
         }
       }
     }


### PR DESCRIPTION
Generated C# repeats namespaces on local model and framework type references, while handwritten runtime type names bypass collision handling. Centralize external types as Smithy `Symbol` constants and register references through the writer's symbol import API. Local model references use names such as `DeleteBookInput`, and unambiguous framework references produce signatures such as:

```csharp
public async IAsyncEnumerable<CitySummary> ListCitiesItemsAsync(
    ListCitiesInput input,
    [EnumeratorCancellation] CancellationToken cancellationToken = default
)
```

`RuntimeTypes` now contains the external type symbols used by generators, following smithy-python's catalog pattern. Templates use `$T`, and expression helpers use the same symbol registration path. Multiline C# templates with scoped, named placeholders cover client configuration, constructors, operation methods, paginators, dependency injection, server handlers, service definitions, prompts, catalogs, registration, protocol declarations, routing, and query validation, and service, operation, structure, list, map, primitive, string-enum, and union schemas. Structure and union schemas use Smithy code-consumer placeholders for member sections. Client constructors use them for conditional initialization. Iteration and schema/runtime decisions remain in Java helpers. Protocol selection returns a symbol instead of maintaining separate type-name and namespace mappings. Only four raw namespace constants remain, for extension-method lookup.

`ImportDeclarations` owns reference resolution and sorted using directives. Its standard `toString()` replaces the additional-import-set `render(...)` API. Resolution remains deferred so later declarations cannot invalidate earlier references. Collisions with model declarations, generated members, namespace segments, or other registered symbols fall back to `global::` qualification; explicit symbol aliases emit C# alias directives. Documentation and model string literals are left intact. Private helpers follow the public and package-private methods in the touched classes.

Regression coverage includes late reservations, repeatable rendering, symbol imports and aliases, and compiled model fixtures that shadow framework and runtime names, including `Task`, `CancellationToken`, `Schema`, `Schemas`, `Document`, `ShapeId`, and `Trait`.

Validation:

- `just build`: zero warnings and errors.
- `just test`: all 68 Java tests and 2,149 .NET tests passed.
- `just pack` and `just refresh-examples`: passed, including dependency injection, gRPC, and streaming examples.
- `just fmt`, `just check-format`, and `git diff --check`: passed.

The named-template migrations were additionally checked with Java generator tests and the Release build. All 1,409 regenerated C# files under the test projects are byte-for-byte unchanged after each template migration.


