### PR TITLE
docs: remove obsolete tool attribution from source comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ build/
 
 *.binlog
 
+# Local agent state
+.claude/
+
 # macOS Finder metadata
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ build/
 
 *.binlog
 
-# LLM things
-.claude/
-
 # macOS Finder metadata
 .DS_Store
 

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -868,11 +868,10 @@ BenchmarkDotNet code path computes that root is still unknown.
 
 ### Formatting could not run in the original benchmark worktree
 
-`OBSERVED`. `csharpier` finds zero files anywhere under
-`.claude/worktrees/performance-suite`, because the whole path is inside gitignored
-`.claude/`. The benchmark sources were subsequently formatted from the main
-checkout; the limitation remains relevant when using a worktree below an ignored
-directory.
+`OBSERVED`. `csharpier` found zero files in the original benchmark worktree
+because its parent directory was gitignored. The benchmark sources were
+subsequently formatted from the main checkout; the limitation remains relevant
+when using a worktree below an ignored directory.
 
 ---
 

--- a/examples/restjson1/README.md
+++ b/examples/restjson1/README.md
@@ -85,6 +85,25 @@ path with an absolute path):
 }
 ```
 
+For [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp), add the
+built server from the repository root:
+
+```bash
+claude mcp add weather -- dotnet /absolute/path/to/smithy-dotnet/examples/restjson1/server/bin/Debug/net10.0/NSmithy.Examples.RestJson1.Server.dll --mcp
+```
+
+Or let Claude Code launch the project through `dotnet run`. Keep `--no-build`:
+build output on stdout would corrupt the MCP stdio stream.
+
+```bash
+claude mcp add weather -- dotnet run --no-build --project /absolute/path/to/smithy-dotnet/examples/restjson1/server/NSmithy.Examples.RestJson1.Server.csproj -- --mcp
+```
+
+Check the registration with `claude mcp get weather`. Inside Claude Code, `/mcp`
+shows the connection, and the generated prompts are available as
+`/mcp__weather__city_weather_brief SEA` and
+`/mcp__weather__forecast_answer SEA`.
+
 The generated `GetCurrentTime`, `GetCity`, `ListCities`, `GetForecast`, and
 `GetFlakyForecast` operations appear as tools. Their descriptions, input and
 output schemas, validation, and read-only hints all come from the Smithy model.

--- a/examples/restjson1/README.md
+++ b/examples/restjson1/README.md
@@ -85,25 +85,6 @@ path with an absolute path):
 }
 ```
 
-For [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp), add the
-built server from the repository root:
-
-```bash
-claude mcp add weather -- dotnet /absolute/path/to/smithy-dotnet/examples/restjson1/server/bin/Debug/net10.0/NSmithy.Examples.RestJson1.Server.dll --mcp
-```
-
-Or let Claude Code launch the project through `dotnet run`. Keep `--no-build`:
-build output on stdout would corrupt the MCP stdio stream.
-
-```bash
-claude mcp add weather -- dotnet run --no-build --project /absolute/path/to/smithy-dotnet/examples/restjson1/server/NSmithy.Examples.RestJson1.Server.csproj -- --mcp
-```
-
-Check the registration with `claude mcp get weather`. Inside Claude Code, `/mcp`
-shows the connection, and the generated prompts are available as
-`/mcp__weather__city_weather_brief SEA` and
-`/mcp__weather__forecast_answer SEA`.
-
 The generated `GetCurrentTime`, `GetCity`, `ListCities`, `GetForecast`, and
 `GetFlakyForecast` operations appear as tools. Their descriptions, input and
 output schemas, validation, and read-only hints all come from the Smithy model.

--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -1,7 +1,6 @@
 ---
 /**
- * LandingPage — full custom landing, ported from the Claude Design
- * "Smithy Landing.dc.html" (violet / Space Grotesk design).
+ * LandingPage — custom landing page.
  *
  * Rendered inside Starlight's splash page; Starlight's own chrome (header,
  * content max-width) is hidden/neutralised on the landing page only — see the


### PR DESCRIPTION
Remove obsolete tool attribution from the landing-page source comment and describe the benchmark formatting limitation without naming a specific local worktree directory.

Validation: formatting and `git diff --check` passed. These are documentation and comment changes; runtime tests were not run.
