### PR TITLE
docs: simplify README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 # NSmithy
 
-**[Docs](https://thomaslaich.github.io/smithy-dotnet/)** · **[Quick Start](https://thomaslaich.github.io/smithy-dotnet/getting-started/quick-start/)** · **[Examples](examples/README.md)** · **[Design Docs](designs/README.md)** · **[smithy.io](https://smithy.io)**
+**[Docs](https://thomaslaich.github.io/smithy-dotnet/)** · **[Examples](examples/README.md)** · **[Design Docs](designs/README.md)** · **[smithy.io](https://smithy.io)**
 
-[Smithy](https://smithy.io) toolkit for .NET.
+Smithy toolkit for .NET.
 
 ## Development
 


### PR DESCRIPTION
Remove the Quick Start link from the README navigation and make the short introduction plain text, keeping the existing smithy.io navigation link.

Validation: reviewed the Markdown diff and ran `git diff --check`.
