### PR TITLE
docs: clarify protocol-independent contracts and improve onboarding

### DIFF
--- a/website/src/components/landing/LandingPage.astro
+++ b/website/src/components/landing/LandingPage.astro
@@ -12,7 +12,6 @@ import LandingTree from './LandingTree.astro';
 // Base-relative so it works on the local dev server and the deployed site
 // (the GitHub Pages base is /smithy-dotnet). `repo` stays absolute — it's external.
 const intro = '/smithy-dotnet/getting-started/introduction/';
-const quickstart = '/smithy-dotnet/getting-started/quick-start/';
 const repo = 'https://github.com/thomaslaich/smithy-dotnet';
 
 ---
@@ -58,7 +57,7 @@ const repo = 'https://github.com/thomaslaich/smithy-dotnet';
       </a>
       <div class="nsl-header-actions">
         <button type="button" class="nsl-theme" aria-label="Toggle theme"></button>
-        <a class="nsl-btn nsl-btn-primary nsl-btn-sm" href={quickstart}>Get Started</a>
+        <a class="nsl-btn nsl-btn-primary nsl-btn-sm" href={intro}>Get Started</a>
       </div>
     </div>
   </header>
@@ -73,7 +72,7 @@ const repo = 'https://github.com/thomaslaich/smithy-dotnet';
           Integrated with MSBuild.
         </p>
         <div class="nsl-hero-actions reveal" style="--reveal-delay: 120ms">
-          <a class="nsl-btn nsl-btn-primary" href={quickstart}>Get Started</a>
+          <a class="nsl-btn nsl-btn-primary" href={intro}>Get Started</a>
           <a class="nsl-btn nsl-btn-ghost" href={repo}>View on GitHub</a>
         </div>
       </div>

--- a/website/src/content/docs/concepts/modeling.md
+++ b/website/src/content/docs/concepts/modeling.md
@@ -1,7 +1,12 @@
 ---
 title: Modeling contracts
-description: Define data, operations, and resources with Smithy shapes and traits.
+description: Define a protocol-independent contract with Smithy shapes and traits, then add wire protocol bindings.
 ---
+
+A Smithy contract describes what a service does independently of how requests
+and responses travel over the wire. You can define its data, operations, and
+errors first, then add protocol bindings for REST/JSON, RPC v2 CBOR, or another
+supported protocol.
 
 A *shape* is a named definition: a data type, operation, resource, or service.
 A *trait* annotates a shape or member with additional meaning, such as a constraint
@@ -9,57 +14,101 @@ or protocol binding.
 
 ## Define the contract
 
-This model describes reading a book without choosing a wire protocol:
+The [Smithy quickstart](https://smithy.io/2.0/quickstart.html) models a Weather
+service with cities and forecasts. This page uses a smaller version of that
+example, focused on `GetCity`. The full tutorial adds forecasts, city listing,
+pagination, and an operation to retrieve the current time.
+
+Start with the information a caller needs: a city identifier goes in; a name and
+coordinates come back; an unknown city produces a modeled error. No wire protocol
+is needed to describe that interaction.
 
 ```smithy
 $version: "2"
-namespace example.library
+namespace example.weather
 
-service Library {
-    version: "1"
-    resources: [Book]
+service Weather {
+    version: "2006-03-01"
+    resources: [City]
 }
 
-resource Book {
-    identifiers: { id: String }
-    properties: { title: String }
-    read: GetBook
+resource City {
+    identifiers: { cityId: CityId }
+    properties: { coordinates: CityCoordinates }
+    read: GetCity
+}
+
+@pattern("^[A-Za-z0-9 ]+$")
+string CityId
+
+structure CityCoordinates {
+    @required
+    latitude: Float
+
+    @required
+    longitude: Float
 }
 
 @readonly
-operation GetBook {
-    input := for Book {
+operation GetCity {
+    input := for City {
         @required
-        $id
+        $cityId
     }
-    output := for Book {
+    output := for City {
         @required
-        $id
+        @notProperty
+        name: String
+
         @required
-        $title
+        $coordinates
     }
-    errors: [BookNotFound]
+    errors: [NoSuchResource]
 }
 
 @error("client")
-structure BookNotFound {
-    message: String
+structure NoSuchResource {
+    @required
+    resourceType: String
 }
 ```
 
-The resource declares identity (`id`), state (`title`), and its read operation.
-It does not define a serialized object. The operation's input and output
-structures define what crosses the service boundary.
+The contract above is **protocol agnostic**. `GetCity` has no HTTP method or URL,
+and `CityCoordinates` has no chosen JSON or binary representation. Even the
+resource's `read` relationship describes behavior without prescribing an HTTP
+`GET`. Protocol bindings add those decisions to the model later, while keeping
+the operation's inputs, outputs, and errors shared.
 
-`:= for Book` binds an inline structure to the resource. [Target elision](https://smithy.io/2.0/spec/idl.html#target-elision)
-with `$id` and `$title`
-reuses the corresponding resource member targets; Smithy validates that they
-agree. `@required` belongs to each operation member, so different operations can
-have different presence requirements. The generated structure names are
-`GetBookInput` and `GetBookOutput`.
+## Read the model
 
-`@readonly` describes operation behavior. `@error("client")` classifies the
-error; it assigns no HTTP status.
+The declarations describe different parts of the contract:
+
+| Shape | Role in this API |
+| --- | --- |
+| `Weather` | Selects the resources and operations that belong to the service. |
+| `City` | Connects a city's identity and state to its read operation. |
+| `GetCity` | Defines the request, response, and possible error. |
+| `CityId` | Gives the identifier a reusable name and a string constraint. |
+| `CityCoordinates` | Groups latitude and longitude into a structured value. |
+| `NoSuchResource` | Describes an error callers can handle explicitly. |
+
+A resource does not define a serialized object or a database table. The
+operation's input and output structures define what crosses the service boundary.
+Here, the request contains `cityId`, while the response contains `name` and
+`coordinates`.
+
+`:=` declares an inline structure, named `GetCityInput` or `GetCityOutput` for
+this operation. `for City` associates it with the resource.
+[Target elision](https://smithy.io/2.0/spec/idl.html#target-elision) lets `$cityId`
+and `$coordinates` reuse the types declared on `City`. The `name` member has
+`@notProperty` because it is additional response data, not a declared resource
+property.
+
+Traits make these definitions more precise. `@required` sets a member's presence
+requirement; `@pattern` constrains the identifier's text. `@readonly` says the
+operation has no side effects. `@error("client")` classifies the error without
+assigning an HTTP status. These annotations give generators and validators
+information beyond the types alone.
 
 ## Apply traits inline or separately
 
@@ -69,15 +118,16 @@ this declaration assigns an HTTP status to the error:
 ```smithy
 @error("client")
 @httpError(404)
-structure BookNotFound {
-    message: String
+structure NoSuchResource {
+    @required
+    resourceType: String
 }
 ```
 
 Alternatively, keep the original error declaration and add:
 
 ```smithy
-apply BookNotFound @httpError(404)
+apply NoSuchResource @httpError(404)
 ```
 
 Both forms attach the same trait to the same shape in the assembled model.
@@ -87,8 +137,8 @@ Use inline traits when they help explain a declaration; use `apply` when keeping
 annotations together—such as a service's HTTP bindings—makes the model easier
 to maintain.
 
-Member targets use `$`: `GetBookInput$id` identifies the `id` member of
-`GetBookInput`. It differs from `$id` inside `for Book`, which reuses a member
+Member targets use `$`: `GetCityInput$cityId` identifies the `cityId` member of
+`GetCityInput`. It differs from `$cityId` inside `for City`, which reuses a member
 target from the resource. See the [Smithy IDL specification](https://smithy.io/2.0/spec/idl.html)
 for trait application and target elision.
 
@@ -98,20 +148,20 @@ A protocol defines request and response encoding, operation dispatch, and error
 representation. A service selects protocols through traits. Some protocols also
 require operation and member bindings.
 
-For the Book contract, these annotations add a REST JSON binding. They can live
+For the Weather contract, these annotations add a REST JSON binding. They can live
 in a separate `.smithy` file in the same namespace:
 
 ```smithy
 $version: "2"
-namespace example.library
+namespace example.weather
 
-apply Library @alloy#simpleRestJson
-apply GetBook @http(method: "GET", uri: "/books/{id}", code: 200)
-apply GetBookInput$id @httpLabel
-apply BookNotFound @httpError(404)
+apply Weather @alloy#simpleRestJson
+apply GetCity @http(method: "GET", uri: "/cities/{cityId}", code: 200)
+apply GetCityInput$cityId @httpLabel
+apply NoSuchResource @httpError(404)
 ```
 
-The operation becomes `GET /books/{id}`; the error maps to HTTP 404.
+The operation becomes `GET /cities/{cityId}`; the error maps to HTTP 404.
 `@httpLabel` binds the input member to the route parameter. Keeping these traits
 in a separate file separates their authoring from the contract declaration;
 they still belong to the same assembled model.
@@ -119,20 +169,10 @@ they still belong to the same assembled model.
 Alternatively, RPC v2 CBOR needs only a service protocol trait for this operation:
 
 ```smithy
-apply Library @smithy.protocols#rpcv2Cbor
+apply Weather @smithy.protocols#rpcv2Cbor
 ```
 
-Its protocol defines dispatch routes and error encoding. The operation's data
-and error definitions do not change.
-
-Protocols differ in supported shapes, streaming, and required annotations; gRPC,
-for example, requires protobuf field indices. See [Protocol status](/smithy-dotnet/protocols/status/)
-for implementation coverage.
-
-A service can declare multiple protocols. NSmithy generates shared operation
-interfaces and protocol-specific bindings. See [Hosting multiple protocols](/smithy-dotnet/servers/hosting/)
-to expose them from one implementation.
-
-Continue with [Code generation](/smithy-dotnet/concepts/code-generation/) to see
-how the model becomes C#. For the full language, see the
-[Smithy specification](https://smithy.io/2.0/spec/).
+The same data and error definitions can serve multiple protocols. See
+[Hosting multiple protocols](/smithy-dotnet/servers/hosting/) to expose them from
+one implementation, or continue with [Code generation](/smithy-dotnet/concepts/code-generation/)
+to see how the model becomes C#.

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -5,7 +5,9 @@ description: Design, share, and evolve API contracts with Smithy, then build the
 
 [Smithy](https://smithy.io/2.0/) is a language for defining API contracts. NSmithy
 uses those contracts to generate C# clients, data types, and ASP.NET Core server
-interfaces, so teams can agree on an API before implementing it.
+interfaces, so teams can agree on an API before implementing it. The core contract
+defines operations, data, and errors independently of a wire protocol. Protocol
+traits then describe how callers and servers exchange those values.
 
 AWS developed Smithy to address a problem at scale: many services, continually
 evolving APIs, and SDKs in many programming languages. A change to a service needs
@@ -25,15 +27,12 @@ implementation. Reviewing a proposed interface means reviewing server changes, a
 client developers may have to wait for that work before they can generate types or
 try a mock implementation.
 
-OpenAPI supports [design-first development](https://learn.openapis.org/best-practices.html),
-but authoring and reviewing a large YAML or JSON description can be cumbersome.
-It can be easier to write server code and generate the description afterward,
-tying the contract to the implementation again. Smithy provides a compact language
-for writing the contract itself, making it practical to discuss operations, data,
-and errors before building the service.
-
-Operations, data types (called *shapes*), and annotations (called *traits*) describe
-the API in files that teams can review and version independently of server code.
+OpenAPI also supports [design-first development](https://learn.openapis.org/best-practices.html),
+but authoring and reviewing large contracts in YAML or JSON can be cumbersome.
+Smithy's compact language makes operations, data, and errors easier to express
+and review directly. Its protocol-independent service model also lets teams
+agree on that contract before choosing HTTP routes or message encoding, then
+use it across multiple wire protocols.
 
 Smithy's tooling also supports the governance around that contract:
 [validators](https://smithy.io/2.0/guides/model-linters.html) can enforce shared
@@ -44,17 +43,27 @@ API review and compatibility checks a place in the build process.
 
 ## A contract that can span protocols
 
-Protobuf and gRPC also let teams define interfaces before writing implementations.
-But an organization may need REST APIs for external consumers, gRPC between
-services, and asynchronous messages between systems. Choosing gRPC for some calls
-still leaves contracts to manage for those other interfaces.
+[OpenAPI describes HTTP APIs](https://spec.openapis.org/oas/v3.2.0.html): paths,
+HTTP methods, parameters, responses, and their media types. It supports JSON, XML,
+binary payloads, and other formats, and does not require a REST architecture.
+Its scope is still HTTP, so the contract incorporates HTTP-specific decisions.
+Protobuf and gRPC also support defining interfaces before implementation, with
+their own encoding and RPC conventions.
 
-Smithy separates the service model from its wire protocol. The operations and data
-can be shared while protocol traits specify how they are transmitted. A service
-can declare multiple protocols, and generators can produce the corresponding
-clients and servers. Smithy tooling can also
+Smithy separates the service model from those wire-level choices. For example,
+the Weather service in [Modeling contracts](/smithy-dotnet/concepts/modeling/)
+defines `GetCity` with a city identifier, a response, and a possible error. That
+same operation can be exposed through REST/JSON, RPC v2 CBOR, or gRPC by adding
+protocol traits and the bindings each protocol requires. The meaning of the operation and
+its data stays shared; routing, serialization, and error encoding depend on the
+selected protocol.
+
+A service can declare multiple protocols, allowing external REST clients and
+internal RPC clients to use the same modeled operations. Generators and runtimes
+must support each chosen protocol, and some require additional annotations, such
+as protobuf field indices for gRPC. Smithy tooling can also
 [derive OpenAPI descriptions](https://smithy.io/2.0/guides/model-translations/converting-to-openapi.html)
-for HTTP APIs.
+for the HTTP API, so a shared Smithy contract can feed existing OpenAPI tooling.
 
 That separation is useful for asynchronous contracts too, where a shared data
 model should not dictate a single message encoding. Delivery semantics and


### PR DESCRIPTION
The landing page now sends readers to Introduction, and Modeling contracts uses a shortened Weather/GetCity example from the official Smithy quickstart.

The introduction and modeling guide explain how operations, data, and errors remain shared across wire protocols. The OpenAPI comparison covers both YAML/JSON authoring overhead and its HTTP scope, while acknowledging support for non-JSON payloads. Repetitive closing material is trimmed.

Validation: website build, Smithy validation of the Weather model, formatting checks, and `git diff --check` passed.
